### PR TITLE
Add SafeSkill security badge (30/100 — Blocked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Forks may experiment, but official updates will always come from this repo.
 
 ## 📢 Project Update (December 2025)
 
+[![SafeSkill 30/100](https://img.shields.io/badge/SafeSkill-30%2F100_Blocked-red)](https://safeskill.dev/scan/lyellr88-marm-systems)
+
 I've been focused on developing a new build powered by MARM Systems as its memory layer, a real-world application of the technology I've been creating. This deep dive into production memory systems has given me valuable insights into how MARM performs under real workflows. 
 
 I'm returning focus to MARM-MCP in **Q1-2 2026** with lessons learned and new improvements. The time spent studying advanced memory architectures and system behavior will directly improve upcoming MARM-MCP updates with better semantic search, optimized recall patterns, and enhanced multi-session handling.


### PR DESCRIPTION
## 🔴 SafeSkill Security Scan Results

| Metric | Value |
|:-------|:------|
| **Overall Score** | **30/100** (Blocked) |
| Code Score | 79/100 |
| Content Score | 58/100 |
| Findings | 329 findings detected (7 critical) |
| Taint Flows | 0 |
| Files Scanned | 24 |
| Scan Duration | 1.4s |

### Top Findings

- 🔴 **critical**: Accesses sensitive environment variable: REPLICATE_API_TOKEN (`webchat/src/chatbot/server.js:16`)
- 🔴 **critical**: Very long single-line expression (777 chars) — possibly minified or obfuscated code (`webchat/src/logic/constants.js:24`)
- 🔴 **critical**: Very long single-line expression (518 chars) — possibly minified or obfuscated code (`webchat/src/logic/constants.js:32`)
- 🔴 **critical**: Very long single-line expression (656 chars) — possibly minified or obfuscated code (`webchat/src/logic/constants.js:40`)
- 🔴 **critical**: Very long single-line expression (741 chars) — possibly minified or obfuscated code (`webchat/src/logic/constants.js:48`)

[View full report on SafeSkill](https://safeskill.dev/scan/lyellr88-marm-systems)

---

### About SafeSkill

[SafeSkill](https://safeskill.dev) is a **free, open-source** security scanner for AI tools, MCP servers, and Claude Code skills. We scan for code exploits, prompt injection, and data exfiltration risks.

**False positive?** We take accuracy seriously. If any finding above is incorrect, please [open an issue](https://github.com/OyadotAI/safeskill/issues/new?title=False+positive+in+Lyellr88%2FMARM-Systems&labels=false-positive) and we will fix it immediately.

- [GitHub](https://github.com/OyadotAI/safeskill) | [Website](https://safeskill.dev) | [Docs](https://safeskill.dev/docs)
- Built by [Oya.ai](https://oya.ai) -- AI Employees Builder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added SafeSkill status badge to project documentation, displaying current score of 30/100 with blocked status indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->