### PR TITLE
perf(memory): harden opus review hot paths

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+tone_instructions: >
+  Be concise and pragmatic. Focus review comments on high and medium priority
+  issues only: correctness bugs, security risks, data loss risks, concurrency
+  hazards, performance regressions, broken tests, release metadata drift, and
+  major maintainability problems. Do not comment on style preferences, naming
+  preferences, formatting, doc wording, missing docstrings, minor refactors, or
+  low-value optimizations unless they directly create a real defect.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  review_details: true
+  poem: false
+  sequence_diagrams: false
+  suggested_labels: false
+  suggested_reviewers: false
+
+  path_filters:
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/__pycache__/**"
+    - "!**/.pytest_cache/**"
+    - "!**/scripts/out/**"
+    - "!**/*.egg-info/**"
+
+  pre_merge_checks:
+    docstrings:
+      mode: off
+    title:
+      mode: off
+    description:
+      mode: off
+
+  path_instructions:
+    - path: "**/*.md"
+      instructions: >
+        Only flag documentation issues that are materially wrong, misleading for
+        installation/release behavior, or inconsistent with live MCP behavior.
+        Skip style, phrasing, formatting, and wording preferences.
+    - path: "**/tests/**"
+      instructions: >
+        Focus on tests that are flaky, non-isolated, incorrectly asserting
+        behavior, or missing coverage for a changed high-risk path. Skip minor
+        naming, comments, and layout preferences.
+    - path: "**/*.py"
+      instructions: >
+        Prioritize runtime correctness, async/concurrency safety, SQLite
+        transaction safety, auth/rate-limit behavior, release-breaking packaging
+        issues, and MCP protocol compatibility.
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  tools:
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -91,14 +91,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -136,8 +128,8 @@ jobs:
             lyellr88/marm-mcp-server:${{ steps.version.outputs.version }}
             lyellr88/marm-mcp-server:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-from: type=gha,scope=marm-mcp-server
+          cache-to: type=gha,scope=marm-mcp-server,mode=max
 
       - name: Build and push Dashboard Docker image
         uses: docker/build-push-action@v5
@@ -148,8 +140,8 @@ jobs:
             lyellr88/marm-dashboard:${{ steps.version.outputs.version }}
             lyellr88/marm-dashboard:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-from: type=gha,scope=marm-dashboard
+          cache-to: type=gha,scope=marm-dashboard,mode=max
 
   publish-mcp-registry:
     needs: [validate-and-test, publish-pypi, publish-docker]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## MARM Protocol – v2.2.9 Change Log
+## MARM Protocol Changelog
 
 ### Version v1 - Prototype to Beta Foundation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1426,3 +1426,45 @@ marm_notebook(action="use"|"status"|"clear", session_name="my_project")
 
 </details>
 
+---
+
+<details>
+<summary><strong>June 4th, 2026: Opus Review Hot-Path & Compaction Hardening (v2.9.1)</strong></summary>
+
+#### Hot-Path Performance Hardening
+
+- Offloaded sentence-transformer encoding from async request paths with `asyncio.to_thread()` so CPU-heavy embedding work no longer blocks the event loop directly.
+- Added a serialized encoder helper around the shared encoder to avoid unsafe concurrent encoder use while still moving the blocking work off the main loop.
+- Reused the precomputed write embedding for write-time semantic consolidation, removing the previous double-encode path when Layer 2 consolidation checked for near-duplicates and then stored the same content.
+- Extended `recall_similar()` and `find_semantic_duplicate()` with an optional `query_vec` path so callers that already computed an embedding can avoid repeating that work.
+- Moved notebook embedding generation onto the same offloaded encoder path.
+
+#### Compaction Tool Reliability
+
+- Made `source_memory_ids` optional when staging compaction summaries; the server now uses the staged candidate's source IDs when omitted and only validates them when provided.
+- Removed `source_memory_ids` from the injected compaction nudge example to reduce UUID transcription errors by connected agents.
+- Rewrote the `marm_compaction` HTTP and STDIO tool descriptions as an agent-facing workflow: `status/candidates -> stage -> review -> apply/discard`.
+- Offloaded compaction summary embedding generation during apply so compaction writes follow the same non-blocking encoder pattern.
+
+#### HTTP Injection & Middleware Hardening
+
+- Added an HTTP MCP middleware fast path that skips response buffering/parsing after the one-time protocol has been delivered when compaction injection is disabled.
+- Added a defensive non-JSON response guard so the middleware avoids parsing responses it cannot mutate.
+- Aligned HTTP compaction injection with STDIO behavior so protocol delivery and compaction nudges do not co-inject on the same first tool call.
+- Kept eligible JSON tool responses mutable when protocol or compaction injection can still happen.
+
+#### Embedding Compatibility Guard
+
+- Added a runtime dimension check before cosine scoring stored embeddings.
+- Wrong-dimension vectors are now skipped with a diagnostic signal instead of silently disappearing through a broad exception path or crashing recall after an embedding-model dimension change.
+- Added regression coverage proving correct-dimension memories still recall while wrong-dimension rows are ignored safely.
+
+#### Test Stability & Coverage
+
+- Replaced brittle multi-step STDIO subprocess behavior tests with in-process STDIO tool tests using isolated temp databases.
+- Added in-process FastMCP client coverage for notebook, delete, log-session, and log-entry result wrapping so JSON-RPC-style tool result envelopes remain covered without relying on stdin EOF timing.
+- Kept real subprocess STDIO smoke coverage for import cleanliness, initialize/tools-list, logging, privacy, and write-queue transport behavior.
+- Added pytest markers for Docker and slow STDIO transport tests so local fast runs can skip heavy transport smoke tests while full runs still cover them.
+- Added regression coverage for optional compaction `source_memory_ids`, semantic consolidation query-vector plumbing, and embedding dimension mismatch handling.
+
+</details>

--- a/MCP-HANDBOOK.md
+++ b/MCP-HANDBOOK.md
@@ -2,7 +2,7 @@
 
 ## Complete Usage Guide for Memory-Augmented AI
 
-**MARM v2.9.0 - Universal MCP Server for AI Memory Intelligence**
+**MARM v2.9.1 - Universal MCP Server for AI Memory Intelligence**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="700"
      height="350">
 </picture>
-<h1 align="center">MARM: The AI That Remembers Your Conversations v2.9.0</h1>
+<h1 align="center">MARM: The AI That Remembers Your Conversations v2.9.1</h1>
 
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/Lyellr88/MARM-Systems/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.9.0** - Memory Accurate Response Mode
+**MARM v2.9.1** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.9.0** - Memory Accurate Response Mode
+**MARM v2.9.1** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -316,7 +316,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.9.0 MCP Server - Platform Integration Guide
+# MARM v2.9.1 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.9.0** - Memory Accurate Response Mode
+**MARM v2.9.1** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -289,7 +289,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -62,7 +62,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # MCP Registry Labels for Docker Hub discovery
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.9.0"
+LABEL org.opencontainers.image.version="2.9.1"
 LABEL org.opencontainers.image.authors="Ryan Lyell - MARM Systems"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/MARM-Systems"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -5,7 +5,7 @@
      width="700"
      height="350">
 </picture>
-<h1 align="center">MARM: The AI That Remembers Your Conversations v2.9.0</h1>
+<h1 align="center">MARM: The AI That Remembers Your Conversations v2.9.1</h1>
 
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/Lyellr88/MARM-Systems/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)

--- a/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
+++ b/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
@@ -2,7 +2,7 @@
 
 ## Complete Usage Guide for Memory-Augmented AI
 
-**MARM v2.9.0 - Universal MCP Server for AI Memory Intelligence**
+**MARM v2.9.1 - Universal MCP Server for AI Memory Intelligence**
 
 ---
 

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,10 +14,10 @@ Features:
 - Production-grade performance
 
 Author: Lyell - MARM Systems
-Version: 2.9.0
+Version: 2.9.1
 """
 
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 __author__ = "Lyell"
 __email__ = "lyell@marmsystems.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -80,7 +80,7 @@ DEFAULT_SEMANTIC_MODEL = "all-MiniLM-L6-v2"
 # Server configuration
 SERVER_HOST = os.environ.get('SERVER_HOST', '127.0.0.1')
 SERVER_PORT = int(os.environ.get('SERVER_PORT', 8001))
-SERVER_VERSION = "2.9.0"
+SERVER_VERSION = "2.9.1"
 
 # Rate limiting configuration. MARM_RATE_LIMIT_RPM=0 disables limiting.
 MARM_RATE_LIMIT_RPM = int(os.environ.get('MARM_RATE_LIMIT_RPM', '80'))

--- a/marm-mcp-server/marm_mcp_server/core/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/core/compaction.py
@@ -328,7 +328,6 @@ def _build_compaction_prompt_block(row: tuple, byte_budget: int) -> dict:
         "summary using only the source previews below, then call:\n\n"
         "marm_compaction(action=\"stage\", summaries=[{"
         "\"candidate_id\": \"<candidate_id>\", "
-        "\"source_memory_ids\": [...], "
         "\"suggested_summary\": \"...\""
         "}])\n\n"
         f"candidate_id: {candidate_id}\n"

--- a/marm-mcp-server/marm_mcp_server/core/consolidation.py
+++ b/marm-mcp-server/marm_mcp_server/core/consolidation.py
@@ -37,16 +37,17 @@ def find_exact_duplicate(
 
 
 async def find_semantic_duplicate(
-    memory, content: str, session_name: str, threshold: float
+    memory, content: str, session_name: str, threshold: float, query_vec=None
 ) -> Optional[str]:
     """Return memory_id of nearest semantic match at or above threshold in session, or None.
 
     Falls back to None if encoder unavailable — never blocks a write.
+    Accepts a pre-computed query_vec to avoid re-encoding already-embedded content.
     """
     try:
-        if not memory._load_encoder_lazily():
+        if query_vec is None and not memory._load_encoder_lazily():
             return None
-        results = await memory.recall_similar(content, session=session_name, limit=1)
+        results = await memory.recall_similar(content, session=session_name, limit=1, query_vec=query_vec)
         if results and results[0]["similarity"] >= threshold:
             return results[0]["id"]
     except Exception:

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -15,13 +15,15 @@ import re
 
 
 def _safe_print(msg: str) -> None:
-    """Print with stderr fallback — prevents charmap UnicodeEncodeError on Windows and avoids
-    polluting STDIO stdout which is reserved for JSON-RPC."""
-    try:
-        print(msg)
-    except UnicodeEncodeError:
-        sys.stderr.buffer.write((msg + "\n").encode("utf-8", errors="replace"))
-        sys.stderr.buffer.flush()
+    """Write diagnostics to stderr so STDIO stdout stays JSON-RPC clean."""
+    stderr_buffer = getattr(sys.stderr, "buffer", None)
+    if stderr_buffer is not None:
+        stderr_buffer.write((msg + "\n").encode("utf-8", errors="replace"))
+        stderr_buffer.flush()
+    else:
+        sys.stderr.write(msg + "\n")
+        sys.stderr.flush()
+
 
 def _strip_script_tags(text: str) -> str:
     lower = text.lower()
@@ -535,7 +537,7 @@ class MARMMemory:
                 pre_embedding = await asyncio.to_thread(self._encode_sync, sanitized_content)
                 pre_embedding_bytes = pre_embedding.tobytes()
             except Exception as e:
-                print(f"Failed to generate embedding: {e}")
+                _safe_print(f"Failed to generate embedding: {e}")
 
         # Layer 2: semantic near-duplicate check — skipped gracefully if encoder unavailable
         if CONSOLIDATION_ENABLED:

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -1,5 +1,6 @@
 """Advanced memory system with semantic search and MARM protocol support."""
 
+import asyncio
 import json
 import sqlite3
 import sys
@@ -188,6 +189,7 @@ class MARMMemory:
         self.encoder = None
         self._encoder_loading = False
         self._encoder_failed = False
+        self._encoder_lock = threading.Lock()
             
         self.init_database()
         
@@ -400,6 +402,11 @@ class MARMMemory:
             )
             conn.commit()
     
+    def _encode_sync(self, text: str):
+        """Encode text with the shared encoder, serialized to prevent concurrent-use hangs."""
+        with self._encoder_lock:
+            return self.encoder.encode(text)
+
     def _load_encoder_lazily(self) -> bool:
         """Lazy load the semantic search model only when needed"""
         if self.encoder is not None or self._encoder_failed:
@@ -474,7 +481,8 @@ class MARMMemory:
             encoder_ok = merged_content.strip() and self._load_encoder_lazily()
             if encoder_ok:
                 try:
-                    merged_embedding_bytes = self.encoder.encode(merged_content).tobytes()
+                    merged_vec = await asyncio.to_thread(self._encode_sync, merged_content)
+                    merged_embedding_bytes = merged_vec.tobytes()
                 except Exception as e:
                     _safe_print(f"Failed to regenerate embedding after merge: {e}")
 
@@ -519,10 +527,20 @@ class MARMMemory:
                 if existing_id:
                     return existing_id
 
+        # Pre-encode once — reused by Layer 2 dedup and storage to avoid a second encode
+        pre_embedding = None
+        pre_embedding_bytes = None
+        if sanitized_content.strip() and self._load_encoder_lazily():
+            try:
+                pre_embedding = await asyncio.to_thread(self._encode_sync, sanitized_content)
+                pre_embedding_bytes = pre_embedding.tobytes()
+            except Exception as e:
+                print(f"Failed to generate embedding: {e}")
+
         # Layer 2: semantic near-duplicate check — skipped gracefully if encoder unavailable
         if CONSOLIDATION_ENABLED:
             existing_id = await find_semantic_duplicate(
-                self, sanitized_content, session, CONSOLIDATION_THRESHOLD
+                self, sanitized_content, session, CONSOLIDATION_THRESHOLD, query_vec=pre_embedding
             )
             if existing_id:
                 await self.update_memory(existing_id, sanitized_content)
@@ -533,14 +551,7 @@ class MARMMemory:
         timestamp = datetime.now(timezone.utc).isoformat()
         metadata = metadata or {}
 
-        # Generate embedding for semantic search (lazy load encoder if needed)
-        embedding_bytes = None
-        if sanitized_content.strip() and self._load_encoder_lazily():
-            try:
-                embedding = self.encoder.encode(sanitized_content)
-                embedding_bytes = embedding.tobytes()
-            except Exception as e:
-                print(f"Failed to generate embedding: {e}")
+        embedding_bytes = pre_embedding_bytes
 
         with self.get_connection() as conn:
             conn.execute("BEGIN IMMEDIATE")
@@ -581,13 +592,17 @@ class MARMMemory:
             return await self._write_queue.put(content, session, context_type, metadata)
         return await self.store_memory(content, session, context_type, metadata)
     
-    async def recall_similar(self, query: str, session: str = None, limit: int = 5) -> List[Dict]:
+    async def recall_similar(self, query: str, session: str = None, limit: int = 5, query_vec=None) -> List[Dict]:
         """Find semantically similar memories"""
-        if not self._load_encoder_lazily():
-            return await self.recall_text_search(query, session, limit)
-        
+        if query_vec is None:
+            if not self._load_encoder_lazily():
+                return await self.recall_text_search(query, session, limit)
+
         try:
-            query_embedding = self.encoder.encode(query)
+            if query_vec is not None:
+                query_embedding = query_vec
+            else:
+                query_embedding = await asyncio.to_thread(self._encode_sync, query)
             
             with self.get_connection() as conn:
                 # If session is None, search all sessions
@@ -613,16 +628,24 @@ class MARMMemory:
                 
                 memories = cursor.fetchall()
                 similarities = []
-                
+                expected_dim = len(query_embedding)
+                dim_skipped = 0
+
                 for memory in memories:
                     try:
                         memory_embedding = np.frombuffer(memory[3], dtype=np.float32)
+                        if len(memory_embedding) != expected_dim:
+                            dim_skipped += 1
+                            continue
                         similarity = np.dot(query_embedding, memory_embedding) / (
                             np.linalg.norm(query_embedding) * np.linalg.norm(memory_embedding)
                         )
                         similarities.append((memory, similarity))
                     except Exception:
                         continue
+
+                if dim_skipped:
+                    _safe_print(f"recall_similar: skipped {dim_skipped} memories with wrong embedding dimension (expected {expected_dim})")
                 
                 similarities.sort(key=lambda x: x[1], reverse=True)
                 

--- a/marm-mcp-server/marm_mcp_server/core/models.py
+++ b/marm-mcp-server/marm_mcp_server/core/models.py
@@ -42,7 +42,7 @@ class DeleteRequest(BaseModel):
 
 class StagedSummaryItem(BaseModel):
     candidate_id: str = Field(..., description="Compaction staging candidate ID")
-    source_memory_ids: list[str] = Field(..., description="Source memory IDs — must match staged candidate exactly")
+    source_memory_ids: Optional[list[str]] = Field(default=None, description="Source memory IDs — omit to use the staged candidate's IDs automatically; if provided, must match exactly")
     suggested_summary: str = Field(..., description="Agent-generated summary of the source memories")
 
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
@@ -1,5 +1,6 @@
 """Compaction MCP endpoint tools — V2 agent-driven summarization, V3 staged apply, V4 write-queue + auto-apply."""
 
+import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
@@ -161,7 +162,7 @@ async def marm_stage_compaction_summaries(request: StageCompactionSummariesReque
 
             staged_source_ids = json.loads(source_ids_json)
 
-            if sorted(source_ids_submitted) != sorted(staged_source_ids):
+            if source_ids_submitted is not None and sorted(source_ids_submitted) != sorted(staged_source_ids):
                 results.append(
                     {
                         "candidate_id": candidate_id,
@@ -450,7 +451,8 @@ async def _apply_compaction_write(candidate_id: str) -> str:
             summary_embedding = None
             if memory._load_encoder_lazily():
                 try:
-                    summary_embedding = memory.encoder.encode(suggested_summary).tobytes()
+                    summary_vec = await asyncio.to_thread(memory._encode_sync, suggested_summary)
+                    summary_embedding = summary_vec.tobytes()
                 except Exception:
                     pass
 
@@ -739,10 +741,16 @@ def _compaction_status() -> dict:
 
 @router.post("/marm_compaction", operation_id="marm_compaction")
 async def marm_compaction(request: CompactionRequest):
-    """Unified public compaction tool.
+    """Compact related memories into a single summary to reduce context bloat.
 
-    Keeps the MCP surface to one tool while raw route functions remain internal
-    implementation helpers and debug HTTP endpoints.
+    Workflow: status/candidates → stage → review → apply/discard
+
+    action="status"     — check if compaction candidates exist (run first)
+    action="candidates" — get pending candidates with source previews; each includes a ready-to-use prompt
+    action="stage"      — submit your summary: {candidate_id, suggested_summary}; source_memory_ids optional
+    action="review"     — inspect staged summaries before committing
+    action="apply"      — commit a staged summary; source memories are marked compacted
+    action="discard"    — reject a staged summary without touching source memories
     """
     if request.action == "status":
         return _compaction_status()

--- a/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
@@ -301,6 +301,26 @@ async def _apply_compaction_write(candidate_id: str) -> str:
     Uses _committed to prevent the except-block ROLLBACK from firing after an
     explicit COMMIT or ROLLBACK in a validation branch.
     """
+    precomputed_summary_hash = None
+    precomputed_summary_embedding = None
+    try:
+        with memory.get_connection() as conn:
+            row = conn.execute(
+                "SELECT suggested_summary FROM compaction_staging WHERE id = ?",
+                (candidate_id,),
+            ).fetchone()
+        if row and row[0]:
+            precomputed_summary = sanitize_content(row[0])
+            precomputed_summary_hash = compute_content_hash(precomputed_summary)
+            if memory._load_encoder_lazily():
+                summary_vec = await asyncio.to_thread(
+                    memory._encode_sync, precomputed_summary
+                )
+                precomputed_summary_embedding = summary_vec.tobytes()
+    except Exception:
+        precomputed_summary_hash = None
+        precomputed_summary_embedding = None
+
     with memory.get_connection() as conn:
         conn.execute("BEGIN IMMEDIATE")
         _committed = False
@@ -448,13 +468,11 @@ async def _apply_compaction_write(candidate_id: str) -> str:
             # All validations pass — sanitize, then compute embedding and write
             suggested_summary = sanitize_content(suggested_summary)
             summary_content_hash = compute_content_hash(suggested_summary)
-            summary_embedding = None
-            if memory._load_encoder_lazily():
-                try:
-                    summary_vec = await asyncio.to_thread(memory._encode_sync, suggested_summary)
-                    summary_embedding = summary_vec.tobytes()
-                except Exception:
-                    pass
+            summary_embedding = (
+                precomputed_summary_embedding
+                if precomputed_summary_hash == summary_content_hash
+                else None
+            )
 
             summary_id = str(uuid.uuid4())
             compacted_at = now

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - MARM Systems
-Version: 2.9.0
+Version: 2.9.1
 """
 
 import json
@@ -263,6 +263,20 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
         asyncio.create_task(maybe_auto_refresh())
 
     if is_tool_call and response.status_code == 200:
+        # Fast path: nothing can inject — skip buffer/parse/reserialize entirely.
+        # _protocol_delivered boolean read without lock is safe; worst case is one
+        # redundant injection attempt under extreme first-call concurrency.
+        if _protocol_delivered and not settings.COMPACTION_ENABLED:
+            return response
+
+        # Non-JSON response — nothing to mutate, return raw without parsing.
+        try:
+            content_type = response.headers.get("content-type", "") or ""
+            if isinstance(content_type, str) and content_type and "application/json" not in content_type:
+                return response
+        except Exception:
+            pass
+
         body_bytes = b""
         try:
             async for chunk in response.body_iterator:
@@ -304,11 +318,12 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
                     error=str(e),
                     body_preview=body[:200].decode("utf-8", errors="replace"),
                 )
-            compaction_block = await asyncio.to_thread(
-                claim_pending_compaction_prompt, memory, _req_session
-            )
-            if compaction_block:
-                injections.append(compaction_block)
+            if not protocol_injected:
+                compaction_block = await asyncio.to_thread(
+                    claim_pending_compaction_prompt, memory, _req_session
+                )
+                if compaction_block:
+                    injections.append(compaction_block)
 
             if not injections:
                 from starlette.responses import Response as StarletteResponse

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -658,14 +658,16 @@ async def marm_compaction(
     candidate_id: Optional[str] = None,
 ) -> dict:
     """
-    Unified compaction workflow.
+    Compact related memories into a single summary to reduce context bloat.
 
-    action="status": lightweight counts and staged candidate IDs
-    action="candidates": full pending candidates with source previews and prompt
-    action="review": full staged proposals awaiting apply/discard
-    action="stage": submit agent-generated summaries
-    action="apply": apply a staged summary
-    action="discard": discard a staged summary
+    Workflow: status/candidates → stage → review → apply/discard
+
+    action="status"     — check if compaction candidates exist (run first)
+    action="candidates" — get pending candidates with source previews; each includes a ready-to-use prompt
+    action="stage"      — submit your summary: {candidate_id, suggested_summary}; source_memory_ids optional
+    action="review"     — inspect staged summaries before committing
+    action="apply"      — commit a staged summary; source memories are marked compacted
+    action="discard"    — reject a staged summary without touching source memories
     """
     try:
         from marm_mcp_server.core.models import CompactionRequest, StagedSummaryItem
@@ -685,7 +687,6 @@ async def marm_compaction(
                     key
                     for key in (
                         "candidate_id",
-                        "source_memory_ids",
                         "suggested_summary",
                     )
                     if key not in item
@@ -698,7 +699,7 @@ async def marm_compaction(
                 items.append(
                     StagedSummaryItem(
                         candidate_id=item["candidate_id"],
-                        source_memory_ids=item["source_memory_ids"],
+                        source_memory_ids=item.get("source_memory_ids"),
                         suggested_summary=item["suggested_summary"],
                     )
                 )

--- a/marm-mcp-server/marm_mcp_server/services/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/services/notebook.py
@@ -1,5 +1,6 @@
 """Shared notebook action dispatcher for MARM MCP Server."""
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -14,7 +15,7 @@ async def _add(name: Optional[str], data: Optional[str], **_) -> dict:
     embedding_bytes = None
     if memory.encoder:
         try:
-            embedding = memory.encoder.encode(data)
+            embedding = await asyncio.to_thread(memory._encode_sync, data)
             embedding_bytes = embedding.tobytes()
         except Exception:
             pass

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.9.0"
+version = "2.9.1"
 description = "MARM-Systems is a complete protocol and platform—combining an advanced memory backend, modular semantic search, and agent-to-agent coordination with a scientifically structured, community-vetted methodology for reasoning, session recall, and collaborative AI workflows. More then just a set of tools, it's a complete AI memory ecosystem"
 readme = "README.md"
 license = "MIT"
@@ -96,6 +96,10 @@ disallow_untyped_defs = true
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "--basetemp=.pytest_tmp"
+markers = [
+    "docker: Docker transport tests skipped by scripts/run-tests.py unless --docker is used",
+    "slow_stdio: subprocess-based STDIO transport tests skipped by scripts/run-tests.py --fast",
+]
 
 # MCP Server Configuration
 [project.entry-points."mcp.servers"]

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "Ryan Lyell - MARM Systems",
   "license": "MIT",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.9.0",
+      "identifier": "lyellr88/marm-mcp-server:2.9.1",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_compaction_staging.py
+++ b/marm-mcp-server/tests/test_compaction_staging.py
@@ -487,6 +487,36 @@ async def test_unified_compaction_stage_action(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_stage_succeeds_without_source_memory_ids(monkeypatch, tmp_path):
+    """source_memory_ids is optional — server uses staged IDs when omitted."""
+    import marm_mcp_server.endpoints.compaction as ep
+    from marm_mcp_server.core.models import CompactionRequest, StagedSummaryItem
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    monkeypatch.setattr(ep, "memory", mem)
+
+    similar = _make_similar_embeddings(3)
+    ids = [_insert_memory_row(mem, "sess", f"c{i}", similar[i], content_hash=f"ch{i}") for i in range(3)]
+    snap = {ids[i]: f"ch{i}" for i in range(3)}
+    row_id = _insert_staging_row(mem, "sess", ids, snapshot=snap)
+
+    result = await ep.marm_compaction(
+        CompactionRequest(
+            action="stage",
+            summaries=[
+                StagedSummaryItem(
+                    candidate_id=row_id,
+                    suggested_summary="Summary without providing source IDs.",
+                )
+            ],
+        )
+    )
+
+    assert result["results"][0]["status"] == "summary_staged"
+    assert _get_staging_row(mem, row_id)["suggested_summary"] == "Summary without providing source IDs."
+
+
+@pytest.mark.asyncio
 async def test_unified_compaction_stage_requires_summaries(monkeypatch, tmp_path):
     from pydantic import ValidationError
     from marm_mcp_server.core.models import CompactionRequest

--- a/marm-mcp-server/tests/test_compaction_worker.py
+++ b/marm-mcp-server/tests/test_compaction_worker.py
@@ -340,7 +340,7 @@ async def test_write_counter_increments_on_layer2_merge(monkeypatch, tmp_path):
     count_after_first = mem._session_write_counts.get("sess-l2", 0)
 
     # Patch the name in memory_module's namespace — that's what store_memory calls
-    async def _fake_semantic_dup(memory, content, session, threshold):
+    async def _fake_semantic_dup(memory, content, session, threshold, query_vec=None):
         return first_id
 
     monkeypatch.setattr(memory_module, "find_semantic_duplicate", _fake_semantic_dup)

--- a/marm-mcp-server/tests/test_consolidation_exact_dedup.py
+++ b/marm-mcp-server/tests/test_consolidation_exact_dedup.py
@@ -205,13 +205,15 @@ async def test_race_window_sealed_by_begin_immediate(monkeypatch, tmp_path):
     started = 0
     release_both = asyncio.Event()
 
-    async def yielding_find_semantic(memory, content, session_name, threshold):
+    async def yielding_find_semantic(memory, content, session_name, threshold, query_vec=None):
         nonlocal started
         started += 1
         if started == 2:
             release_both.set()
         await release_both.wait()
-        return await original_find_semantic(memory, content, session_name, threshold)
+        return await original_find_semantic(
+            memory, content, session_name, threshold, query_vec=query_vec
+        )
 
     monkeypatch.setattr(memory_module, "find_semantic_duplicate", yielding_find_semantic)
 

--- a/marm-mcp-server/tests/test_consolidation_write_time.py
+++ b/marm-mcp-server/tests/test_consolidation_write_time.py
@@ -113,7 +113,7 @@ async def test_find_semantic_duplicate_returns_id_when_similarity_above_threshol
 
     monkeypatched_recall_called = []
 
-    async def mock_recall(query, session=None, limit=5):
+    async def mock_recall(query, session=None, limit=5, query_vec=None):
         monkeypatched_recall_called.append(query)
         return [{"id": "existing-id", "similarity": 0.95, "content": "similar content"}]
 
@@ -130,7 +130,7 @@ async def test_find_semantic_duplicate_returns_id_when_similarity_above_threshol
 async def test_find_semantic_duplicate_returns_none_when_similarity_below_threshold(tmp_path):
     mem = MARMMemory(str(tmp_path / "memory.db"))
 
-    async def mock_recall(query, session=None, limit=5):
+    async def mock_recall(query, session=None, limit=5, query_vec=None):
         return [{"id": "existing-id", "similarity": 0.85, "content": "similar content"}]
 
     mem._load_encoder_lazily = lambda: True
@@ -145,7 +145,7 @@ async def test_find_semantic_duplicate_returns_none_when_similarity_below_thresh
 async def test_find_semantic_duplicate_returns_none_when_no_results(tmp_path):
     mem = MARMMemory(str(tmp_path / "memory.db"))
 
-    async def mock_recall(query, session=None, limit=5):
+    async def mock_recall(query, session=None, limit=5, query_vec=None):
         return []
 
     mem._load_encoder_lazily = lambda: True
@@ -178,7 +178,7 @@ async def test_semantic_merge_returns_existing_id_and_skips_new_row(monkeypatch,
 
     first_id = await mem.store_memory("fixed the authentication bug in login flow", "session-a")
 
-    async def mock_semantic_dup(memory, content, session_name, threshold):
+    async def mock_semantic_dup(memory, content, session_name, threshold, query_vec=None):
         return first_id
 
     monkeypatch.setattr(memory_module, "find_semantic_duplicate", mock_semantic_dup)
@@ -205,7 +205,7 @@ async def test_semantic_merge_writes_merged_content_to_existing_row(monkeypatch,
 
     first_id = await mem.store_memory("fixed the authentication bug", "session-a")
 
-    async def mock_semantic_dup(memory, content, session_name, threshold):
+    async def mock_semantic_dup(memory, content, session_name, threshold, query_vec=None):
         return first_id
 
     monkeypatch.setattr(memory_module, "find_semantic_duplicate", mock_semantic_dup)
@@ -232,7 +232,7 @@ async def test_dissimilar_content_stores_as_new_row(monkeypatch, tmp_path):
 
     first_id = await mem.store_memory("fixed the authentication bug", "session-a")
 
-    async def mock_no_match(memory, content, session_name, threshold):
+    async def mock_no_match(memory, content, session_name, threshold, query_vec=None):
         return None
 
     monkeypatch.setattr(memory_module, "find_semantic_duplicate", mock_no_match)
@@ -277,7 +277,7 @@ async def test_find_semantic_duplicate_passes_correct_session_to_recall(tmp_path
 
     sessions_seen = []
 
-    async def mock_recall(query, session=None, limit=5):
+    async def mock_recall(query, session=None, limit=5, query_vec=None):
         sessions_seen.append(session)
         return []
 
@@ -300,7 +300,7 @@ async def test_similar_content_in_different_session_stores_as_new_row(monkeypatc
     first_id = await mem.store_memory("fixed the authentication bug", "session-a")
 
     # find_semantic_duplicate is session-scoped; no match exists in session-b
-    async def mock_no_cross_session_match(memory, content, session_name, threshold):
+    async def mock_no_cross_session_match(memory, content, session_name, threshold, query_vec=None):
         assert session_name == "session-b"
         return None
 

--- a/marm-mcp-server/tests/test_consolidation_write_time.py
+++ b/marm-mcp-server/tests/test_consolidation_write_time.py
@@ -2,6 +2,7 @@
 
 import json
 
+import numpy as np
 import pytest
 
 from marm_mcp_server.core.consolidation import find_semantic_duplicate
@@ -228,11 +229,17 @@ async def test_dissimilar_content_stores_as_new_row(monkeypatch, tmp_path):
 
     monkeypatch.setattr(memory_module, "CONSOLIDATION_ENABLED", True)
     mem = MARMMemory(str(tmp_path / "memory.db"))
-    mem._encoder_failed = True
+
+    class FakeEncoder:
+        def encode(self, text):
+            return np.ones(3, dtype=np.float32)
+
+    mem.encoder = FakeEncoder()
 
     first_id = await mem.store_memory("fixed the authentication bug", "session-a")
 
     async def mock_no_match(memory, content, session_name, threshold, query_vec=None):
+        assert query_vec is not None
         return None
 
     monkeypatch.setattr(memory_module, "find_semantic_duplicate", mock_no_match)

--- a/marm-mcp-server/tests/test_docker_transports.py
+++ b/marm-mcp-server/tests/test_docker_transports.py
@@ -8,6 +8,8 @@ import pytest
 import requests
 
 
+pytestmark = pytest.mark.docker
+
 DOCKER_IMAGE = os.environ.get("MARM_DOCKER_IMAGE", "lyellr88/marm-mcp-server:latest")
 
 

--- a/marm-mcp-server/tests/test_http_tools.py
+++ b/marm-mcp-server/tests/test_http_tools.py
@@ -872,15 +872,39 @@ def test_http_mcp_tool_response_orders_protocol_before_compaction(monkeypatch, t
     )
 
     async def run():
-        call = AsyncMock(return_value=resp)
-        return await server._mcp_tool_call_tracker(req, call)
+        async def body_iter():
+            yield body
 
-    response = asyncio.run(run())
-    content = json.loads(response.body)["result"]["content"]
+        # Call 1: protocol is injected, compaction is suppressed on this call
+        resp1 = MagicMock()
+        resp1.status_code = 200
+        resp1.headers = MagicMock()
+        resp1.headers.items.return_value = [("x-request-id", "1")]
+        resp1.body_iterator = body_iter()
+        call1 = AsyncMock(return_value=resp1)
+        r1 = await server._mcp_tool_call_tracker(req, call1)
 
-    assert content[0]["text"].startswith("[MARM SESSION INIT]")
-    assert content[1]["text"].startswith("[MARM COMPACTION REQUEST]")
-    assert candidate_id in content[1]["text"]
+        # Call 2: protocol already delivered, compaction fires
+        resp2 = MagicMock()
+        resp2.status_code = 200
+        resp2.headers = MagicMock()
+        resp2.headers.items.return_value = [("x-request-id", "2")]
+        resp2.body_iterator = body_iter()
+        call2 = AsyncMock(return_value=resp2)
+        r2 = await server._mcp_tool_call_tracker(req, call2)
+
+        return r1, r2
+
+    r1, r2 = asyncio.run(run())
+
+    content1 = json.loads(r1.body)["result"]["content"]
+    assert content1[0]["text"].startswith("[MARM SESSION INIT]"), "protocol must inject on first call"
+    assert not any("[MARM COMPACTION REQUEST]" in c["text"] for c in content1), \
+        "compaction must not co-inject with protocol on first call"
+
+    content2 = json.loads(r2.body)["result"]["content"]
+    assert content2[0]["text"].startswith("[MARM COMPACTION REQUEST]"), "compaction must inject on second call"
+    assert candidate_id in content2[0]["text"]
 
 
 def test_http_protocol_injected_on_first_mcp_tool_call_not_on_second(monkeypatch, tmp_path):

--- a/marm-mcp-server/tests/test_memory_database.py
+++ b/marm-mcp-server/tests/test_memory_database.py
@@ -205,3 +205,45 @@ def test_close_all_drains_connection_pool(tmp_path):
     memory.connection_pool.close_all()
 
     assert memory.connection_pool.pool.empty()
+
+
+@pytest.mark.asyncio
+async def test_mismatched_embedding_dimension_skipped_with_signal_without_breaking_recall(tmp_path):
+    """Vectors stored by a different model (wrong dimension) must not silently poison recall.
+
+    Regression for: old embeddings surviving a model change cause shape-mismatch errors
+    swallowed by bare `except Exception: continue`, making memories vanish with no signal.
+    """
+    import numpy as np
+    import uuid
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    correct_dim = 384
+    wrong_dim = 768
+
+    correct_vec = np.ones(correct_dim, dtype=np.float32)
+    correct_vec /= np.linalg.norm(correct_vec)
+    wrong_vec = np.ones(wrong_dim, dtype=np.float32)
+    wrong_vec /= np.linalg.norm(wrong_vec)
+
+    good_id = str(uuid.uuid4())
+    bad_id = str(uuid.uuid4())
+
+    with memory.get_connection() as conn:
+        conn.execute(
+            "INSERT INTO memories (id, session_name, content, embedding, content_hash, timestamp, context_type, metadata) VALUES (?, ?, ?, ?, ?, datetime('now'), 'general', '{}')",
+            (good_id, "sess", "correct dimension memory", correct_vec.tobytes(), "hash-good"),
+        )
+        conn.execute(
+            "INSERT INTO memories (id, session_name, content, embedding, content_hash, timestamp, context_type, metadata) VALUES (?, ?, ?, ?, ?, datetime('now'), 'general', '{}')",
+            (bad_id, "sess", "wrong dimension memory", wrong_vec.tobytes(), "hash-bad"),
+        )
+
+    query_vec = np.ones(correct_dim, dtype=np.float32)
+    query_vec /= np.linalg.norm(query_vec)
+
+    results = await memory.recall_similar("test query", session="sess", limit=10, query_vec=query_vec)
+
+    result_ids = {r["id"] for r in results}
+    assert good_id in result_ids, "correct-dimension memory must be returned"
+    assert bad_id not in result_ids, "wrong-dimension memory must be skipped, not crash recall"

--- a/marm-mcp-server/tests/test_stdio_transport.py
+++ b/marm-mcp-server/tests/test_stdio_transport.py
@@ -5,9 +5,32 @@ import subprocess
 import sys
 import asyncio
 
+import pytest
 from anyio import ClosedResourceError, EndOfStream
+from fastmcp import Client
 
 
+def _isolated_stdio(monkeypatch, tmp_path):
+    import marm_mcp_server.server_stdio as stdio
+    import marm_mcp_server.services.notebook as notebook_service
+    from marm_mcp_server.core.memory import MARMMemory
+
+    mem = MARMMemory(str(tmp_path / "stdio-inprocess.db"))
+    mem._encoder_failed = True
+    monkeypatch.setattr(stdio, "memory", mem)
+    monkeypatch.setattr(notebook_service, "memory", mem)
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(stdio, "ensure_marm_started", _noop)
+    monkeypatch.setattr(stdio, "maybe_auto_refresh", _noop)
+    monkeypatch.setattr(stdio, "claim_pending_compaction_prompt", lambda *args, **kwargs: None)
+    stdio._protocol_delivered = True
+    return stdio
+
+
+@pytest.mark.slow_stdio
 def test_stdio_module_import_keeps_stdout_clean_for_json_rpc(tmp_path):
     env = os.environ.copy()
     env["MARM_DB_PATH"] = str(tmp_path / "stdio-memory.db")
@@ -30,6 +53,7 @@ def test_stdio_module_import_keeps_stdout_clean_for_json_rpc(tmp_path):
     assert result.stdout == ""
 
 
+@pytest.mark.slow_stdio
 def test_stdio_handles_mcp_initialize_and_exposes_tools(tmp_path):
     env = os.environ.copy()
     env["MARM_DB_PATH"] = str(tmp_path / "stdio-rpc.db")
@@ -96,237 +120,73 @@ def test_stdio_handles_mcp_initialize_and_exposes_tools(tmp_path):
     assert len(tools) == 9
 
 
-def test_stdio_delete_notebook_removes_entry_from_active_state(tmp_path):
-    env = os.environ.copy()
-    env["MARM_DB_PATH"] = str(tmp_path / "stdio-notebook.db")
-    env["MARM_ANALYTICS_DB_PATH"] = str(tmp_path / "stdio-notebook-analytics.db")
+def test_stdio_delete_notebook_removes_entry_from_active_state(monkeypatch, tmp_path):
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
 
-    def message(msg):
-        return (json.dumps(msg) + "\n").encode("utf-8")
-
-    stdin_data = (
-        message({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "test-client", "version": "0.1"},
-        }})
-        + message({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
-        + message({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "add", "name": "smoke_test_entry", "data": "temporary regression fixture"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "use", "names": "smoke_test_entry"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {
-            "name": "marm_delete",
-            "arguments": {"type": "notebook", "target": "smoke_test_entry"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 5, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status"},
-        }})
-        # Drain calls — marm_delete races with shutdown; extra messages keep stdin
-        # open until all responses including delete are written before EOF.
-        + message({"jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 8, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status"},
-        }})
-    )
-
-    result = subprocess.run(
-        [sys.executable, "-m", "marm_mcp_server.server_stdio"],
-        input=stdin_data,
-        cwd=os.getcwd(),
-        env=env,
-        capture_output=True,
-        timeout=30,
-    )
-
-    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")[:500]
-
-    responses = {}
-    for line in result.stdout.splitlines():
-        msg = json.loads(line)
-        if "id" in msg:
-            responses[msg["id"]] = msg
-
-    add_result = json.loads(responses[2]["result"]["content"][0]["text"])
+    add_result = asyncio.run(stdio.marm_notebook(
+        action="add",
+        name="smoke_test_entry",
+        data="temporary regression fixture",
+    ))
     assert add_result["status"] == "success"
 
-    use_result = json.loads(responses[3]["result"]["content"][0]["text"])
+    use_result = asyncio.run(stdio.marm_notebook(
+        action="use",
+        names="smoke_test_entry",
+    ))
     assert use_result["activated_entries"] == ["smoke_test_entry"]
 
-    delete_result = json.loads(responses[4]["result"]["content"][0]["text"])
+    delete_result = asyncio.run(stdio.marm_delete(
+        type="notebook",
+        target="smoke_test_entry",
+    ))
     assert delete_result["deleted"] is True
 
-    with sqlite3.connect(env["MARM_DB_PATH"]) as conn:
+    with stdio.memory.get_connection() as conn:
         remaining = conn.execute(
             "SELECT COUNT(*) FROM notebook_entries WHERE name = ?",
             ("smoke_test_entry",),
         ).fetchone()[0]
     assert remaining == 0
 
-    status_response = next((responses[i] for i in (5, 6, 7, 8) if i in responses), None)
-    if status_response is not None:
-        status_result = json.loads(status_response["result"]["content"][0]["text"])
-        assert status_result["active_entries"] == [], (
-            f"Deleted entry still active after marm_delete(type='notebook'): {status_result['active_entries']}"
-        )
-
-
-def test_stdio_notebook_session_name_scopes_active_state(tmp_path):
-    env = os.environ.copy()
-    env["MARM_DB_PATH"] = str(tmp_path / "stdio-notebook-scope.db")
-    env["MARM_ANALYTICS_DB_PATH"] = str(tmp_path / "stdio-notebook-scope-analytics.db")
-
-    def message(msg):
-        return (json.dumps(msg) + "\n").encode("utf-8")
-
-    stdin_data = (
-        message({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "test-client", "version": "0.1"},
-        }})
-        + message({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
-        + message({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "add", "name": "alpha_rule", "data": "alpha scoped instruction"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "use", "names": "alpha_rule", "session_name": "alpha"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status", "session_name": "alpha"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 5, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status", "session_name": "main"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status", "session_name": "alpha"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status", "session_name": "alpha"},
-        }})
-        # Drain calls — status responses race with shutdown; extra messages keep stdin
-        # open until all earlier responses are flushed before EOF.
-        + message({"jsonrpc": "2.0", "id": 8, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status", "session_name": "alpha"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 9, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status", "session_name": "alpha"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 10, "method": "tools/call", "params": {
-            "name": "marm_notebook",
-            "arguments": {"action": "status", "session_name": "alpha"},
-        }})
+    status_result = asyncio.run(stdio.marm_notebook(action="status"))
+    assert status_result["active_entries"] == [], (
+        f"Deleted entry still active after marm_delete(type='notebook'): {status_result['active_entries']}"
     )
 
-    result = subprocess.run(
-        [sys.executable, "-m", "marm_mcp_server.server_stdio"],
-        input=stdin_data,
-        cwd=os.getcwd(),
-        env=env,
-        capture_output=True,
-        timeout=30,
-    )
 
-    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")[:500]
+def test_stdio_notebook_session_name_scopes_active_state(monkeypatch, tmp_path):
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
 
-    responses = {}
-    for line in result.stdout.splitlines():
-        msg = json.loads(line)
-        if "id" in msg:
-            responses[msg["id"]] = msg
+    asyncio.run(stdio.marm_notebook(
+        action="add",
+        name="alpha_rule",
+        data="alpha scoped instruction",
+    ))
+    asyncio.run(stdio.marm_notebook(
+        action="use",
+        names="alpha_rule",
+        session_name="alpha",
+    ))
 
-    # Accept any alpha status response from id=4 onward; drain calls ensure it is flushed.
-    alpha_status_response = next((responses[i] for i in range(4, 11) if i in responses), None)
-    assert alpha_status_response is not None, f"Missing STDIO responses: {sorted(responses)}"
+    alpha_status = asyncio.run(stdio.marm_notebook(action="status", session_name="alpha"))
+    main_status = asyncio.run(stdio.marm_notebook(action="status", session_name="main"))
 
-    alpha_status = json.loads(alpha_status_response["result"]["content"][0]["text"])
     assert alpha_status["active_entries"] == ["alpha_rule"]
+    assert main_status["active_entries"] == []
 
 
-def test_stdio_log_entry_without_session_uses_active_session(tmp_path):
-    env = os.environ.copy()
-    env["MARM_DB_PATH"] = str(tmp_path / "stdio-session.db")
-    env["MARM_ANALYTICS_DB_PATH"] = str(tmp_path / "stdio-session-analytics.db")
+def test_stdio_log_entry_without_session_uses_active_session(monkeypatch, tmp_path):
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
 
-    def message(msg):
-        return (json.dumps(msg) + "\n").encode("utf-8")
-
-    stdin_data = (
-        message({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "test-client", "version": "0.1"},
-        }})
-        + message({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
-        + message({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {
-            "name": "marm_log_session",
-            "arguments": {"session_name": "myproject"},
-        }})
-        # No session_name — should route to "myproject" via active_log_session
-        + message({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {
-            "name": "marm_log_entry",
-            "arguments": {"entry": "2026-05-20-setup-initial scaffolding done"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {
-            "name": "marm_log_show",
-            "arguments": {"session_name": "myproject"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 5, "method": "tools/call", "params": {
-            "name": "marm_log_show",
-            "arguments": {"session_name": "main"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": {
-            "name": "marm_log_show",
-            "arguments": {"session_name": "myproject"},
-        }})
-        + message({"jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": {
-            "name": "marm_log_show",
-            "arguments": {"session_name": "main"},
-        }})
-    )
-
-    result = subprocess.run(
-        [sys.executable, "-m", "marm_mcp_server.server_stdio"],
-        input=stdin_data,
-        cwd=os.getcwd(),
-        env=env,
-        capture_output=True,
-        timeout=30,
-    )
-
-    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")[:500]
-
-    responses = {}
-    for line in result.stdout.splitlines():
-        msg = json.loads(line)
-        if "id" in msg:
-            responses[msg["id"]] = msg
-
-    switch_result = json.loads(responses[2]["result"]["content"][0]["text"])
+    switch_result = asyncio.run(stdio.marm_log_session(session_name="myproject"))
     assert switch_result["status"] == "success"
 
-    with sqlite3.connect(env["MARM_DB_PATH"]) as conn:
+    asyncio.run(stdio.marm_log_entry(
+        entry="2026-05-20-setup-initial scaffolding done",
+    ))
+
+    with stdio.memory.get_connection() as conn:
         project_count = conn.execute(
             "SELECT COUNT(*) FROM log_entries WHERE session_name = ?",
             ("myproject",),
@@ -338,6 +198,50 @@ def test_stdio_log_entry_without_session_uses_active_session(tmp_path):
 
     assert project_count == 1, f"Entry did not land in 'myproject'; count={project_count}"
     assert main_count == 0, f"Entry incorrectly landed in 'main'; count={main_count}"
+
+
+def test_stdio_inprocess_client_wraps_notebook_delete_and_log_results(monkeypatch, tmp_path):
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+
+    async def run():
+        async with Client(stdio.mcp) as client:
+            add_result = await client.call_tool(
+                "marm_notebook",
+                {
+                    "action": "add",
+                    "name": "envelope_entry",
+                    "data": "temporary envelope fixture",
+                },
+            )
+            use_result = await client.call_tool(
+                "marm_notebook",
+                {"action": "use", "names": "envelope_entry"},
+            )
+            delete_result = await client.call_tool(
+                "marm_delete",
+                {"type": "notebook", "target": "envelope_entry"},
+            )
+            session_result = await client.call_tool(
+                "marm_log_session",
+                {"session_name": "envelope-session"},
+            )
+            entry_result = await client.call_tool(
+                "marm_log_entry",
+                {"entry": "2026-06-03-envelope-routing verified"},
+            )
+        return add_result, use_result, delete_result, session_result, entry_result
+
+    add_result, use_result, delete_result, session_result, entry_result = asyncio.run(run())
+
+    for result in (add_result, use_result, delete_result, session_result, entry_result):
+        assert result.content
+        assert result.content[0].type == "text"
+
+    assert json.loads(add_result.content[0].text)["status"] == "success"
+    assert json.loads(use_result.content[0].text)["activated_entries"] == ["envelope_entry"]
+    assert json.loads(delete_result.content[0].text)["deleted"] is True
+    assert json.loads(session_result.content[0].text)["status"] == "success"
+    assert json.loads(entry_result.content[0].text)["status"] == "success"
 
 
 def _base_rpc_stdin():
@@ -355,6 +259,7 @@ def _base_rpc_stdin():
     )
 
 
+@pytest.mark.slow_stdio
 def test_stdio_log_file_is_created_and_contains_startup(tmp_path):
     log_dir = tmp_path / "logs"
     env = os.environ.copy()
@@ -380,6 +285,7 @@ def test_stdio_log_file_is_created_and_contains_startup(tmp_path):
     assert "startup" in content, f"Expected 'startup' in log, got: {content[:500]}"
 
 
+@pytest.mark.slow_stdio
 def test_stdio_log_records_tool_call_and_ok_status(tmp_path):
     log_dir = tmp_path / "logs"
     env = os.environ.copy()
@@ -427,6 +333,7 @@ def test_stdio_log_records_tool_call_and_ok_status(tmp_path):
     assert "OK marm_log_session" in log_content, f"Expected OK entry, got: {log_content}"
 
 
+@pytest.mark.slow_stdio
 def test_stdio_debug_mode_logs_session_name_not_content(tmp_path):
     log_dir = tmp_path / "logs"
     env = os.environ.copy()
@@ -474,6 +381,7 @@ def test_stdio_debug_mode_logs_session_name_not_content(tmp_path):
     assert "session=debug-session" in log_content, f"Expected session name in DEBUG log, got: {log_content}"
 
 
+@pytest.mark.slow_stdio
 def test_stdio_log_does_not_contain_stored_memory_content(tmp_path):
     log_dir = tmp_path / "logs"
     env = os.environ.copy()
@@ -516,6 +424,7 @@ def test_stdio_log_does_not_contain_stored_memory_content(tmp_path):
     )
 
 
+@pytest.mark.slow_stdio
 def test_stdio_context_log_uses_write_queue_when_enabled(tmp_path):
     env = os.environ.copy()
     env["MARM_DB_PATH"] = str(tmp_path / "stdio-queue.db")

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Run the known-good local MARM MCP test checks."""
+"""Run local MARM MCP tests with fast defaults and explicit Docker opt-in."""
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import sys
@@ -16,13 +17,27 @@ RESET = "\033[0m"
 
 ROOT = Path(__file__).resolve().parent.parent
 SERVER_ROOT = ROOT / "marm-mcp-server"
+TESTS_ROOT = SERVER_ROOT / "tests"
 BASE_TEMP = Path(r"C:\tmp\marm-pytest") if os.name == "nt" else Path("/tmp/marm-pytest")
+FAST_TEMP_ROOT = SERVER_ROOT / ".pytest_tmp_fast"
+DOCKER_IMAGE = "lyellr88/marm-mcp-server:latest"
 
 
-def run_step(name: str, command: list[str], cwd: Path) -> bool:
+def pytest_env() -> dict[str, str]:
+    env = os.environ.copy()
+    FAST_TEMP_ROOT.mkdir(parents=True, exist_ok=True)
+    temp_root = str(FAST_TEMP_ROOT)
+    env["PYTEST_DEBUG_TEMPROOT"] = temp_root
+    env["TMP"] = temp_root
+    env["TEMP"] = temp_root
+    env["TMPDIR"] = temp_root
+    return env
+
+
+def run_step(name: str, command: list[str], cwd: Path, env: dict[str, str] | None = None) -> bool:
     print(f"\n{CYAN}==> {name}{RESET}")
     print(" ".join(command))
-    result = subprocess.run(command, cwd=cwd)
+    result = subprocess.run(command, cwd=cwd, env=env)
     if result.returncode == 0:
         print(f"{GREEN}PASS: {name}{RESET}")
         return True
@@ -30,36 +45,141 @@ def run_step(name: str, command: list[str], cwd: Path) -> bool:
     return False
 
 
+def docker_available() -> bool:
+    try:
+        ps = subprocess.run(
+            ["docker", "ps"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=20,
+        )
+        if ps.returncode != 0:
+            return False
+        image = subprocess.run(
+            ["docker", "image", "inspect", DOCKER_IMAGE],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=20,
+        )
+        return image.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def pytest_base_command(args: argparse.Namespace) -> list[str]:
+    command = [sys.executable, "-m", "pytest", "-q", "--tb=short"]
+    if not args.project_addopts:
+        # pyproject.toml sets --basetemp=.pytest_tmp globally. Fast local runs
+        # intentionally bypass that cleanup cost unless --clean-temp/--full is used.
+        command.extend(["-o", "addopts="])
+    if not args.show_warnings:
+        command.append("--disable-warnings")
+    if args.clean_temp:
+        BASE_TEMP.parent.mkdir(parents=True, exist_ok=True)
+        command.extend(["--basetemp", str(BASE_TEMP)])
+    if args.last_failed:
+        command.append("--lf")
+    marker_filters = []
+    if not args.docker:
+        marker_filters.append("not docker")
+    if args.fast:
+        marker_filters.append("not slow_stdio")
+    if marker_filters:
+        command.extend(["-m", " and ".join(marker_filters)])
+    return command
+
+
+def run_pytest_all(args: argparse.Namespace) -> bool:
+    command = pytest_base_command(args)
+    command.append("tests")
+    return run_step("Pytest suite", command, SERVER_ROOT, env=pytest_env())
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run MARM MCP tests with Docker and slow checks opt-in."
+    )
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help="Run one non-Docker pytest pass with fast local defaults.",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Run compile check and clean pytest temp directory.",
+    )
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        help="Run compileall before pytest.",
+    )
+    parser.add_argument(
+        "--clean-temp",
+        action="store_true",
+        help=f"Pass --basetemp={BASE_TEMP} to pytest. This deletes that temp tree.",
+    )
+    parser.add_argument(
+        "--docker",
+        action="store_true",
+        help="Include Docker transport tests if Docker and the local image are available.",
+    )
+    parser.add_argument(
+        "--last-failed",
+        action="store_true",
+        help="Pass --lf to pytest.",
+    )
+    parser.add_argument(
+        "--show-warnings",
+        action="store_true",
+        help="Show pytest warning summaries. Hidden by default for fast local runs.",
+    )
+    parser.add_argument(
+        "--project-addopts",
+        action="store_true",
+        help="Use pytest addopts from pyproject.toml instead of clearing them.",
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
+    args = parse_args()
+    if args.full:
+        args.compile = True
+        args.clean_temp = True
+
     if not SERVER_ROOT.exists():
         print(f"{RED}MCP server folder not found: {SERVER_ROOT}{RESET}")
         return 1
 
-    BASE_TEMP.parent.mkdir(parents=True, exist_ok=True)
+    if args.docker:
+        if not docker_available():
+            print(
+                f"{YELLOW}Docker tests requested but Docker/image is unavailable; "
+                f"skipping docker-marked tests.{RESET}"
+            )
+            args.docker = False
+    else:
+        print(f"{YELLOW}Docker tests skipped by default. Use --docker to include them.{RESET}")
 
-    steps = [
-        (
-            "Python compile check",
-            [sys.executable, "-m", "compileall", "-q", "marm_mcp_server", "tests"],
-        ),
-        (
-            "Pytest suite",
-            [sys.executable, "-m", "pytest", "-q", "--basetemp", str(BASE_TEMP)],
-        ),
-    ]
+    if args.compile and not run_step(
+        "Python compile check",
+        [sys.executable, "-m", "compileall", "-q", "marm_mcp_server", "tests"],
+        SERVER_ROOT,
+    ):
+        print(f"\n{RED}Test runner failed.{RESET}")
+        return 1
 
-    failed = False
-    for name, command in steps:
-        if not run_step(name, command, SERVER_ROOT):
-            failed = True
-            break
+    if not TESTS_ROOT.exists():
+        print(f"{RED}Tests folder not found: {TESTS_ROOT}{RESET}")
+        return 1
 
-    if failed:
+    ok = run_pytest_all(args)
+    if not ok:
         print(f"\n{RED}Test runner failed.{RESET}")
         return 1
 
     print(f"\n{GREEN}All test checks passed.{RESET}")
-    print(f"{YELLOW}Note: Docker tests skip automatically if Docker/image is unavailable.{RESET}")
     return 0
 
 

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -25,8 +25,9 @@ DOCKER_IMAGE = "lyellr88/marm-mcp-server:latest"
 
 def pytest_env() -> dict[str, str]:
     env = os.environ.copy()
-    FAST_TEMP_ROOT.mkdir(parents=True, exist_ok=True)
-    temp_root = str(FAST_TEMP_ROOT)
+    temp_root_path = FAST_TEMP_ROOT / f"run-{os.getpid()}"
+    temp_root_path.mkdir(parents=True, exist_ok=True)
+    temp_root = str(temp_root_path)
     env["PYTEST_DEBUG_TEMPROOT"] = temp_root
     env["TMP"] = temp_root
     env["TEMP"] = temp_root
@@ -82,7 +83,7 @@ def pytest_base_command(args: argparse.Namespace) -> list[str]:
     marker_filters = []
     if not args.docker:
         marker_filters.append("not docker")
-    if args.fast:
+    if not args.slow:
         marker_filters.append("not slow_stdio")
     if marker_filters:
         command.extend(["-m", " and ".join(marker_filters)])
@@ -103,6 +104,11 @@ def parse_args() -> argparse.Namespace:
         "--fast",
         action="store_true",
         help="Run one non-Docker pytest pass with fast local defaults.",
+    )
+    parser.add_argument(
+        "--slow",
+        action="store_true",
+        help="Include slow subprocess STDIO transport tests.",
     )
     parser.add_argument(
         "--full",
@@ -147,6 +153,7 @@ def main() -> int:
     if args.full:
         args.compile = True
         args.clean_temp = True
+        args.slow = True
 
     if not SERVER_ROOT.exists():
         print(f"{RED}MCP server folder not found: {SERVER_ROOT}{RESET}")


### PR DESCRIPTION
Offload embedding generation from async request paths and reuse precomputed vectors during write-time consolidation to avoid double encoding.

Make compaction staging easier for agents by allowing source_memory_ids to be omitted, improve the marm_compaction workflow description, and align HTTP/STDIO injection behavior.

Add embedding dimension guards, STDIO in-process coverage, Docker/slow-STDIO test markers, v2.9.1 metadata, and CodeRabbit review-noise configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Embedding-dimension mismatches are now skipped safely during recall; recall remains robust.
  * HTTP middleware hardened to avoid unsafe injection and double processing.
  * Compaction staging now accepts optional source IDs.

* **Documentation**
  * All version references updated to v2.9.1.

* **Tests**
  * Added embedding-dimension regression test and expanded in-process notebook/logging coverage.

* **Chores**
  * Bumped package to 2.9.1 and switched Docker build caching to GitHub Actions.
  * Embedding work moved off the hot request path for better responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->