### PR TITLE
fix: preserve compaction trigger env override

### DIFF
--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -548,7 +548,10 @@ def apply_runtime_preset(
         mode = "trusted"
         write_queue_enabled = True
 
-    compaction_trigger_count = 5 if mode == "default" else 20
+    if "COMPACTION_TRIGGER_COUNT" in os.environ:
+        compaction_trigger_count = settings.COMPACTION_TRIGGER_COUNT
+    else:
+        compaction_trigger_count = 5 if mode == "default" else 20
 
     settings.MARM_RATE_LIMIT_RPM = rpm
     settings.WRITE_QUEUE_ENABLED = write_queue_enabled

--- a/marm-mcp-server/tests/test_cli_entrypoint.py
+++ b/marm-mcp-server/tests/test_cli_entrypoint.py
@@ -136,6 +136,21 @@ def test_default_runtime_preset_uses_low_compaction_trigger(monkeypatch, tmp_pat
     assert memory_module.COMPACTION_TRIGGER_COUNT == 5
 
 
+def test_runtime_preset_preserves_compaction_env_override(monkeypatch, tmp_path):
+    from conftest import load_isolated_server
+
+    monkeypatch.setenv("COMPACTION_TRIGGER_COUNT", "50")
+    server = load_isolated_server(monkeypatch, tmp_path)
+    settings = importlib.import_module("marm_mcp_server.config.settings")
+    memory_module = importlib.import_module("marm_mcp_server.core.memory")
+
+    result = server.apply_runtime_preset(swarm=True)
+
+    assert result["mode"] == "swarm"
+    assert settings.COMPACTION_TRIGGER_COUNT == 50
+    assert memory_module.COMPACTION_TRIGGER_COUNT == 50
+
+
 def _free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))


### PR DESCRIPTION
## Summary
- Preserve an explicitly configured `COMPACTION_TRIGGER_COUNT` when runtime presets are applied.
- Continue using preset defaults (`5` for default mode, `20` for swarm/trusted/custom modes) when no env override is present.
- Add regression coverage for the env override path so Docker/operator tuning is not silently clobbered.

## Test Plan
- [x] `PYTHONPATH=. .venv/bin/python -m pytest tests/test_cli_entrypoint.py::test_runtime_preset_preserves_compaction_env_override -q`
- [x] `PYTHONPATH=. .venv/bin/python -m pytest tests/test_cli_entrypoint.py::test_runtime_presets_configure_rate_limit_and_write_queue tests/test_cli_entrypoint.py::test_default_runtime_preset_uses_low_compaction_trigger tests/test_cli_entrypoint.py::test_runtime_preset_preserves_compaction_env_override -q`
- [x] `PYTHONPATH=. .venv/bin/python -m py_compile marm_mcp_server/server.py tests/test_cli_entrypoint.py`

Closes #35

Note: `tests/test_cli_entrypoint.py` as a whole currently needs the optional semantic-search dependency installed locally; the focused runtime-preset tests above pass in the local lightweight test environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The server's compaction trigger count can now be configured via the `COMPACTION_TRIGGER_COUNT` environment variable, with fallback to default mode-based values when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->