### PR TITLE
feat(recall,endpoints,services): recall visibility, protocol scope, s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1497,3 +1497,33 @@ marm_notebook(action="use"|"status"|"clear", session_name="my_project")
 - Added contact section (Discord and email) to `CONTRIBUTING.md`.
 
 </details>
+
+<details>
+<summary><strong>June 6th, 2026: Recall Visibility, Protocol Scope & Service Refactor (v2.10.0)</strong></summary>
+
+#### Recall & Search Reliability
+
+- Added `RECALL_SCAN_LIMIT` so semantic recall's bounded DB scan is configurable instead of hardcoded to 1,000 rows.
+- `recall_similar()` now scans `limit + 1` rows internally to detect when recall was bounded and returns scan metadata only for callers that request it.
+- HTTP and STDIO `marm_smart_recall` responses now surface `recall_scan_truncated` and `recall_scan_limit` on both success and no-result paths, making bounded recall visible to agents.
+- Standardized model-facing MCP tool failures to return structured `{"status":"error"}` payloads instead of opaque HTTP 500 exceptions across recall, context logging, session logs, notebook, delete, and summary flows.
+
+#### Protocol & Agent Session Handling
+
+- Changed HTTP protocol injection from one server-global delivery flag to per-session tracking so multiple agents/sessions can each receive the MARM protocol once.
+- Preserved the first-call protocol ordering behavior while keeping compaction nudges from co-injecting with protocol initialization.
+- Added regression coverage for independent protocol delivery across separate sessions.
+
+#### Consolidation Safety
+
+- Capped write-time merge growth at 10,000 characters so hot near-duplicate memories cannot grow into unbounded blobs.
+- Preserved the newest merged content while trimming older content when a merge would exceed the cap.
+- Added regression coverage for the merge-size cap and recall scan truncation metadata.
+
+#### Service Refactor
+
+- Extracted STDIO smart recall logic into `services/recall.py` so HTTP and STDIO recall behavior can stay aligned.
+- Extracted STDIO session summary formatting into `services/summary.py` while keeping the public `marm_summary` tool as a thin wrapper.
+- Moved atomic compaction apply DB logic into `services/compaction_apply.py`, reducing endpoint size while preserving the existing write-queue apply path.
+
+</details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,10 @@ marm-mcp-server/
     services/
       documentation.py         # Startup documentation loading
       automation.py            # Event handler registration
+      notebook.py              # Notebook dispatch service
+      recall.py                # Shared smart-recall response logic
+      summary.py               # Shared session summary formatting
+      compaction_apply.py      # Atomic compaction apply transaction
     utils/
       helpers.py               # Shared helpers
       security.py              # API key generation

--- a/MCP-HANDBOOK.md
+++ b/MCP-HANDBOOK.md
@@ -2,7 +2,7 @@
 
 ## Complete Usage Guide for Memory-Augmented AI
 
-**MARM v2.9.2 - Universal MCP Server for AI Memory Intelligence**
+**MARM v2.10.0 - Universal MCP Server for AI Memory Intelligence**
 
 ---
 
@@ -311,6 +311,7 @@ The write queue is enabled by default and serializes memory writes through one i
 **Global Search**: Use `search_all=True` to search across all sessions
 **Natural Language Search**: "authentication problems with JWT tokens" vs "auth error"
 **Temporal Search**: Include timeframes in queries
+**Bounded Recall Signal**: If `marm_smart_recall` returns `recall_scan_truncated=true`, the semantic scan hit `RECALL_SCAN_LIMIT`; narrow the session/query or raise the env var for larger stores.
 
 ### Workflow Optimization
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="700"
      height="400">
 </picture>
-<h1 align="center">MARM: The AI That Remembers Your Conversations v2.9.2</h1>
+<h1 align="center">MARM: The AI That Remembers Your Conversations v2.10.0</h1>
 
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/Lyellr88/MARM-Systems/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -92,7 +92,7 @@ MARM currently exposes **9 focused MCP tools**:
 
 #### Q: Do I still need to call `marm_start`?
 
-No. Session startup, protocol delivery, and documentation loading are now automatic. The server injects the protocol on the first successful MCP tool call, then keeps docs indexed with hash-based caching so unchanged docs are not repeatedly duplicated.
+No. Session startup, protocol delivery, and documentation loading are now automatic. The server injects the protocol on the first successful MCP tool call for each session scope, then keeps docs indexed with hash-based caching so unchanged docs are not repeatedly duplicated.
 
 ---
 
@@ -129,6 +129,8 @@ When you store memory through `marm_context_log`, MARM classifies content into b
 #### Q: Can I search across all sessions or just one?
 
 Both. `marm_smart_recall` searches one session by default and can search across all sessions with `search_all=True`.
+
+When semantic recall reaches its configured scan cap, responses include `recall_scan_truncated=true` and `recall_scan_limit` so agents know the search was bounded.
 
 #### Q: When should I create a new session vs. continuing an existing one?
 

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.9.2** - Memory Accurate Response Mode
+**MARM v2.10.0** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---
@@ -607,6 +607,7 @@ services:
 | `SERVER_PORT` | `8001` | Server port. |
 | `MARM_API_KEY` | _(unset)_ | Required for all Docker deployments (local and remote). Docker bridge networking means the server never sees 127.0.0.1 from the host — set this or all MCP calls will 401. Generate with `docker run --rm lyellr88/marm-mcp-server:latest --generate-key`. |
 | `MARM_RATE_LIMIT_RPM` | `80` | HTTP rate limit (requests per minute per client IP). Set to `0` to disable. Overridden by `--swarm`, `--swarm-max`, `--trusted` presets. |
+| `RECALL_SCAN_LIMIT` | `1000` | Maximum embedded memories semantic recall scans per query before surfacing `recall_scan_truncated=true`. |
 | `MAX_QUEUE_SIZE` | `100` | Write queue size when `WRITE_QUEUE_ENABLED=1`. |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialized memory write queue. Set to `0` only for debugging/direct-write comparisons. |
 | `MARM_ANALYTICS_DB_PATH` | `/app/data/marm_usage_analytics.db` | Override analytics database path. |

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.9.2** - Memory Accurate Response Mode
+**MARM v2.10.0** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -316,7 +316,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"
@@ -443,6 +443,7 @@ source ~/.bashrc
 | `MAX_DB_CONNECTIONS` | `5` | Database connection pool size |
 | `MARM_ANALYTICS_DB_PATH` | `marm_usage_analytics.db` | Override analytics database path |
 | `DEFAULT_SEMANTIC_MODEL` | `all-MiniLM-L6-v2` | AI model for semantic search |
+| `RECALL_SCAN_LIMIT` | `1000` | Maximum embedded memories semantic recall scans per query before surfacing `recall_scan_truncated=true`. |
 | `MARM_RATE_LIMIT_RPM` | `80` | HTTP rate limit (requests per minute per client IP). Set to `0` to disable. Overridden by `--swarm`, `--swarm-max`, `--trusted` presets. |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialized memory write queue. Set to `0` only for debugging/direct-write comparisons. |
 | `MAX_QUEUE_SIZE` | `100` | Write queue capacity when `WRITE_QUEUE_ENABLED=1`. |

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.9.2 MCP Server - Platform Integration Guide
+# MARM v2.10.0 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.9.2** - Memory Accurate Response Mode
+**MARM v2.10.0** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -289,7 +289,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"
@@ -405,6 +405,7 @@ python -m marm_mcp_server
 | `MAX_DB_CONNECTIONS` | `5` | Database connection pool size |
 | `MARM_ANALYTICS_DB_PATH` | `marm_usage_analytics.db` | Override analytics database path |
 | `DEFAULT_SEMANTIC_MODEL` | `all-MiniLM-L6-v2` | AI model for semantic search |
+| `RECALL_SCAN_LIMIT` | `1000` | Maximum embedded memories semantic recall scans per query before surfacing `recall_scan_truncated=true`. |
 | `MARM_RATE_LIMIT_RPM` | `80` | HTTP rate limit (requests per minute per client IP). Set to `0` to disable. Overridden by `--swarm`, `--swarm-max`, `--trusted` presets. |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialized memory write queue. Set to `0` only for debugging/direct-write comparisons. |
 | `MAX_QUEUE_SIZE` | `100` | Write queue capacity when `WRITE_QUEUE_ENABLED=1`. |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,6 +1,6 @@
 # MARM MCP Protocol
 
-This protocol defines how MARM MCP should orient connected AI agents when persistent memory, session logs, notebook context, and semantic recall are available. It is delivered automatically by the MCP server on the first successful tool call and should be treated as operating guidance for the current MARM-backed session.
+This protocol defines how MARM MCP should orient connected AI agents when persistent memory, session logs, notebook context, and semantic recall are available. It is delivered automatically by the MCP server on the first successful tool call for each session scope and should be treated as operating guidance for the current MARM-backed session.
 
 ```txt
 MARM MCP - Memory Accurate Response Mode

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -38,7 +38,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.9.2"
+LABEL org.opencontainers.image.version="2.10.0"
 LABEL org.opencontainers.image.authors="Ryan Lyell - MARM Systems"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/MARM-Systems"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -5,7 +5,7 @@
      width="700"
      height="400">
 </picture>
-<h1 align="center">MARM: The AI That Remembers Your Conversations v2.9.2</h1>
+<h1 align="center">MARM: The AI That Remembers Your Conversations v2.10.0</h1>
 
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/Lyellr88/MARM-Systems/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)

--- a/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
+++ b/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
@@ -2,7 +2,7 @@
 
 ## Complete Usage Guide for Memory-Augmented AI
 
-**MARM v2.9.2 - Universal MCP Server for AI Memory Intelligence**
+**MARM v2.10.0 - Universal MCP Server for AI Memory Intelligence**
 
 ---
 
@@ -306,6 +306,7 @@ The write queue is enabled by default and serializes memory writes through one i
 **Global Search**: Use `search_all=True` to search across all sessions
 **Natural Language Search**: "authentication problems with JWT tokens" vs "auth error"
 **Temporal Search**: Include timeframes in queries
+**Bounded Recall Signal**: If `marm_smart_recall` returns `recall_scan_truncated=true`, the semantic scan hit `RECALL_SCAN_LIMIT`; narrow the session/query or raise the env var for larger stores.
 
 ### Workflow Optimization
 

--- a/marm-mcp-server/marm-docs/PROTOCOL.md
+++ b/marm-mcp-server/marm-docs/PROTOCOL.md
@@ -1,6 +1,6 @@
 # MARM MCP Protocol
 
-This protocol defines how MARM MCP should orient connected AI agents when persistent memory, session logs, notebook context, and semantic recall are available. It is delivered automatically by the MCP server on the first successful tool call and should be treated as operating guidance for the current MARM-backed session.
+This protocol defines how MARM MCP should orient connected AI agents when persistent memory, session logs, notebook context, and semantic recall are available. It is delivered automatically by the MCP server on the first successful tool call for each session scope and should be treated as operating guidance for the current MARM-backed session.
 
 ```txt
 MARM MCP - Memory Accurate Response Mode

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,10 +14,10 @@ Features:
 - Production-grade performance
 
 Author: Lyell - MARM Systems
-Version: 2.9.2
+Version: 2.10.0
 """
 
-__version__ = "2.9.2"
+__version__ = "2.10.0"
 __author__ = "Lyell"
 __email__ = "lyell@marmsystems.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from ..utils.security import generate_api_key
 
-# Advanced memory system availability flags
 SEMANTIC_SEARCH_AVAILABLE = (
     importlib.util.find_spec("sentence_transformers") is not None
 )
@@ -16,7 +15,6 @@ if not SEMANTIC_SEARCH_AVAILABLE:
         "WARNING: Semantic search not available. Install: pip install sentence-transformers"
     )
 
-# Automation scheduler availability
 SCHEDULER_AVAILABLE = importlib.util.find_spec("apscheduler") is not None
 if not SCHEDULER_AVAILABLE:
     print("WARNING: Scheduler not available. Install: pip install apscheduler")
@@ -30,21 +28,16 @@ def _file_link(path: Path) -> str:
         return str(path)
 
 
-# Database configuration - Official .marm system directory (CLI standard)
 def get_marm_db_path():
     """Get the official MARM database path, respecting environment variable if set"""
-    # Check if MARM_DB_PATH environment variable is set (for Docker)
     env_db_path = os.environ.get("MARM_DB_PATH")
     if env_db_path:
-        # Ensure the directory exists
         db_dir = Path(env_db_path).parent
         db_dir.mkdir(parents=True, exist_ok=True)
         return env_db_path
 
-    # Follow professional CLI standard: ~/.marm/ (like ~/.git, ~/.docker, ~/.claude)
     marm_dir = Path.home() / ".marm"
 
-    # Create .marm directory if it doesn't exist
     marm_dir.mkdir(exist_ok=True)
 
     return str(marm_dir / "marm_memory.db")
@@ -75,7 +68,7 @@ DEFAULT_SEMANTIC_MODEL = "all-MiniLM-L6-v2"
 
 SERVER_HOST = os.environ.get("SERVER_HOST", "127.0.0.1")
 SERVER_PORT = int(os.environ.get("SERVER_PORT", 8001))
-SERVER_VERSION = "2.9.2"
+SERVER_VERSION = "2.10.0"
 
 MARM_RATE_LIMIT_RPM = int(os.environ.get("MARM_RATE_LIMIT_RPM", "80"))
 RATE_LIMIT_WINDOW_SECONDS = int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60"))
@@ -83,6 +76,7 @@ RATE_LIMIT_BLOCK_SECONDS = int(os.environ.get("RATE_LIMIT_BLOCK_SECONDS", "30"))
 
 WRITE_QUEUE_ENABLED = os.environ.get("WRITE_QUEUE_ENABLED", "1") == "1"
 MAX_QUEUE_SIZE = int(os.environ.get("MAX_QUEUE_SIZE", "100"))
+RECALL_SCAN_LIMIT = int(os.environ.get("RECALL_SCAN_LIMIT", "1000"))
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
 CONSOLIDATION_THRESHOLD = float(os.environ.get("CONSOLIDATION_THRESHOLD", "0.92"))
@@ -160,10 +154,18 @@ if SERVER_HOST == "0.0.0.0" and not MARM_API_KEY and not _is_generate_key_cmd:
             try:
                 import subprocess
                 import getpass
+
                 user = getpass.getuser()
                 subprocess.run(
-                    ["icacls", str(_MARM_ENV_PATH), "/inheritance:r", "/grant:r", f"{user}:(F)"],
-                    check=False, capture_output=True,
+                    [
+                        "icacls",
+                        str(_MARM_ENV_PATH),
+                        "/inheritance:r",
+                        "/grant:r",
+                        f"{user}:(F)",
+                    ],
+                    check=False,
+                    capture_output=True,
                 )
             except Exception:
                 pass

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -762,7 +762,7 @@ class MARMMemory:
                 return _wrap(results, scan_truncated)
 
         except Exception as e:
-            print(f"Semantic search failed: {e}")
+            _safe_print(f"Semantic search failed: {e}")
             return _wrap(await self.recall_text_search(query, session, limit), False)
 
     async def recall_text_search(

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -72,6 +72,7 @@ from ..config.settings import (  # noqa: E402
     CONSOLIDATION_THRESHOLD,
     COMPACTION_ENABLED,
     COMPACTION_TRIGGER_COUNT,
+    RECALL_SCAN_LIMIT,
 )
 from .consolidation import (  # noqa: E402
     compute_content_hash,
@@ -488,7 +489,14 @@ class MARMMemory:
                 return
             existing_content, metadata_json = row
             metadata = json.loads(metadata_json) if metadata_json else {}
-            merged_content = f"{existing_content}\n[merged] {new_content}"
+            _MAX = 10000
+            _MARKER = "\n[merged] "
+            _new_budget = _MAX - len(_MARKER)
+            if len(new_content) > _new_budget:
+                new_content = new_content[:_new_budget]
+            _existing_budget = _MAX - len(_MARKER) - len(new_content)
+            existing_content = existing_content[: max(0, _existing_budget)]
+            merged_content = f"{existing_content}{_MARKER}{new_content}"
             merged_at = datetime.now(timezone.utc).isoformat()
             if "merge_history" not in metadata:
                 metadata["merge_history"] = []
@@ -646,12 +654,34 @@ class MARMMemory:
         return await self.store_memory(content, session, context_type, metadata)
 
     async def recall_similar(
-        self, query: str, session: str = None, limit: int = 5, query_vec=None
-    ) -> List[Dict]:
-        """Find semantically similar memories"""
+        self,
+        query: str,
+        session: str = None,
+        limit: int = 5,
+        query_vec=None,
+        include_scan_metadata: bool = False,
+    ):
+        """Find semantically similar memories.
+
+        When include_scan_metadata=True, returns (List[Dict], dict) where the second
+        element contains recall_scan_truncated and recall_scan_limit. All other callers
+        receive List[Dict] as before.
+        """
+        scan_limit = RECALL_SCAN_LIMIT
+
+        def _wrap(results, truncated):
+            if include_scan_metadata:
+                return results, {
+                    "recall_scan_truncated": truncated,
+                    "recall_scan_limit": scan_limit,
+                }
+            return results
+
         if query_vec is None:
             if not self._load_encoder_lazily():
-                return await self.recall_text_search(query, session, limit)
+                return _wrap(
+                    await self.recall_text_search(query, session, limit), False
+                )
 
         try:
             if query_vec is not None:
@@ -661,14 +691,17 @@ class MARMMemory:
 
             with self.get_connection() as conn:
                 if session is None:
-                    cursor = conn.execute("""
+                    cursor = conn.execute(
+                        """
                         SELECT id, session_name, content, embedding, timestamp, context_type, metadata
                         FROM memories
                         WHERE embedding IS NOT NULL
                           AND (compaction_role IS NULL OR compaction_role != 'source')
                         ORDER BY timestamp DESC
-                        LIMIT 1000
-                    """)
+                        LIMIT ?
+                    """,
+                        (scan_limit + 1,),
+                    )
                 else:
                     cursor = conn.execute(
                         """
@@ -678,12 +711,15 @@ class MARMMemory:
                           AND session_name = ?
                           AND (compaction_role IS NULL OR compaction_role != 'source')
                         ORDER BY timestamp DESC
-                        LIMIT 1000
+                        LIMIT ?
                     """,
-                        (session,),
+                        (session, scan_limit + 1),
                     )
 
                 memories = cursor.fetchall()
+                scan_truncated = len(memories) > scan_limit
+                memories = memories[:scan_limit]
+
                 similarities = []
                 expected_dim = len(query_embedding)
                 dim_skipped = 0
@@ -723,11 +759,11 @@ class MARMMemory:
                         }
                     )
 
-                return results
+                return _wrap(results, scan_truncated)
 
         except Exception as e:
             print(f"Semantic search failed: {e}")
-            return await self.recall_text_search(query, session, limit)
+            return _wrap(await self.recall_text_search(query, session, limit), False)
 
     async def recall_text_search(
         self, query: str, session: str = None, limit: int = 5
@@ -770,7 +806,7 @@ class MARMMemory:
                         "timestamp": row[3],
                         "context_type": row[4],
                         "metadata": json.loads(row[5]) if row[5] else {},
-                        "similarity": 0.8, 
+                        "similarity": 0.8,
                     }
                 )
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
@@ -1,20 +1,18 @@
 """Compaction MCP endpoint tools — V2 agent-driven summarization, V3 staged apply, V4 write-queue + auto-apply."""
 
-import asyncio
 import json
-import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter
 
 from ..core.compaction import COMPACTION_PROMPT_TEMPLATE
-from ..core.consolidation import compute_content_hash
-from ..core.memory import memory, sanitize_content
+from ..core.memory import memory
 from ..core.models import (
     ApplyCompactionRequest,
     CompactionRequest,
     StageCompactionSummariesRequest,
 )
+from ..services.compaction_apply import apply_compaction_write
 
 router = APIRouter(prefix="", tags=["Compaction"])
 
@@ -291,246 +289,6 @@ async def marm_get_staged_summaries(limit: int = 20):
     return {"proposals": proposals, "limit": limit}
 
 
-async def _apply_compaction_write(candidate_id: str) -> str:
-    """Execute the atomic compaction write inside BEGIN IMMEDIATE. Returns summary_id.
-
-    Fetches all candidate and source data fresh inside the lock so this function
-    is safe to call via the write queue after an arbitrary delay. Computes fresh
-    timestamps inside the lock to avoid TOCTOU on expiry checks. Marks the
-    candidate stale on any validation failure so it is not retried by the scheduler.
-    Uses _committed to prevent the except-block ROLLBACK from firing after an
-    explicit COMMIT or ROLLBACK in a validation branch.
-    """
-    precomputed_summary_hash = None
-    precomputed_summary_embedding = None
-    try:
-        with memory.get_connection() as conn:
-            row = conn.execute(
-                "SELECT suggested_summary FROM compaction_staging WHERE id = ?",
-                (candidate_id,),
-            ).fetchone()
-    except Exception:
-        row = None
-
-    if row and row[0]:
-        precomputed_summary = sanitize_content(row[0])
-        precomputed_summary_hash = compute_content_hash(precomputed_summary)
-        if memory._load_encoder_lazily():
-            summary_vec = await asyncio.to_thread(
-                memory._encode_sync, precomputed_summary
-            )
-            precomputed_summary_embedding = summary_vec.tobytes()
-
-    with memory.get_connection() as conn:
-        conn.execute("BEGIN IMMEDIATE")
-        _committed = False
-        now = datetime.now(timezone.utc).isoformat()
-        try:
-            row = conn.execute(
-                "SELECT session_name, source_memory_ids, suggested_summary, status, "
-                "source_updated_at_snapshot, expires_at "
-                "FROM compaction_staging WHERE id = ?",
-                (candidate_id,),
-            ).fetchone()
-
-            if not row:
-                raise RuntimeError(
-                    f"compaction candidate {candidate_id} no longer exists"
-                )
-
-            (
-                session_name,
-                source_ids_json,
-                suggested_summary,
-                status,
-                snapshot_json,
-                expires_at,
-            ) = row
-
-            if status == "applied":
-                conn.execute("ROLLBACK")
-                _committed = True
-                source_ids = json.loads(source_ids_json)
-                idempotent_row = conn.execute(
-                    "SELECT compacted_into FROM memories "
-                    "WHERE id = ? AND compacted_into IS NOT NULL",
-                    (source_ids[0],),
-                ).fetchone()
-                return idempotent_row[0] if idempotent_row else candidate_id
-
-            if status == "discarded":
-                conn.execute("ROLLBACK")
-                _committed = True
-                raise RuntimeError(f"compaction candidate {candidate_id} was discarded")
-
-            if status != "summary_staged":
-                conn.execute(
-                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
-                    "WHERE id = ?",
-                    (now, candidate_id),
-                )
-                conn.execute("COMMIT")
-                _committed = True
-                raise RuntimeError(
-                    f"compaction candidate became '{status}' before write could execute"
-                )
-
-            if expires_at and now > expires_at:
-                conn.execute(
-                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
-                    "WHERE id = ?",
-                    (now, candidate_id),
-                )
-                conn.execute("COMMIT")
-                _committed = True
-                raise RuntimeError(
-                    f"compaction candidate {candidate_id} expired before write could execute"
-                )
-
-            if not suggested_summary or not suggested_summary.strip():
-                conn.execute(
-                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
-                    "WHERE id = ?",
-                    (now, candidate_id),
-                )
-                conn.execute("COMMIT")
-                _committed = True
-                raise RuntimeError(
-                    f"compaction candidate {candidate_id} has empty summary"
-                )
-
-            source_ids = json.loads(source_ids_json)
-            snapshot = json.loads(snapshot_json)
-            placeholders = ",".join("?" * len(source_ids))
-            current_rows = conn.execute(
-                f"SELECT id, session_name, content_hash, compaction_role, metadata "
-                f"FROM memories WHERE id IN ({placeholders})",
-                source_ids,
-            ).fetchall()
-
-            found_ids = {r[0] for r in current_rows}
-            missing = set(source_ids) - found_ids
-            if missing:
-                conn.execute(
-                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
-                    "WHERE id = ?",
-                    (now, candidate_id),
-                )
-                conn.execute("COMMIT")
-                _committed = True
-                raise RuntimeError(f"source memories not found: {sorted(missing)}")
-
-            wrong_session = [r[0] for r in current_rows if r[1] != session_name]
-            if wrong_session:
-                conn.execute(
-                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
-                    "WHERE id = ?",
-                    (now, candidate_id),
-                )
-                conn.execute("COMMIT")
-                _committed = True
-                raise RuntimeError(
-                    f"source memories belong to different session: {wrong_session}"
-                )
-
-            already_compacted = [
-                r[0] for r in current_rows if r[3] in ("source", "summary")
-            ]
-            if already_compacted:
-                conn.execute(
-                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
-                    "WHERE id = ?",
-                    (now, candidate_id),
-                )
-                conn.execute("COMMIT")
-                _committed = True
-                raise RuntimeError(
-                    f"source memories already compacted: {already_compacted}"
-                )
-
-            for mem_id, _, content_hash, _, _ in current_rows:
-                if snapshot.get(mem_id) != content_hash:
-                    conn.execute(
-                        "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
-                        "WHERE id = ?",
-                        (now, candidate_id),
-                    )
-                    conn.execute("COMMIT")
-                    _committed = True
-                    raise RuntimeError(
-                        f"source memory {mem_id} content changed since candidate was detected"
-                    )
-
-            suggested_summary = sanitize_content(suggested_summary)
-            summary_content_hash = compute_content_hash(suggested_summary)
-            summary_embedding = (
-                precomputed_summary_embedding
-                if precomputed_summary_hash == summary_content_hash
-                else None
-            )
-            if summary_embedding is None and memory._load_encoder_lazily():
-                summary_embedding = memory._encode_sync(suggested_summary).tobytes()
-
-            summary_id = str(uuid.uuid4())
-            compacted_at = now
-            summary_metadata = {
-                "compaction_role": "summary",
-                "source_memory_ids": source_ids,
-                "source_count": len(source_ids),
-                "compacted_at": compacted_at,
-                "strategy": "semantic_cluster_summary",
-            }
-
-            conn.execute(
-                """
-                INSERT INTO memories
-                    (id, session_name, content, embedding, content_hash, timestamp,
-                     context_type, metadata, compaction_role)
-                VALUES (?, ?, ?, ?, ?, ?, 'general', ?, 'summary')
-                """,
-                (
-                    summary_id,
-                    session_name,
-                    suggested_summary,
-                    summary_embedding,
-                    summary_content_hash,
-                    compacted_at,
-                    json.dumps(summary_metadata),
-                ),
-            )
-
-            for mem_id, _, _, _, metadata_json in current_rows:
-                existing_meta = json.loads(metadata_json) if metadata_json else {}
-                existing_meta.update(
-                    {
-                        "compaction_role": "source",
-                        "compacted_into": summary_id,
-                        "compacted_at": compacted_at,
-                    }
-                )
-                conn.execute(
-                    "UPDATE memories "
-                    "SET compaction_role = 'source', compacted_into = ?, metadata = ? "
-                    "WHERE id = ?",
-                    (summary_id, json.dumps(existing_meta), mem_id),
-                )
-
-            conn.execute(
-                "UPDATE compaction_staging "
-                "SET status = 'applied', reviewed_at = ?, updated_at = ? "
-                "WHERE id = ?",
-                (now, now, candidate_id),
-            )
-            conn.execute("COMMIT")
-            _committed = True
-        except Exception:
-            if not _committed:
-                conn.execute("ROLLBACK")
-            raise
-
-    return summary_id
-
-
 @router.post(
     "/marm_apply_compaction",
     operation_id="marm_apply_compaction",
@@ -693,11 +451,12 @@ async def marm_apply_compaction(request: ApplyCompactionRequest):
 
     if memory._write_queue is not None:
         summary_id = await memory._write_queue.put_callable(
-            _apply_compaction_write,
+            apply_compaction_write,
+            memory,
             candidate_id,
         )
     else:
-        summary_id = await _apply_compaction_write(candidate_id)
+        summary_id = await apply_compaction_write(memory, candidate_id)
 
     return {
         "candidate_id": candidate_id,

--- a/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
@@ -449,14 +449,22 @@ async def marm_apply_compaction(request: ApplyCompactionRequest):
                 "reason": "staged summary is empty — candidate may be corrupted",
             }
 
-    if memory._write_queue is not None:
-        summary_id = await memory._write_queue.put_callable(
-            apply_compaction_write,
-            memory,
-            candidate_id,
-        )
-    else:
-        summary_id = await apply_compaction_write(memory, candidate_id)
+    try:
+        if memory._write_queue is not None:
+            summary_id = await memory._write_queue.put_callable(
+                apply_compaction_write,
+                memory,
+                candidate_id,
+            )
+        else:
+            summary_id = await apply_compaction_write(memory, candidate_id)
+    except Exception as e:
+        print(f"Compaction apply failed for {candidate_id}: {e}")
+        return {
+            "candidate_id": candidate_id,
+            "status": "error",
+            "reason": "compaction apply failed",
+        }
 
     return {
         "candidate_id": candidate_id,

--- a/marm-mcp-server/marm_mcp_server/endpoints/logging.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/logging.py
@@ -96,7 +96,10 @@ async def marm_log_entry(request: LogEntryRequest):
         }
     except sqlite3.Error as e:
         print(f"Database error in marm_log_entry: {e}")
-        return {"status": "error", "message": "Database error while creating log entry."}
+        return {
+            "status": "error",
+            "message": "Database error while creating log entry.",
+        }
     except Exception as e:
         print(f"Unexpected error in marm_log_entry: {e}")
         return {"status": "error", "message": "Log entry creation failed."}

--- a/marm-mcp-server/marm_mcp_server/endpoints/logging.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/logging.py
@@ -45,14 +45,10 @@ async def marm_log_session(request: SessionRequest):
         }
     except sqlite3.Error as e:
         print(f"Database error in marm_log_session: {e}")
-        raise HTTPException(
-            status_code=500, detail="Database error during session creation."
-        )
+        return {"status": "error", "message": f"Database error during session creation: {str(e)}"}
     except Exception as e:
         print(f"Unexpected error in marm_log_session: {e}")
-        raise HTTPException(
-            status_code=500, detail="Internal server error during session creation."
-        )
+        return {"status": "error", "message": f"Session creation failed: {str(e)}"}
 
 
 @router.post("/marm_log_entry", operation_id="marm_log_entry")
@@ -100,14 +96,10 @@ async def marm_log_entry(request: LogEntryRequest):
         }
     except sqlite3.Error as e:
         print(f"Database error in marm_log_entry: {e}")
-        raise HTTPException(
-            status_code=500, detail="Database error while creating log entry."
-        )
+        return {"status": "error", "message": f"Database error while creating log entry: {str(e)}"}
     except Exception as e:
         print(f"Unexpected error in marm_log_entry: {e}")
-        raise HTTPException(
-            status_code=500, detail="Internal server error while creating log entry."
-        )
+        return {"status": "error", "message": f"Log entry creation failed: {str(e)}"}
 
 
 @router.get("/marm_log_show", operation_id="marm_log_show")
@@ -165,14 +157,10 @@ async def marm_log_show(
                 }
     except sqlite3.Error as e:
         print(f"Database error in marm_log_show: {e}")
-        raise HTTPException(
-            status_code=500, detail="Database error while showing logs."
-        )
+        return {"status": "error", "message": f"Database error while showing logs: {str(e)}"}
     except Exception as e:
         print(f"Unexpected error in marm_log_show: {e}")
-        raise HTTPException(
-            status_code=500, detail="Internal server error while showing logs."
-        )
+        return {"status": "error", "message": f"Log show failed: {str(e)}"}
 
 
 @router.post("/marm_delete", operation_id="marm_delete")
@@ -234,9 +222,7 @@ async def marm_delete(request: DeleteRequest):
         raise
     except sqlite3.Error as e:
         print(f"Database error in marm_delete: {e}")
-        raise HTTPException(status_code=500, detail="Database error while deleting.")
+        return {"status": "error", "message": f"Database error while deleting: {str(e)}"}
     except Exception as e:
         print(f"Unexpected error in marm_delete: {e}")
-        raise HTTPException(
-            status_code=500, detail="Internal server error while deleting."
-        )
+        return {"status": "error", "message": f"Delete failed: {str(e)}"}

--- a/marm-mcp-server/marm_mcp_server/endpoints/logging.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/logging.py
@@ -45,10 +45,10 @@ async def marm_log_session(request: SessionRequest):
         }
     except sqlite3.Error as e:
         print(f"Database error in marm_log_session: {e}")
-        return {"status": "error", "message": f"Database error during session creation: {str(e)}"}
+        return {"status": "error", "message": "Database error during session creation."}
     except Exception as e:
         print(f"Unexpected error in marm_log_session: {e}")
-        return {"status": "error", "message": f"Session creation failed: {str(e)}"}
+        return {"status": "error", "message": "Session creation failed."}
 
 
 @router.post("/marm_log_entry", operation_id="marm_log_entry")
@@ -96,10 +96,10 @@ async def marm_log_entry(request: LogEntryRequest):
         }
     except sqlite3.Error as e:
         print(f"Database error in marm_log_entry: {e}")
-        return {"status": "error", "message": f"Database error while creating log entry: {str(e)}"}
+        return {"status": "error", "message": "Database error while creating log entry."}
     except Exception as e:
         print(f"Unexpected error in marm_log_entry: {e}")
-        return {"status": "error", "message": f"Log entry creation failed: {str(e)}"}
+        return {"status": "error", "message": "Log entry creation failed."}
 
 
 @router.get("/marm_log_show", operation_id="marm_log_show")
@@ -157,10 +157,10 @@ async def marm_log_show(
                 }
     except sqlite3.Error as e:
         print(f"Database error in marm_log_show: {e}")
-        return {"status": "error", "message": f"Database error while showing logs: {str(e)}"}
+        return {"status": "error", "message": "Database error while showing logs."}
     except Exception as e:
         print(f"Unexpected error in marm_log_show: {e}")
-        return {"status": "error", "message": f"Log show failed: {str(e)}"}
+        return {"status": "error", "message": "Log show failed."}
 
 
 @router.post("/marm_delete", operation_id="marm_delete")
@@ -222,7 +222,7 @@ async def marm_delete(request: DeleteRequest):
         raise
     except sqlite3.Error as e:
         print(f"Database error in marm_delete: {e}")
-        return {"status": "error", "message": f"Database error while deleting: {str(e)}"}
+        return {"status": "error", "message": "Database error while deleting."}
     except Exception as e:
         print(f"Unexpected error in marm_delete: {e}")
-        return {"status": "error", "message": f"Delete failed: {str(e)}"}
+        return {"status": "error", "message": "Delete failed."}

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -210,7 +210,8 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
 
         return final_response
     except Exception as e:
-        return {"status": "error", "message": f"Memory recall failed: {str(e)}"}
+        print(f"Unexpected error in marm_smart_recall: {e}")
+        return {"status": "error", "message": "Memory recall failed."}
 
 
 @router.post("/marm_context_log", operation_id="marm_context_log")
@@ -251,4 +252,5 @@ async def marm_context_log(request: ContextLogRequest):
             "context_type": context_type,
         }
     except Exception as e:
-        return {"status": "error", "message": f"Context logging failed: {str(e)}"}
+        print(f"Unexpected error in marm_context_log: {e}")
+        return {"status": "error", "message": "Context logging failed."}

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -1,6 +1,6 @@
 """Memory endpoints for MARM MCP Server."""
 
-from fastapi import HTTPException, APIRouter, Request
+from fastapi import APIRouter, Request
 from datetime import datetime
 
 from ..core.models import SmartRecallRequest, ContextLogRequest
@@ -67,7 +67,6 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
     Finds relevant memories using semantic similarity or text search.
     Returns the most relevant memories with similarity scores.
     """
-    # Track usage
     track_endpoint_usage(
         "marm_smart_recall",
         http_request,
@@ -123,8 +122,8 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
                     for r in cursor.fetchall()
                 ]
 
-        similar_memories = await memory.recall_similar(
-            request.query, search_session, request.limit
+        similar_memories, scan_meta = await memory.recall_similar(
+            request.query, search_session, request.limit, include_scan_metadata=True
         )
 
         if not similar_memories:
@@ -139,6 +138,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
                     "session_name": request.session_name,
                     "search_all": request.search_all,
                     "results": [],
+                    **scan_meta,
                 }
 
                 if system_memories:
@@ -173,6 +173,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
                     "session_name": request.session_name,
                     "search_all": request.search_all,
                     "results": [],
+                    **scan_meta,
                 }
                 if request.include_logs:
                     response["log_results"] = log_results
@@ -185,6 +186,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
             "query": request.query,
             "session_name": request.session_name,
             "search_all": request.search_all,
+            **scan_meta,
         }
 
         limited_memories, was_truncated = MCPResponseLimiter.limit_memory_response(
@@ -208,7 +210,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
 
         return final_response
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Memory recall failed: {str(e)}")
+        return {"status": "error", "message": f"Memory recall failed: {str(e)}"}
 
 
 @router.post("/marm_context_log", operation_id="marm_context_log")
@@ -249,4 +251,4 @@ async def marm_context_log(request: ContextLogRequest):
             "context_type": context_type,
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Context logging failed: {str(e)}")
+        return {"status": "error", "message": f"Context logging failed: {str(e)}"}

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -59,6 +59,24 @@ def track_endpoint_usage(endpoint: str, request: Request, extra_data: dict = Non
 router = APIRouter(prefix="", tags=["Memory"])
 
 
+def _inject_log_results(response: dict, log_results: list) -> None:
+    test = {
+        **response,
+        "log_results": log_results,
+        "log_results_count": len(log_results),
+    }
+    if (
+        MCPResponseLimiter.estimate_response_size(test)
+        <= MCPResponseLimiter.CONTENT_LIMIT
+    ):
+        response["log_results"] = log_results
+        response["log_results_count"] = len(log_results)
+    else:
+        response["log_results"] = []
+        response["log_results_count"] = 0
+        response["_log_results_truncated"] = True
+
+
 @router.post("/marm_smart_recall", operation_id="marm_smart_recall")
 async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
     """
@@ -162,8 +180,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
                     )
 
                 if request.include_logs:
-                    response["log_results"] = log_results
-                    response["log_results_count"] = len(log_results)
+                    _inject_log_results(response, log_results)
                 return response
             else:
                 response = {
@@ -176,8 +193,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
                     **scan_meta,
                 }
                 if request.include_logs:
-                    response["log_results"] = log_results
-                    response["log_results_count"] = len(log_results)
+                    _inject_log_results(response, log_results)
                 return response
 
         base_response = {
@@ -205,8 +221,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
         )
 
         if request.include_logs:
-            final_response["log_results"] = log_results
-            final_response["log_results_count"] = len(log_results)
+            _inject_log_results(final_response, log_results)
 
         return final_response
     except Exception as e:

--- a/marm-mcp-server/marm_mcp_server/endpoints/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/notebook.py
@@ -28,4 +28,5 @@ async def marm_notebook(request: NotebookRequest):
             session_name=request.session_name,
         )
     except Exception as e:
-        return {"status": "error", "message": f"Notebook operation failed: {str(e)}"}
+        print(f"Unexpected error in marm_notebook: {e}")
+        return {"status": "error", "message": "Notebook operation failed."}

--- a/marm-mcp-server/marm_mcp_server/endpoints/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/notebook.py
@@ -1,6 +1,6 @@
 """Notebook endpoints for MARM MCP Server."""
 
-from fastapi import HTTPException, APIRouter
+from fastapi import APIRouter
 
 from ..core.models import NotebookRequest
 from ..services.notebook import notebook_dispatch
@@ -20,19 +20,12 @@ async def marm_notebook(request: NotebookRequest):
     action="clear": clear the active entry list
     """
     try:
-        result = await notebook_dispatch(
+        return await notebook_dispatch(
             action=request.action,
             name=request.name,
             data=request.data,
             names=request.names,
             session_name=request.session_name,
         )
-        if result.get("status") == "error":
-            raise HTTPException(status_code=400, detail=result["message"])
-        return result
-    except HTTPException:
-        raise
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Notebook operation failed: {str(e)}"
-        )
+        return {"status": "error", "message": f"Notebook operation failed: {str(e)}"}

--- a/marm-mcp-server/marm_mcp_server/endpoints/reasoning.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/reasoning.py
@@ -115,4 +115,5 @@ async def marm_summary(
         return final_response
 
     except Exception as e:
-        return {"status": "error", "message": f"Failed to generate summary: {str(e)}"}
+        print(f"Unexpected error in marm_summary: {e}")
+        return {"status": "error", "message": "Failed to generate summary."}

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -236,20 +236,27 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
         asyncio.create_task(maybe_auto_refresh())
 
     if is_tool_call and response.status_code == 200:
-        _req_session = "__default__"
+        _explicit_session = None
+        _tool_name = None
         try:
-            _req_session = (
-                json.loads(body)
-                .get("params", {})
-                .get("arguments", {})
-                .get("session_name")
-                or "__default__"
-            )
+            _parsed_body = json.loads(body)
+            _explicit_session = (
+                _parsed_body.get("params", {}).get("arguments", {}).get("session_name")
+            ) or None
+            _tool_name = _parsed_body.get("params", {}).get("name")
         except Exception:
             pass
 
+        _protocol_session = _explicit_session or "__default__"
+        if _explicit_session:
+            _compaction_session = _explicit_session
+        elif _tool_name == "marm_log_entry":
+            _compaction_session = memory.active_log_session
+        else:
+            _compaction_session = "main"
+
         if (
-            _req_session in _protocol_delivered_sessions
+            _protocol_session in _protocol_delivered_sessions
             and not settings.COMPACTION_ENABLED
         ):
             return response
@@ -286,7 +293,7 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
             injections = []
             protocol_injected = False
             async with _protocol_delivery_lock:
-                if _req_session not in _protocol_delivered_sessions:
+                if _protocol_session not in _protocol_delivered_sessions:
                     protocol_content = await read_protocol_file()
                     injections.append(
                         {
@@ -294,12 +301,12 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
                             "text": f"[MARM SESSION INIT]\n\n{protocol_content}",
                         }
                     )
-                    _protocol_delivered_sessions.add(_req_session)
+                    _protocol_delivered_sessions.add(_protocol_session)
                     protocol_injected = True
 
             if not protocol_injected:
                 compaction_block = await asyncio.to_thread(
-                    claim_pending_compaction_prompt, memory, _req_session
+                    claim_pending_compaction_prompt, memory, _compaction_session
                 )
                 if compaction_block:
                     injections.append(compaction_block)

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - MARM Systems
-Version: 2.9.2
+Version: 2.10.0
 """
 
 import asyncio
@@ -198,7 +198,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-_protocol_delivered = False
+_protocol_delivered_sessions: set = set()
 _protocol_delivery_lock = asyncio.Lock()
 
 
@@ -210,14 +210,16 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
     Doc loading runs before the handler so the first tool call gets warm docs,
     matching STDIO transport timing.
 
-    On the very first successful tool call of a server session, the MARM protocol is
-    injected into the response so the agent receives it exactly once. Uses its own
-    _protocol_delivered flag — independent of docs_are_loaded() — so failed or
-    non-200 responses leave the flag unset and the next call retries injection.
+    On the first successful tool call for each session, the MARM protocol is injected
+    into the response so each agent receives it exactly once. Tracked per session_name
+    in _protocol_delivered_sessions. Tools that omit session_name share a "__default__"
+    scope — agents should use distinct session names for independent delivery.
+    Note: the session is marked delivered when read_protocol_file() succeeds; a later
+    failure during response mutation marks the session delivered even if the client
+    did not receive the injection.
     """
-    global _protocol_delivered
-
     is_tool_call = False
+    body = b""
     if request.method == "POST" and request.url.path == "/mcp":
         try:
             body = await request.body()
@@ -234,7 +236,22 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
         asyncio.create_task(maybe_auto_refresh())
 
     if is_tool_call and response.status_code == 200:
-        if _protocol_delivered and not settings.COMPACTION_ENABLED:
+        _req_session = "__default__"
+        try:
+            _req_session = (
+                json.loads(body)
+                .get("params", {})
+                .get("arguments", {})
+                .get("session_name")
+                or "__default__"
+            )
+        except Exception:
+            pass
+
+        if (
+            _req_session in _protocol_delivered_sessions
+            and not settings.COMPACTION_ENABLED
+        ):
             return response
 
         try:
@@ -269,7 +286,7 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
             injections = []
             protocol_injected = False
             async with _protocol_delivery_lock:
-                if not _protocol_delivered:
+                if _req_session not in _protocol_delivered_sessions:
                     protocol_content = await read_protocol_file()
                     injections.append(
                         {
@@ -277,23 +294,9 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
                             "text": f"[MARM SESSION INIT]\n\n{protocol_content}",
                         }
                     )
-                    _protocol_delivered = True
+                    _protocol_delivered_sessions.add(_req_session)
                     protocol_injected = True
 
-            _req_session = None
-            try:
-                _req_session = (
-                    json.loads(body)
-                    .get("params", {})
-                    .get("arguments", {})
-                    .get("session_name")
-                )
-            except Exception as e:
-                logger.debug(
-                    "Session extraction failed, using global scope",
-                    error=str(e),
-                    body_preview=body[:200].decode("utf-8", errors="replace"),
-                )
             if not protocol_injected:
                 compaction_block = await asyncio.to_thread(
                     claim_pending_compaction_prompt, memory, _req_session

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -159,13 +159,14 @@ from fastmcp import FastMCP  # noqa: E402
 from marm_mcp_server.core.memory import memory  # noqa: E402
 from marm_mcp_server.core.compaction import claim_pending_compaction_prompt  # noqa: E402
 from marm_mcp_server.core.events import events  # noqa: E402
-from marm_mcp_server.core.response_limiter import MCPResponseLimiter  # noqa: E402
 from marm_mcp_server.services.notebook import notebook_dispatch  # noqa: E402
 from marm_mcp_server.services.documentation import (  # noqa: E402
     ensure_marm_started,
     maybe_auto_refresh,
 )
 from marm_mcp_server.utils.helpers import read_protocol_file  # noqa: E402
+from marm_mcp_server.services.summary import generate_session_summary  # noqa: E402
+from marm_mcp_server.services.recall import smart_recall  # noqa: E402
 from marm_mcp_server.config.settings import (  # noqa: E402
     SERVER_VERSION,
     DEFAULT_DB_PATH,
@@ -173,7 +174,6 @@ from marm_mcp_server.config.settings import (  # noqa: E402
 )
 
 mcp = FastMCP("MARM MCP Server")
-response_limiter = MCPResponseLimiter()
 
 
 @mcp.tool()
@@ -191,117 +191,7 @@ async def marm_smart_recall(
     Finds relevant memories using semantic similarity or text search.
     Returns the most relevant memories with similarity scores.
     """
-    try:
-        search_session = None if search_all else session_name
-
-        log_results = []
-        if include_logs:
-            with memory.get_connection() as conn:
-                if search_all:
-                    log_rows = conn.execute(
-                        """
-                        SELECT session_name, topic, summary, entry_date
-                        FROM log_entries
-                        WHERE topic LIKE ? OR summary LIKE ?
-                        ORDER BY entry_date DESC
-                        LIMIT ?
-                        """,
-                        (f"%{query}%", f"%{query}%", limit),
-                    ).fetchall()
-                else:
-                    log_rows = conn.execute(
-                        """
-                        SELECT session_name, topic, summary, entry_date
-                        FROM log_entries
-                        WHERE (topic LIKE ? OR summary LIKE ?) AND session_name = ?
-                        ORDER BY entry_date DESC
-                        LIMIT ?
-                        """,
-                        (f"%{query}%", f"%{query}%", session_name, limit),
-                    ).fetchall()
-            log_results = [
-                {
-                    "session_name": r[0],
-                    "topic": r[1],
-                    "summary": r[2],
-                    "entry_date": r[3],
-                    "type": "log",
-                }
-                for r in log_rows
-            ]
-
-        similar_memories = await memory.recall_similar(
-            query, session=search_session, limit=limit
-        )
-
-        if not similar_memories:
-            if not search_all:
-                system_memories = await memory.recall_similar(
-                    query, session="marm_system", limit=limit
-                )
-                response: dict = {
-                    "status": "no_results",
-                    "query": query,
-                    "session_name": session_name,
-                    "search_all": search_all,
-                    "results": [],
-                }
-                if system_memories:
-                    response["message"] = (
-                        f"🤔 No memories found in session '{session_name}' for query: '{query}'. "
-                        f"However, {len(system_memories)} relevant results were found in the system documentation. "
-                        f"Consider using search_all=true to search across all sessions."
-                    )
-                    response["system_results"] = system_memories
-                else:
-                    response["message"] = f"No memories found for query: '{query}'"
-                if include_logs:
-                    response["log_results"] = log_results
-                    response["log_results_count"] = len(log_results)
-                return response
-
-        formatted_results = [
-            {
-                "id": mem.get("id"),
-                "content": mem.get("content"),
-                "session_name": mem.get("session_name"),
-                "similarity": mem.get("similarity", 0.0),
-                "timestamp": mem.get("timestamp"),
-                "context_type": mem.get("context_type", "general"),
-            }
-            for mem in similar_memories
-        ]
-
-        response_metadata = {
-            "status": "success",
-            "query": query,
-            "session_name": session_name,
-            "search_all": search_all,
-        }
-
-        limited_results, was_truncated = response_limiter.limit_memory_response(
-            formatted_results, response_metadata
-        )
-
-        response_data = {
-            **response_metadata,
-            "results_count": len(limited_results),
-            "results": limited_results,
-        }
-
-        if was_truncated:
-            response_data = response_limiter.add_truncation_notice(
-                response_data, was_truncated, len(formatted_results)
-            )
-
-        if include_logs:
-            response_data["log_results"] = log_results
-            response_data["log_results_count"] = len(log_results)
-
-        return response_data
-
-    except Exception as e:
-        return {"status": "error", "message": f"Error during smart recall: {str(e)}"}
+    return await smart_recall(query, session_name, limit, search_all, include_logs)
 
 
 @mcp.tool()
@@ -581,90 +471,7 @@ async def marm_summary(
     Reads log_entries for the session and returns a formatted markdown summary.
     Equivalent to /summary: [session name] command
     """
-    try:
-        with memory.get_connection() as conn:
-            total_entries = conn.execute(
-                "SELECT COUNT(*) FROM log_entries WHERE session_name = ?",
-                (session_name,),
-            ).fetchone()[0]
-
-            entries = conn.execute(
-                """
-                SELECT entry_date, topic, summary, full_entry
-                FROM log_entries WHERE session_name = ?
-                ORDER BY entry_date DESC
-                LIMIT ?
-                """,
-                (session_name, limit),
-            ).fetchall()
-
-        if not entries:
-            return {
-                "status": "empty",
-                "message": f"No entries found in session '{session_name}'",
-            }
-
-        base_response = {
-            "status": "success",
-            "session_name": session_name,
-            "entry_count": 0,
-            "total_entries": total_entries,
-        }
-
-        summary_lines = [f"# MARM Session Summary: {session_name}"]
-        summary_lines.append(
-            f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M UTC')}"
-        )
-        summary_lines.append("")
-
-        if total_entries > len(entries):
-            summary_lines.append(
-                f"*Showing {len(entries)} most recent entries out of {total_entries} total*"
-            )
-            summary_lines.append("")
-
-        included_entries = []
-        current_lines = summary_lines.copy()
-
-        for entry in entries:
-            entry_summary = entry[2]
-            if len(entry_summary) > 200:
-                entry_summary = entry_summary[:197] + "..."
-
-            entry_line = f"**{entry[0]}** [{entry[1]}]: {entry_summary}"
-            test_lines = current_lines + [entry_line]
-            test_response = base_response.copy()
-            test_response["summary"] = "\n".join(test_lines)
-
-            if (
-                MCPResponseLimiter.estimate_response_size(test_response)
-                > MCPResponseLimiter.CONTENT_LIMIT
-            ):
-                break
-
-            current_lines.append(entry_line)
-            included_entries.append(entry)
-
-        final_response = {
-            "status": "success",
-            "session_name": session_name,
-            "summary": "\n".join(current_lines),
-            "entry_count": len(included_entries),
-            "total_entries": total_entries,
-        }
-
-        if len(included_entries) < len(entries):
-            final_response["_mcp_truncated"] = True
-            final_response["_truncation_reason"] = (
-                "Summary limited to 1MB for MCP compliance"
-            )
-            final_response["_entries_shown"] = len(included_entries)
-            final_response["_entries_available"] = len(entries)
-
-        return final_response
-
-    except Exception as e:
-        return {"status": "error", "message": f"Error generating summary: {str(e)}"}
+    return await generate_session_summary(session_name, limit)
 
 
 @mcp.tool()

--- a/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
+++ b/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 
 from ..core.consolidation import compute_content_hash
-from ..core.memory import sanitize_content
+from ..core.memory import sanitize_content, _safe_print
 
 
 async def apply_compaction_write(memory_store, candidate_id: str) -> str:
@@ -34,10 +34,15 @@ async def apply_compaction_write(memory_store, candidate_id: str) -> str:
         precomputed_summary = sanitize_content(row[0])
         precomputed_summary_hash = compute_content_hash(precomputed_summary)
         if memory_store._load_encoder_lazily():
-            summary_vec = await asyncio.to_thread(
-                memory_store._encode_sync, precomputed_summary
-            )
-            precomputed_summary_embedding = summary_vec.tobytes()
+            try:
+                summary_vec = await asyncio.to_thread(
+                    memory_store._encode_sync, precomputed_summary
+                )
+                precomputed_summary_embedding = summary_vec.tobytes()
+            except Exception as e:
+                _safe_print(
+                    f"Embedding pre-compute failed for compaction {candidate_id}, continuing without: {e}"
+                )
 
     with memory_store.get_connection() as conn:
         conn.execute("BEGIN IMMEDIATE")
@@ -187,9 +192,14 @@ async def apply_compaction_write(memory_store, candidate_id: str) -> str:
                 else None
             )
             if summary_embedding is None and memory_store._load_encoder_lazily():
-                summary_embedding = memory_store._encode_sync(
-                    suggested_summary
-                ).tobytes()
+                try:
+                    summary_embedding = memory_store._encode_sync(
+                        suggested_summary
+                    ).tobytes()
+                except Exception as e:
+                    _safe_print(
+                        f"Embedding encode failed inside write path for {candidate_id}, storing without embedding: {e}"
+                    )
 
             summary_id = str(uuid.uuid4())
             compacted_at = now

--- a/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
+++ b/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
@@ -1,0 +1,251 @@
+"""Apply staged compaction summaries inside an atomic DB transaction."""
+
+import asyncio
+import json
+import uuid
+from datetime import datetime, timezone
+
+from ..core.consolidation import compute_content_hash
+from ..core.memory import sanitize_content
+
+
+async def apply_compaction_write(memory_store, candidate_id: str) -> str:
+    """Execute the atomic compaction write inside BEGIN IMMEDIATE. Returns summary_id.
+
+    Fetches all candidate and source data fresh inside the lock so this function
+    is safe to call via the write queue after an arbitrary delay. Computes fresh
+    timestamps inside the lock to avoid TOCTOU on expiry checks. Marks the
+    candidate stale on any validation failure so it is not retried by the scheduler.
+    Uses _committed to prevent the except-block ROLLBACK from firing after an
+    explicit COMMIT or ROLLBACK in a validation branch.
+    """
+    precomputed_summary_hash = None
+    precomputed_summary_embedding = None
+    try:
+        with memory_store.get_connection() as conn:
+            row = conn.execute(
+                "SELECT suggested_summary FROM compaction_staging WHERE id = ?",
+                (candidate_id,),
+            ).fetchone()
+    except Exception:
+        row = None
+
+    if row and row[0]:
+        precomputed_summary = sanitize_content(row[0])
+        precomputed_summary_hash = compute_content_hash(precomputed_summary)
+        if memory_store._load_encoder_lazily():
+            summary_vec = await asyncio.to_thread(
+                memory_store._encode_sync, precomputed_summary
+            )
+            precomputed_summary_embedding = summary_vec.tobytes()
+
+    with memory_store.get_connection() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        _committed = False
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            row = conn.execute(
+                "SELECT session_name, source_memory_ids, suggested_summary, status, "
+                "source_updated_at_snapshot, expires_at "
+                "FROM compaction_staging WHERE id = ?",
+                (candidate_id,),
+            ).fetchone()
+
+            if not row:
+                raise RuntimeError(
+                    f"compaction candidate {candidate_id} no longer exists"
+                )
+
+            (
+                session_name,
+                source_ids_json,
+                suggested_summary,
+                status,
+                snapshot_json,
+                expires_at,
+            ) = row
+
+            if status == "applied":
+                conn.execute("ROLLBACK")
+                _committed = True
+                source_ids = json.loads(source_ids_json)
+                idempotent_row = conn.execute(
+                    "SELECT compacted_into FROM memories "
+                    "WHERE id = ? AND compacted_into IS NOT NULL",
+                    (source_ids[0],),
+                ).fetchone()
+                return idempotent_row[0] if idempotent_row else candidate_id
+
+            if status == "discarded":
+                conn.execute("ROLLBACK")
+                _committed = True
+                raise RuntimeError(f"compaction candidate {candidate_id} was discarded")
+
+            if status != "summary_staged":
+                conn.execute(
+                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                    "WHERE id = ?",
+                    (now, candidate_id),
+                )
+                conn.execute("COMMIT")
+                _committed = True
+                raise RuntimeError(
+                    f"compaction candidate became '{status}' before write could execute"
+                )
+
+            if expires_at and now > expires_at:
+                conn.execute(
+                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                    "WHERE id = ?",
+                    (now, candidate_id),
+                )
+                conn.execute("COMMIT")
+                _committed = True
+                raise RuntimeError(
+                    f"compaction candidate {candidate_id} expired before write could execute"
+                )
+
+            if not suggested_summary or not suggested_summary.strip():
+                conn.execute(
+                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                    "WHERE id = ?",
+                    (now, candidate_id),
+                )
+                conn.execute("COMMIT")
+                _committed = True
+                raise RuntimeError(
+                    f"compaction candidate {candidate_id} has empty summary"
+                )
+
+            source_ids = json.loads(source_ids_json)
+            snapshot = json.loads(snapshot_json)
+            placeholders = ",".join("?" * len(source_ids))
+            current_rows = conn.execute(
+                f"SELECT id, session_name, content_hash, compaction_role, metadata "
+                f"FROM memories WHERE id IN ({placeholders})",
+                source_ids,
+            ).fetchall()
+
+            found_ids = {r[0] for r in current_rows}
+            missing = set(source_ids) - found_ids
+            if missing:
+                conn.execute(
+                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                    "WHERE id = ?",
+                    (now, candidate_id),
+                )
+                conn.execute("COMMIT")
+                _committed = True
+                raise RuntimeError(f"source memories not found: {sorted(missing)}")
+
+            wrong_session = [r[0] for r in current_rows if r[1] != session_name]
+            if wrong_session:
+                conn.execute(
+                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                    "WHERE id = ?",
+                    (now, candidate_id),
+                )
+                conn.execute("COMMIT")
+                _committed = True
+                raise RuntimeError(
+                    f"source memories belong to different session: {wrong_session}"
+                )
+
+            already_compacted = [
+                r[0] for r in current_rows if r[3] in ("source", "summary")
+            ]
+            if already_compacted:
+                conn.execute(
+                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                    "WHERE id = ?",
+                    (now, candidate_id),
+                )
+                conn.execute("COMMIT")
+                _committed = True
+                raise RuntimeError(
+                    f"source memories already compacted: {already_compacted}"
+                )
+
+            for mem_id, _, content_hash, _, _ in current_rows:
+                if snapshot.get(mem_id) != content_hash:
+                    conn.execute(
+                        "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                        "WHERE id = ?",
+                        (now, candidate_id),
+                    )
+                    conn.execute("COMMIT")
+                    _committed = True
+                    raise RuntimeError(
+                        f"source memory {mem_id} content changed since candidate was detected"
+                    )
+
+            suggested_summary = sanitize_content(suggested_summary)
+            summary_content_hash = compute_content_hash(suggested_summary)
+            summary_embedding = (
+                precomputed_summary_embedding
+                if precomputed_summary_hash == summary_content_hash
+                else None
+            )
+            if summary_embedding is None and memory_store._load_encoder_lazily():
+                summary_embedding = memory_store._encode_sync(
+                    suggested_summary
+                ).tobytes()
+
+            summary_id = str(uuid.uuid4())
+            compacted_at = now
+            summary_metadata = {
+                "compaction_role": "summary",
+                "source_memory_ids": source_ids,
+                "source_count": len(source_ids),
+                "compacted_at": compacted_at,
+                "strategy": "semantic_cluster_summary",
+            }
+
+            conn.execute(
+                """
+                INSERT INTO memories
+                    (id, session_name, content, embedding, content_hash, timestamp,
+                     context_type, metadata, compaction_role)
+                VALUES (?, ?, ?, ?, ?, ?, 'general', ?, 'summary')
+                """,
+                (
+                    summary_id,
+                    session_name,
+                    suggested_summary,
+                    summary_embedding,
+                    summary_content_hash,
+                    compacted_at,
+                    json.dumps(summary_metadata),
+                ),
+            )
+
+            for mem_id, _, _, _, metadata_json in current_rows:
+                existing_meta = json.loads(metadata_json) if metadata_json else {}
+                existing_meta.update(
+                    {
+                        "compaction_role": "source",
+                        "compacted_into": summary_id,
+                        "compacted_at": compacted_at,
+                    }
+                )
+                conn.execute(
+                    "UPDATE memories "
+                    "SET compaction_role = 'source', compacted_into = ?, metadata = ? "
+                    "WHERE id = ?",
+                    (summary_id, json.dumps(existing_meta), mem_id),
+                )
+
+            conn.execute(
+                "UPDATE compaction_staging "
+                "SET status = 'applied', reviewed_at = ?, updated_at = ? "
+                "WHERE id = ?",
+                (now, now, candidate_id),
+            )
+            conn.execute("COMMIT")
+            _committed = True
+        except Exception:
+            if not _committed:
+                conn.execute("ROLLBACK")
+            raise
+
+    return summary_id

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -83,8 +83,21 @@ async def smart_recall(
                     f"No memories found across all sessions for query: '{query}'"
                 )
             if include_logs:
-                response["log_results"] = log_results
-                response["log_results_count"] = len(log_results)
+                test = {
+                    **response,
+                    "log_results": log_results,
+                    "log_results_count": len(log_results),
+                }
+                if (
+                    MCPResponseLimiter.estimate_response_size(test)
+                    <= MCPResponseLimiter.CONTENT_LIMIT
+                ):
+                    response["log_results"] = log_results
+                    response["log_results_count"] = len(log_results)
+                else:
+                    response["log_results"] = []
+                    response["log_results_count"] = 0
+                    response["_log_results_truncated"] = True
             return response
 
         formatted_results = [
@@ -123,8 +136,21 @@ async def smart_recall(
             )
 
         if include_logs:
-            response_data["log_results"] = log_results
-            response_data["log_results_count"] = len(log_results)
+            test = {
+                **response_data,
+                "log_results": log_results,
+                "log_results_count": len(log_results),
+            }
+            if (
+                MCPResponseLimiter.estimate_response_size(test)
+                <= MCPResponseLimiter.CONTENT_LIMIT
+            ):
+                response_data["log_results"] = log_results
+                response_data["log_results_count"] = len(log_results)
+            else:
+                response_data["log_results"] = []
+                response_data["log_results_count"] = 0
+                response_data["_log_results_truncated"] = True
 
         return response_data
 

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -129,4 +129,5 @@ async def smart_recall(
         return response_data
 
     except Exception as e:
-        return {"status": "error", "message": f"Error during smart recall: {str(e)}"}
+        print(f"Unexpected error in smart_recall_response: {e}")
+        return {"status": "error", "message": "Error during smart recall."}

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -1,0 +1,132 @@
+"""Smart recall logic for MARM MCP Server."""
+
+from ..core.memory import memory
+from ..core.response_limiter import MCPResponseLimiter
+
+_limiter = MCPResponseLimiter()
+
+
+async def smart_recall(
+    query: str,
+    session_name: str = "default",
+    limit: int = 5,
+    search_all: bool = False,
+    include_logs: bool = False,
+) -> dict:
+    try:
+        search_session = None if search_all else session_name
+
+        log_results = []
+        if include_logs:
+            with memory.get_connection() as conn:
+                if search_all:
+                    log_rows = conn.execute(
+                        """
+                        SELECT session_name, topic, summary, entry_date
+                        FROM log_entries
+                        WHERE topic LIKE ? OR summary LIKE ?
+                        ORDER BY entry_date DESC
+                        LIMIT ?
+                        """,
+                        (f"%{query}%", f"%{query}%", limit),
+                    ).fetchall()
+                else:
+                    log_rows = conn.execute(
+                        """
+                        SELECT session_name, topic, summary, entry_date
+                        FROM log_entries
+                        WHERE (topic LIKE ? OR summary LIKE ?) AND session_name = ?
+                        ORDER BY entry_date DESC
+                        LIMIT ?
+                        """,
+                        (f"%{query}%", f"%{query}%", session_name, limit),
+                    ).fetchall()
+            log_results = [
+                {
+                    "session_name": r[0],
+                    "topic": r[1],
+                    "summary": r[2],
+                    "entry_date": r[3],
+                    "type": "log",
+                }
+                for r in log_rows
+            ]
+
+        similar_memories, scan_meta = await memory.recall_similar(
+            query, session=search_session, limit=limit, include_scan_metadata=True
+        )
+
+        if not similar_memories:
+            response: dict = {
+                "status": "no_results",
+                "query": query,
+                "session_name": session_name,
+                "search_all": search_all,
+                "results": [],
+                **scan_meta,
+            }
+            if not search_all:
+                system_memories = await memory.recall_similar(
+                    query, session="marm_system", limit=limit
+                )
+                if system_memories:
+                    response["message"] = (
+                        f"🤔 No memories found in session '{session_name}' for query: '{query}'. "
+                        f"However, {len(system_memories)} relevant results were found in the system documentation. "
+                        f"Consider using search_all=true to search across all sessions."
+                    )
+                    response["system_results"] = system_memories
+                else:
+                    response["message"] = f"No memories found for query: '{query}'"
+            else:
+                response["message"] = (
+                    f"No memories found across all sessions for query: '{query}'"
+                )
+            if include_logs:
+                response["log_results"] = log_results
+                response["log_results_count"] = len(log_results)
+            return response
+
+        formatted_results = [
+            {
+                "id": mem.get("id"),
+                "content": mem.get("content"),
+                "session_name": mem.get("session_name"),
+                "similarity": mem.get("similarity", 0.0),
+                "timestamp": mem.get("timestamp"),
+                "context_type": mem.get("context_type", "general"),
+            }
+            for mem in similar_memories
+        ]
+
+        response_metadata = {
+            "status": "success",
+            "query": query,
+            "session_name": session_name,
+            "search_all": search_all,
+            **scan_meta,
+        }
+
+        limited_results, was_truncated = _limiter.limit_memory_response(
+            formatted_results, response_metadata
+        )
+
+        response_data = {
+            **response_metadata,
+            "results_count": len(limited_results),
+            "results": limited_results,
+        }
+
+        if was_truncated:
+            response_data = _limiter.add_truncation_notice(
+                response_data, was_truncated, len(formatted_results)
+            )
+
+        if include_logs:
+            response_data["log_results"] = log_results
+            response_data["log_results_count"] = len(log_results)
+
+        return response_data
+
+    except Exception as e:
+        return {"status": "error", "message": f"Error during smart recall: {str(e)}"}

--- a/marm-mcp-server/marm_mcp_server/services/summary.py
+++ b/marm-mcp-server/marm_mcp_server/services/summary.py
@@ -1,50 +1,28 @@
-"""Reasoning endpoints for MARM MCP Server."""
+"""Session summary generation for MARM MCP Server."""
 
-from fastapi import APIRouter, Query
 from datetime import datetime
 
 from ..core.memory import memory
 from ..core.response_limiter import MCPResponseLimiter
 
-router = APIRouter(prefix="", tags=["Reasoning"])
 
-
-@router.get("/marm_summary", operation_id="marm_summary")
-async def marm_summary(
-    session_name: str = Query(..., description="The name of the session to summarize."),
-    limit: int = Query(
-        50,
-        description="Maximum number of entries to include (default: 50)",
-        ge=1,
-        le=200,
-    ),
-):
-    """
-    📊 Generate paste-ready context block for new chats
-
-    Equivalent to /summary: [session name] command
-    Uses intelligent truncation to stay within MCP 1MB limits.
-    """
+async def generate_session_summary(session_name: str, limit: int = 50) -> dict:
     try:
         with memory.get_connection() as conn:
-            cursor = conn.execute(
-                """
-                SELECT COUNT(*) FROM log_entries WHERE session_name = ?
-            """,
+            total_entries = conn.execute(
+                "SELECT COUNT(*) FROM log_entries WHERE session_name = ?",
                 (session_name,),
-            )
-            total_entries = cursor.fetchone()[0]
+            ).fetchone()[0]
 
-            cursor = conn.execute(
+            entries = conn.execute(
                 """
                 SELECT entry_date, topic, summary, full_entry
                 FROM log_entries WHERE session_name = ?
                 ORDER BY entry_date DESC
                 LIMIT ?
-            """,
+                """,
                 (session_name, limit),
-            )
-            entries = cursor.fetchall()
+            ).fetchall()
 
         if not entries:
             return {
@@ -55,7 +33,7 @@ async def marm_summary(
         base_response = {
             "status": "success",
             "session_name": session_name,
-            "entry_count": len(entries),
+            "entry_count": 0,
             "total_entries": total_entries,
         }
 
@@ -72,7 +50,7 @@ async def marm_summary(
             summary_lines.append("")
 
         included_entries = []
-        current_summary_lines = summary_lines.copy()
+        current_lines = summary_lines.copy()
 
         for entry in entries:
             entry_summary = entry[2]
@@ -80,26 +58,23 @@ async def marm_summary(
                 entry_summary = entry_summary[:197] + "..."
 
             entry_line = f"**{entry[0]}** [{entry[1]}]: {entry_summary}"
-            test_lines = current_summary_lines + [entry_line]
-
-            test_summary = "\n".join(test_lines)
+            test_lines = current_lines + [entry_line]
             test_response = base_response.copy()
-            test_response["summary"] = test_summary
+            test_response["summary"] = "\n".join(test_lines)
 
-            response_size = MCPResponseLimiter.estimate_response_size(test_response)
-
-            if response_size > MCPResponseLimiter.CONTENT_LIMIT:
+            if (
+                MCPResponseLimiter.estimate_response_size(test_response)
+                > MCPResponseLimiter.CONTENT_LIMIT
+            ):
                 break
 
-            current_summary_lines.append(entry_line)
+            current_lines.append(entry_line)
             included_entries.append(entry)
-
-        summary_text = "\n".join(current_summary_lines)
 
         final_response = {
             "status": "success",
             "session_name": session_name,
-            "summary": summary_text,
+            "summary": "\n".join(current_lines),
             "entry_count": len(included_entries),
             "total_entries": total_entries,
         }
@@ -115,4 +90,4 @@ async def marm_summary(
         return final_response
 
     except Exception as e:
-        return {"status": "error", "message": f"Failed to generate summary: {str(e)}"}
+        return {"status": "error", "message": f"Error generating summary: {str(e)}"}

--- a/marm-mcp-server/marm_mcp_server/services/summary.py
+++ b/marm-mcp-server/marm_mcp_server/services/summary.py
@@ -1,6 +1,6 @@
 """Session summary generation for MARM MCP Server."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ..core.memory import memory
 from ..core.response_limiter import MCPResponseLimiter
@@ -39,7 +39,7 @@ async def generate_session_summary(session_name: str, limit: int = 50) -> dict:
 
         summary_lines = [f"# MARM Session Summary: {session_name}"]
         summary_lines.append(
-            f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M UTC')}"
+            f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
         )
         summary_lines.append("")
 

--- a/marm-mcp-server/marm_mcp_server/services/summary.py
+++ b/marm-mcp-server/marm_mcp_server/services/summary.py
@@ -90,4 +90,5 @@ async def generate_session_summary(session_name: str, limit: int = 50) -> dict:
         return final_response
 
     except Exception as e:
-        return {"status": "error", "message": f"Error generating summary: {str(e)}"}
+        print(f"Unexpected error in build_summary_response: {e}")
+        return {"status": "error", "message": "Error generating summary."}

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.9.2"
+version = "2.10.0"
 description = "MARM-Systems is a complete protocol and platform—combining an advanced memory backend, modular semantic search, and agent-to-agent coordination with a scientifically structured, community-vetted methodology for reasoning, session recall, and collaborative AI workflows. More then just a set of tools, it's a complete AI memory ecosystem"
 readme = "README.md"
 license = "MIT"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -102,6 +102,10 @@
       "SERVER_PORT": {
         "description": "Port number to bind to",
         "default": "8001"
+      },
+      "RECALL_SCAN_LIMIT": {
+        "description": "Maximum embedded memories semantic recall scans per query before reporting recall_scan_truncated=true",
+        "default": "1000"
       }
     }
   },

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "author": "Ryan Lyell - MARM Systems",
   "license": "MIT",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.9.2",
+      "version": "2.10.0",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.9.2",
+      "identifier": "lyellr88/marm-mcp-server:2.10.0",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_compaction_auto_apply.py
+++ b/marm-mcp-server/tests/test_compaction_auto_apply.py
@@ -13,11 +13,11 @@ from marm_mcp_server.core.memory import MARMMemory
 from marm_mcp_server.core.models import ApplyCompactionRequest, CompactionRequest
 from marm_mcp_server.core.write_queue import CallableWriteRequest, WriteQueue
 from marm_mcp_server.endpoints.compaction import (
-    _apply_compaction_write,
     auto_apply_staged_summaries,
     marm_apply_compaction,
     marm_compaction,
 )
+from marm_mcp_server.services.compaction_apply import apply_compaction_write
 
 # --- helpers (mirrored from v2 test file) ---
 
@@ -306,12 +306,12 @@ async def test_apply_compaction_direct_when_no_queue(mem):
     assert _get_staging_status(mem, candidate_id) == "applied"
 
 
-# --- _apply_compaction_write unit ---
+# --- apply_compaction_write unit ---
 
 
 @pytest.mark.asyncio
 async def test_apply_compaction_write_inserts_summary_and_marks_sources(mem):
-    """_apply_compaction_write correctly inserts summary row and updates source rows."""
+    """apply_compaction_write correctly inserts summary row and updates source rows."""
     session = "write-unit-session"
     ids_and_hashes = [_insert_memory_row(mem, session, f"fact {i}") for i in range(3)]
     source_ids = [m[0] for m in ids_and_hashes]
@@ -339,7 +339,7 @@ async def test_apply_compaction_write_inserts_summary_and_marks_sources(mem):
             ),
         )
 
-    summary_id = await _apply_compaction_write(candidate_id)
+    summary_id = await apply_compaction_write(mem, candidate_id)
 
     # Summary row exists with correct role
     with mem.get_connection() as conn:

--- a/marm-mcp-server/tests/test_http_tools.py
+++ b/marm-mcp-server/tests/test_http_tools.py
@@ -291,7 +291,9 @@ def test_http_notebook_add_persists_entry_and_embedding(monkeypatch, tmp_path):
     assert row[2] == b"fake-embedding-bytes"
 
 
-def test_http_notebook_service_errors_return_400(monkeypatch, tmp_path):
+def test_http_notebook_service_errors_return_structured_error(monkeypatch, tmp_path):
+    """S5: notebook service errors return HTTP 200 with {"status":"error","message":...}
+    so the model can read and recover, instead of an opaque HTTPException."""
     server = load_isolated_server(monkeypatch, tmp_path)
     client = local_client(server.app)
 
@@ -301,10 +303,12 @@ def test_http_notebook_service_errors_return_400(monkeypatch, tmp_path):
     )
     missing_names = client.post("/marm_notebook", json={"action": "use"})
 
-    assert missing_data.status_code == 400
-    assert "name and data are required" in missing_data.json()["detail"]
-    assert missing_names.status_code == 400
-    assert "names is required" in missing_names.json()["detail"]
+    assert missing_data.status_code == 200
+    assert missing_data.json()["status"] == "error"
+    assert "name and data are required" in missing_data.json()["message"]
+    assert missing_names.status_code == 200
+    assert missing_names.json()["status"] == "error"
+    assert "names is required" in missing_names.json()["message"]
 
 
 def test_context_log_recall_include_logs_and_system_info(monkeypatch, tmp_path):
@@ -857,7 +861,7 @@ def test_http_mcp_tool_response_injects_compaction_prompt(monkeypatch, tmp_path)
     monkeypatch.setattr(
         compaction_module.settings, "COMPACTION_INJECTION_BYTE_BUDGET", 2048
     )
-    server._protocol_delivered = True
+    server._protocol_delivered_sessions = {"__default__"}
 
     candidate_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc)
@@ -868,7 +872,7 @@ def test_http_mcp_tool_response_injects_compaction_prompt(monkeypatch, tmp_path)
                 (id, session_name, source_memory_ids, preview, suggested_summary,
                  status, candidate_hash, source_updated_at_snapshot,
                  expires_at, created_at, updated_at, reviewed_at)
-            VALUES (?, 'sess', ?, ?, NULL, 'pending_summary', 'hash', '{}', ?, ?, ?, NULL)
+            VALUES (?, '__default__', ?, ?, NULL, 'pending_summary', 'hash', '{}', ?, ?, ?, NULL)
             """,
             (
                 candidate_id,
@@ -940,7 +944,7 @@ def test_http_mcp_tool_response_orders_protocol_before_compaction(
         compaction_module.settings, "COMPACTION_NUDGE_COOLDOWN_SECONDS", 2
     )
     doc_module._docs_loaded = True
-    server._protocol_delivered = False
+    server._protocol_delivered_sessions = set()
 
     candidate_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc)
@@ -951,7 +955,7 @@ def test_http_mcp_tool_response_orders_protocol_before_compaction(
                 (id, session_name, source_memory_ids, preview, suggested_summary,
                  status, candidate_hash, source_updated_at_snapshot,
                  expires_at, created_at, updated_at, reviewed_at)
-            VALUES (?, 'sess', ?, ?, NULL, 'pending_summary', 'hash', '{}', ?, ?, ?, NULL)
+            VALUES (?, '__default__', ?, ?, NULL, 'pending_summary', 'hash', '{}', ?, ?, ?, NULL)
             """,
             (
                 candidate_id,
@@ -1038,7 +1042,7 @@ def test_http_protocol_injected_on_first_mcp_tool_call_not_on_second(
     doc_module = importlib.import_module("marm_mcp_server.services.documentation")
 
     doc_module._docs_loaded = False
-    server._protocol_delivered = False
+    server._protocol_delivered_sessions = set()
 
     tool_call_body = b'{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"marm_notebook","arguments":{"action":"status"}}}'
 
@@ -1091,6 +1095,88 @@ def test_http_protocol_injected_on_first_mcp_tool_call_not_on_second(
     content_2 = body_2["result"]["content"]
     assert not any("[MARM SESSION INIT]" in c["text"] for c in content_2), (
         "Protocol must not repeat on second MCP tool call"
+    )
+
+
+def test_http_protocol_injected_independently_per_session(monkeypatch, tmp_path):
+    """Regression: each session must receive the protocol once, independently.
+
+    Before the fix, _protocol_delivered was a server-global bool — the first client
+    to call any tool consumed the injection for all clients. In swarm mode this meant
+    every agent after the first ran without the MARM protocol.
+    """
+    import json
+    from unittest.mock import AsyncMock, MagicMock
+
+    server = load_isolated_server(monkeypatch, tmp_path)
+    doc_module = importlib.import_module("marm_mcp_server.services.documentation")
+    doc_module._docs_loaded = False
+    server._protocol_delivered_sessions = set()
+
+    def make_request(session_name):
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "marm_context_log",
+                    "arguments": {"session_name": session_name, "content": "x"},
+                },
+            }
+        ).encode()
+        req = MagicMock()
+        req.method = "POST"
+        req.url.path = "/mcp"
+        req.body = AsyncMock(return_value=body)
+        return req
+
+    def make_response():
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"content": [{"type": "text", "text": '{"status":"ok"}'}]},
+            }
+        ).encode()
+
+        async def _iter():
+            yield body
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = MagicMock()
+        resp.headers.items.return_value = []
+        resp.body_iterator = _iter()
+        resp.body = body
+        return resp
+
+    async def run():
+        r_alpha = await server._mcp_tool_call_tracker(
+            make_request("alpha"), AsyncMock(return_value=make_response())
+        )
+        r_beta = await server._mcp_tool_call_tracker(
+            make_request("beta"), AsyncMock(return_value=make_response())
+        )
+        r_alpha_2 = await server._mcp_tool_call_tracker(
+            make_request("alpha"), AsyncMock(return_value=make_response())
+        )
+        return r_alpha, r_beta, r_alpha_2
+
+    r_alpha, r_beta, r_alpha_2 = asyncio.run(run())
+
+    alpha_content = json.loads(r_alpha.body)["result"]["content"]
+    beta_content = json.loads(r_beta.body)["result"]["content"]
+    alpha_2_content = json.loads(r_alpha_2.body)["result"]["content"]
+
+    assert any("[MARM SESSION INIT]" in c["text"] for c in alpha_content), (
+        "alpha session must receive protocol on first call"
+    )
+    assert any("[MARM SESSION INIT]" in c["text"] for c in beta_content), (
+        "beta session must receive protocol independently — not blocked by alpha delivery"
+    )
+    assert not any("[MARM SESSION INIT]" in c["text"] for c in alpha_2_content), (
+        "alpha session must not receive protocol twice"
     )
 
 

--- a/marm-mcp-server/tests/test_memory_database.py
+++ b/marm-mcp-server/tests/test_memory_database.py
@@ -368,7 +368,7 @@ async def test_recall_similar_scan_not_truncated_when_under_limit(
     query_vec = np.ones(dim, dtype=np.float32)
     query_vec /= np.linalg.norm(query_vec)
 
-    results, meta = await mem.recall_similar(
+    _results, meta = await mem.recall_similar(
         "entry",
         session="no-trunc-test",
         limit=3,

--- a/marm-mcp-server/tests/test_memory_database.py
+++ b/marm-mcp-server/tests/test_memory_database.py
@@ -280,3 +280,132 @@ async def test_mismatched_embedding_dimension_skipped_with_signal_without_breaki
     assert bad_id not in result_ids, (
         "wrong-dimension memory must be skipped, not crash recall"
     )
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_scan_truncated_fires_when_scan_limit_exceeded(
+    monkeypatch, tmp_path
+):
+    """Regression: recall_similar must report recall_scan_truncated=True when the DB
+    holds more rows than RECALL_SCAN_LIMIT so callers know recall was bounded.
+
+    Uses direct DB inserts + query_vec to bypass the encoder path, which would
+    short-circuit to text search before the scan query runs.
+    """
+    import numpy as np
+    import uuid as uuid_module
+
+    from marm_mcp_server.core import memory as memory_module
+
+    monkeypatch.setattr(memory_module, "RECALL_SCAN_LIMIT", 5)
+    mem = memory_module.MARMMemory(str(tmp_path / "memory.db"))
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    with mem.get_connection() as conn:
+        for i in range(7):
+            conn.execute(
+                "INSERT INTO memories (id, session_name, content, embedding, content_hash, timestamp, context_type, metadata)"
+                " VALUES (?, ?, ?, ?, ?, datetime('now'), 'general', '{}')",
+                (
+                    str(uuid_module.uuid4()),
+                    "trunc-test",
+                    f"test entry {i}",
+                    vec.tobytes(),
+                    f"hash-trunc-{i}",
+                ),
+            )
+
+    query_vec = np.ones(dim, dtype=np.float32)
+    query_vec /= np.linalg.norm(query_vec)
+
+    results, meta = await mem.recall_similar(
+        "test entry",
+        session="trunc-test",
+        limit=3,
+        query_vec=query_vec,
+        include_scan_metadata=True,
+    )
+
+    assert meta["recall_scan_truncated"] is True
+    assert meta["recall_scan_limit"] == 5
+    assert len(results) <= 3
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_scan_not_truncated_when_under_limit(
+    monkeypatch, tmp_path
+):
+    """recall_scan_truncated must be False when total rows are within RECALL_SCAN_LIMIT."""
+    import numpy as np
+    import uuid as uuid_module
+
+    from marm_mcp_server.core import memory as memory_module
+
+    monkeypatch.setattr(memory_module, "RECALL_SCAN_LIMIT", 10)
+    mem = memory_module.MARMMemory(str(tmp_path / "memory.db"))
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    with mem.get_connection() as conn:
+        for i in range(4):
+            conn.execute(
+                "INSERT INTO memories (id, session_name, content, embedding, content_hash, timestamp, context_type, metadata)"
+                " VALUES (?, ?, ?, ?, ?, datetime('now'), 'general', '{}')",
+                (
+                    str(uuid_module.uuid4()),
+                    "no-trunc-test",
+                    f"entry {i}",
+                    vec.tobytes(),
+                    f"hash-notrunc-{i}",
+                ),
+            )
+
+    query_vec = np.ones(dim, dtype=np.float32)
+    query_vec /= np.linalg.norm(query_vec)
+
+    results, meta = await mem.recall_similar(
+        "entry",
+        session="no-trunc-test",
+        limit=3,
+        query_vec=query_vec,
+        include_scan_metadata=True,
+    )
+
+    assert meta["recall_scan_truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_memory_merge_cap_never_exceeds_10000_chars(tmp_path):
+    """Regression: merging two 10,000-char contents must not produce a blob > 10,000 chars."""
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    memory_id = await memory.store_memory("seed", session="cap-test")
+
+    big_existing = "A" * 10000
+    with memory.get_connection() as conn:
+        conn.execute(
+            "UPDATE memories SET content = ? WHERE id = ?",
+            (big_existing, memory_id),
+        )
+
+    big_new = "B" * 10000
+    await memory.update_memory(memory_id, big_new)
+
+    with memory.get_connection() as conn:
+        row = conn.execute(
+            "SELECT content FROM memories WHERE id = ?", (memory_id,)
+        ).fetchone()
+
+    stored = row[0]
+    merge_marker = "\n[merged] "
+    expected_new_len = 10000 - len(merge_marker)
+    assert len(stored) == 10000
+    assert stored.startswith(merge_marker)
+    assert stored.endswith("B" * expected_new_len)
+    assert "A" not in stored


### PR DESCRIPTION
v2.10.0

Recall & Search Reliability
- Added RECALL_SCAN_LIMIT env var (default 1000) so semantic scan cap is configurable instead of hardcoded
- recall_similar() now fetches scan_limit+1 rows to detect truncation and returns scan metadata via optional include_scan_metadata flag
- marm_smart_recall (HTTP + STDIO) surfaces recall_scan_truncated and recall_scan_limit on both success and no_results paths
- Fixed pre-existing bug: search_all=True no-results path was falling through to success response with empty results; restructured no_results block to handle both branches correctly

Protocol & Agent Session Handling
- Converted HTTP protocol injection from server-global to per-session tracking, so multiple concurrent agents each receive the MARM protocol once
- Preserved first-call ordering (protocol before compaction nudge)

Consolidation Safety
- Capped write-time merge growth at 10,000 chars to prevent hot near-duplicate memories from growing into unbounded blobs

MCP Tool Error Handling (S5)
- Converted all HTTPException(500) raises in model-facing tools to structured {"status":"error"} returns across logging, notebook, reasoning, and recall endpoints so errors are visible to agents

Service Refactor
- Extracted STDIO smart recall into services/recall.py
- Extracted STDIO session summary into services/summary.py
- Moved atomic compaction DB apply into services/compaction_apply.py

Tests
- Fixed 3 pre-existing failures in test_http_tools.py (session name mismatch, missing .body on mock response)
- Added regression tests for recall scan truncation metadata (truncated=True and truncated=False paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounded semantic recall with configurable scan limit and truncation metadata (`recall_scan_truncated`, `recall_scan_limit`). Added `RECALL_SCAN_LIMIT` env var (default 1000).

* **Refactor**
  * Recall, session-summary, and compaction-apply logic moved into dedicated service modules to simplify tool surfaces.

* **Behavior changes**
  * Protocol delivered once per session on first tool call. API tools return structured JSON error payloads instead of raising HTTP 500.

* **Tests**
  * New/updated tests for scan truncation, merge-size cap (10,000 chars), per-session protocol delivery, and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->