### PR TITLE
fix: add config safety clamping and recall-path observability

### DIFF
--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -76,13 +76,47 @@ if not (1 <= _raw_port <= 65535):
     )
 SERVER_VERSION = "2.12.2"
 
-MARM_RATE_LIMIT_RPM = max(1, int(os.environ.get("MARM_RATE_LIMIT_RPM", "80")))
-RATE_LIMIT_WINDOW_SECONDS = max(1, int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60")))
-RATE_LIMIT_BLOCK_SECONDS = max(0, int(os.environ.get("RATE_LIMIT_BLOCK_SECONDS", "30")))
+_raw_rpm = int(os.environ.get("MARM_RATE_LIMIT_RPM", "80"))
+MARM_RATE_LIMIT_RPM = max(1, _raw_rpm)
+if _raw_rpm < 1:
+    print(
+        f"WARNING: MARM_RATE_LIMIT_RPM={_raw_rpm} below minimum 1, clamped to {MARM_RATE_LIMIT_RPM}",
+        file=sys.stderr,
+    )
+
+_raw_rls = int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60"))
+RATE_LIMIT_WINDOW_SECONDS = max(1, _raw_rls)
+if _raw_rls < 1:
+    print(
+        f"WARNING: RATE_LIMIT_WINDOW_SECONDS={_raw_rls} below minimum 1, clamped to {RATE_LIMIT_WINDOW_SECONDS}",
+        file=sys.stderr,
+    )
+
+_raw_rbs = int(os.environ.get("RATE_LIMIT_BLOCK_SECONDS", "30"))
+RATE_LIMIT_BLOCK_SECONDS = max(0, _raw_rbs)
+if _raw_rbs < 0:
+    print(
+        f"WARNING: RATE_LIMIT_BLOCK_SECONDS={_raw_rbs} below minimum 0, clamped to {RATE_LIMIT_BLOCK_SECONDS}",
+        file=sys.stderr,
+    )
 
 WRITE_QUEUE_ENABLED = os.environ.get("WRITE_QUEUE_ENABLED", "1") == "1"
-MAX_QUEUE_SIZE = max(1, int(os.environ.get("MAX_QUEUE_SIZE", "100")))
-RECALL_SCAN_LIMIT = max(1, int(os.environ.get("RECALL_SCAN_LIMIT", "10000")))
+
+_raw_mqs = int(os.environ.get("MAX_QUEUE_SIZE", "100"))
+MAX_QUEUE_SIZE = max(1, _raw_mqs)
+if _raw_mqs < 1:
+    print(
+        f"WARNING: MAX_QUEUE_SIZE={_raw_mqs} below minimum 1, clamped to {MAX_QUEUE_SIZE}",
+        file=sys.stderr,
+    )
+
+_raw_rsl = int(os.environ.get("RECALL_SCAN_LIMIT", "10000"))
+RECALL_SCAN_LIMIT = max(1, _raw_rsl)
+if _raw_rsl < 1:
+    print(
+        f"WARNING: RECALL_SCAN_LIMIT={_raw_rsl} below minimum 1, clamped to {RECALL_SCAN_LIMIT}",
+        file=sys.stderr,
+    )
 _raw_hsw = float(os.environ.get("HYBRID_SEARCH_TEXT_WEIGHT", "0.35"))
 _raw_tw = float(os.environ.get("TEMPORAL_WEIGHT", "0.1"))
 _raw_hld = float(os.environ.get("TEMPORAL_HALF_LIFE_DAYS", "30"))
@@ -123,28 +157,54 @@ if not (0.0 <= _raw_cst <= 1.0):
         file=sys.stderr,
     )
 
-COMPACTION_TRIGGER_COUNT = max(1, int(os.environ.get("COMPACTION_TRIGGER_COUNT", "5")))
-COMPACTION_MIN_CLUSTER_SIZE = max(1, int(os.environ.get("COMPACTION_MIN_CLUSTER_SIZE", "3")))
-COMPACTION_MIN_AGE_HOURS = max(0, int(os.environ.get("COMPACTION_MIN_AGE_HOURS", "24")))
-COMPACTION_ACTIVE_SESSION_GRACE_MINUTES = max(
-    0, int(os.environ.get("COMPACTION_ACTIVE_SESSION_GRACE_MINUTES", "15"))
-)
-COMPACTION_STAGING_TTL_HOURS = max(
-    1, int(os.environ.get("COMPACTION_STAGING_TTL_HOURS", "168"))
-)
+_raw_ctc = int(os.environ.get("COMPACTION_TRIGGER_COUNT", "5"))
+COMPACTION_TRIGGER_COUNT = max(1, _raw_ctc)
+if _raw_ctc < 1:
+    print(f"WARNING: COMPACTION_TRIGGER_COUNT={_raw_ctc} below minimum 1, clamped to {COMPACTION_TRIGGER_COUNT}", file=sys.stderr)
+
+_raw_cmcs = int(os.environ.get("COMPACTION_MIN_CLUSTER_SIZE", "3"))
+COMPACTION_MIN_CLUSTER_SIZE = max(1, _raw_cmcs)
+if _raw_cmcs < 1:
+    print(f"WARNING: COMPACTION_MIN_CLUSTER_SIZE={_raw_cmcs} below minimum 1, clamped to {COMPACTION_MIN_CLUSTER_SIZE}", file=sys.stderr)
+
+_raw_cmah = int(os.environ.get("COMPACTION_MIN_AGE_HOURS", "24"))
+COMPACTION_MIN_AGE_HOURS = max(0, _raw_cmah)
+if _raw_cmah < 0:
+    print(f"WARNING: COMPACTION_MIN_AGE_HOURS={_raw_cmah} below minimum 0, clamped to {COMPACTION_MIN_AGE_HOURS}", file=sys.stderr)
+
+_raw_casm = int(os.environ.get("COMPACTION_ACTIVE_SESSION_GRACE_MINUTES", "15"))
+COMPACTION_ACTIVE_SESSION_GRACE_MINUTES = max(0, _raw_casm)
+if _raw_casm < 0:
+    print(f"WARNING: COMPACTION_ACTIVE_SESSION_GRACE_MINUTES={_raw_casm} below minimum 0, clamped to {COMPACTION_ACTIVE_SESSION_GRACE_MINUTES}", file=sys.stderr)
+
+_raw_csttl = int(os.environ.get("COMPACTION_STAGING_TTL_HOURS", "168"))
+COMPACTION_STAGING_TTL_HOURS = max(1, _raw_csttl)
+if _raw_csttl < 1:
+    print(f"WARNING: COMPACTION_STAGING_TTL_HOURS={_raw_csttl} below minimum 1, clamped to {COMPACTION_STAGING_TTL_HOURS}", file=sys.stderr)
+
 COMPACTION_AUTO_APPLY_ENABLED = (
     os.environ.get("COMPACTION_AUTO_APPLY_ENABLED", "0") == "1"
 )
-COMPACTION_AUTO_APPLY_INTERVAL_MINUTES = max(
-    1, int(os.environ.get("COMPACTION_AUTO_APPLY_INTERVAL_MINUTES", "60"))
-)
-COMPACTION_MAX_NUDGES = max(1, int(os.environ.get("COMPACTION_MAX_NUDGES", "5")))
-COMPACTION_NUDGE_COOLDOWN_SECONDS = max(
-    0, int(os.environ.get("COMPACTION_NUDGE_COOLDOWN_SECONDS", "2"))
-)
-COMPACTION_INJECTION_BYTE_BUDGET = max(
-    0, int(os.environ.get("COMPACTION_INJECTION_BYTE_BUDGET", "2048"))
-)
+
+_raw_caai = int(os.environ.get("COMPACTION_AUTO_APPLY_INTERVAL_MINUTES", "60"))
+COMPACTION_AUTO_APPLY_INTERVAL_MINUTES = max(1, _raw_caai)
+if _raw_caai < 1:
+    print(f"WARNING: COMPACTION_AUTO_APPLY_INTERVAL_MINUTES={_raw_caai} below minimum 1, clamped to {COMPACTION_AUTO_APPLY_INTERVAL_MINUTES}", file=sys.stderr)
+
+_raw_cmn = int(os.environ.get("COMPACTION_MAX_NUDGES", "5"))
+COMPACTION_MAX_NUDGES = max(1, _raw_cmn)
+if _raw_cmn < 1:
+    print(f"WARNING: COMPACTION_MAX_NUDGES={_raw_cmn} below minimum 1, clamped to {COMPACTION_MAX_NUDGES}", file=sys.stderr)
+
+_raw_cncs = int(os.environ.get("COMPACTION_NUDGE_COOLDOWN_SECONDS", "2"))
+COMPACTION_NUDGE_COOLDOWN_SECONDS = max(0, _raw_cncs)
+if _raw_cncs < 0:
+    print(f"WARNING: COMPACTION_NUDGE_COOLDOWN_SECONDS={_raw_cncs} below minimum 0, clamped to {COMPACTION_NUDGE_COOLDOWN_SECONDS}", file=sys.stderr)
+
+_raw_cibb = int(os.environ.get("COMPACTION_INJECTION_BYTE_BUDGET", "2048"))
+COMPACTION_INJECTION_BYTE_BUDGET = max(0, _raw_cibb)
+if _raw_cibb < 0:
+    print(f"WARNING: COMPACTION_INJECTION_BYTE_BUDGET={_raw_cibb} below minimum 0, clamped to {COMPACTION_INJECTION_BYTE_BUDGET}", file=sys.stderr)
 
 MARM_API_KEY = os.environ.get("MARM_API_KEY", "")
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -67,16 +67,22 @@ ANALYTICS_DB_PATH = get_analytics_db_path()
 DEFAULT_SEMANTIC_MODEL = "all-MiniLM-L6-v2"
 
 SERVER_HOST = os.environ.get("SERVER_HOST", "127.0.0.1")
-SERVER_PORT = int(os.environ.get("SERVER_PORT", 8001))
+_raw_port = int(os.environ.get("SERVER_PORT", 8001))
+SERVER_PORT = max(1, min(65535, _raw_port))
+if not (1 <= _raw_port <= 65535):
+    print(
+        f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
+        file=sys.stderr,
+    )
 SERVER_VERSION = "2.12.2"
 
-MARM_RATE_LIMIT_RPM = int(os.environ.get("MARM_RATE_LIMIT_RPM", "80"))
-RATE_LIMIT_WINDOW_SECONDS = int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60"))
-RATE_LIMIT_BLOCK_SECONDS = int(os.environ.get("RATE_LIMIT_BLOCK_SECONDS", "30"))
+MARM_RATE_LIMIT_RPM = max(1, int(os.environ.get("MARM_RATE_LIMIT_RPM", "80")))
+RATE_LIMIT_WINDOW_SECONDS = max(1, int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60")))
+RATE_LIMIT_BLOCK_SECONDS = max(0, int(os.environ.get("RATE_LIMIT_BLOCK_SECONDS", "30")))
 
 WRITE_QUEUE_ENABLED = os.environ.get("WRITE_QUEUE_ENABLED", "1") == "1"
-MAX_QUEUE_SIZE = int(os.environ.get("MAX_QUEUE_SIZE", "100"))
-RECALL_SCAN_LIMIT = int(os.environ.get("RECALL_SCAN_LIMIT", "10000"))
+MAX_QUEUE_SIZE = max(1, int(os.environ.get("MAX_QUEUE_SIZE", "100")))
+RECALL_SCAN_LIMIT = max(1, int(os.environ.get("RECALL_SCAN_LIMIT", "10000")))
 _raw_hsw = float(os.environ.get("HYBRID_SEARCH_TEXT_WEIGHT", "0.35"))
 _raw_tw = float(os.environ.get("TEMPORAL_WEIGHT", "0.1"))
 _raw_hld = float(os.environ.get("TEMPORAL_HALF_LIFE_DAYS", "30"))
@@ -100,33 +106,44 @@ if _raw_hld < 1.0:
     )
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
-CONSOLIDATION_THRESHOLD = float(os.environ.get("CONSOLIDATION_THRESHOLD", "0.92"))
+_raw_ct = float(os.environ.get("CONSOLIDATION_THRESHOLD", "0.92"))
+CONSOLIDATION_THRESHOLD = max(0.0, min(1.0, _raw_ct))
+if not (0.0 <= _raw_ct <= 1.0):
+    print(
+        f"WARNING: CONSOLIDATION_THRESHOLD={_raw_ct} out of [0, 1], clamped to {CONSOLIDATION_THRESHOLD}",
+        file=sys.stderr,
+    )
 
 COMPACTION_ENABLED = os.environ.get("COMPACTION_ENABLED", "0") == "1"
-COMPACTION_TRIGGER_COUNT = int(os.environ.get("COMPACTION_TRIGGER_COUNT", "5"))
-COMPACTION_SIMILARITY_THRESHOLD = float(
-    os.environ.get("COMPACTION_SIMILARITY_THRESHOLD", "0.88")
+_raw_cst = float(os.environ.get("COMPACTION_SIMILARITY_THRESHOLD", "0.88"))
+COMPACTION_SIMILARITY_THRESHOLD = max(0.0, min(1.0, _raw_cst))
+if not (0.0 <= _raw_cst <= 1.0):
+    print(
+        f"WARNING: COMPACTION_SIMILARITY_THRESHOLD={_raw_cst} out of [0, 1], clamped to {COMPACTION_SIMILARITY_THRESHOLD}",
+        file=sys.stderr,
+    )
+
+COMPACTION_TRIGGER_COUNT = max(1, int(os.environ.get("COMPACTION_TRIGGER_COUNT", "5")))
+COMPACTION_MIN_CLUSTER_SIZE = max(1, int(os.environ.get("COMPACTION_MIN_CLUSTER_SIZE", "3")))
+COMPACTION_MIN_AGE_HOURS = max(0, int(os.environ.get("COMPACTION_MIN_AGE_HOURS", "24")))
+COMPACTION_ACTIVE_SESSION_GRACE_MINUTES = max(
+    0, int(os.environ.get("COMPACTION_ACTIVE_SESSION_GRACE_MINUTES", "15"))
 )
-COMPACTION_MIN_CLUSTER_SIZE = int(os.environ.get("COMPACTION_MIN_CLUSTER_SIZE", "3"))
-COMPACTION_MIN_AGE_HOURS = int(os.environ.get("COMPACTION_MIN_AGE_HOURS", "24"))
-COMPACTION_ACTIVE_SESSION_GRACE_MINUTES = int(
-    os.environ.get("COMPACTION_ACTIVE_SESSION_GRACE_MINUTES", "15")
-)
-COMPACTION_STAGING_TTL_HOURS = int(
-    os.environ.get("COMPACTION_STAGING_TTL_HOURS", "168")
+COMPACTION_STAGING_TTL_HOURS = max(
+    1, int(os.environ.get("COMPACTION_STAGING_TTL_HOURS", "168"))
 )
 COMPACTION_AUTO_APPLY_ENABLED = (
     os.environ.get("COMPACTION_AUTO_APPLY_ENABLED", "0") == "1"
 )
-COMPACTION_AUTO_APPLY_INTERVAL_MINUTES = int(
-    os.environ.get("COMPACTION_AUTO_APPLY_INTERVAL_MINUTES", "60")
+COMPACTION_AUTO_APPLY_INTERVAL_MINUTES = max(
+    1, int(os.environ.get("COMPACTION_AUTO_APPLY_INTERVAL_MINUTES", "60"))
 )
-COMPACTION_MAX_NUDGES = int(os.environ.get("COMPACTION_MAX_NUDGES", "5"))
-COMPACTION_NUDGE_COOLDOWN_SECONDS = int(
-    os.environ.get("COMPACTION_NUDGE_COOLDOWN_SECONDS", "2")
+COMPACTION_MAX_NUDGES = max(1, int(os.environ.get("COMPACTION_MAX_NUDGES", "5")))
+COMPACTION_NUDGE_COOLDOWN_SECONDS = max(
+    0, int(os.environ.get("COMPACTION_NUDGE_COOLDOWN_SECONDS", "2"))
 )
-COMPACTION_INJECTION_BYTE_BUDGET = int(
-    os.environ.get("COMPACTION_INJECTION_BYTE_BUDGET", "2048")
+COMPACTION_INJECTION_BYTE_BUDGET = max(
+    0, int(os.environ.get("COMPACTION_INJECTION_BYTE_BUDGET", "2048"))
 )
 
 MARM_API_KEY = os.environ.get("MARM_API_KEY", "")

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -7,6 +7,36 @@ from pathlib import Path
 
 from ..utils.security import generate_api_key
 
+
+def _safe_int(env_key: str, default: int) -> int:
+    """Parse an env var as int, falling back to default on malformed input."""
+    raw = os.environ.get(env_key)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        print(
+            f"WARNING: {env_key}={raw!r} is not a valid integer, using default {default}",
+            file=sys.stderr,
+        )
+        return default
+
+
+def _safe_float(env_key: str, default: float) -> float:
+    """Parse an env var as float, falling back to default on malformed input."""
+    raw = os.environ.get(env_key)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        print(
+            f"WARNING: {env_key}={raw!r} is not a valid number, using default {default}",
+            file=sys.stderr,
+        )
+        return default
+
 SEMANTIC_SEARCH_AVAILABLE = (
     importlib.util.find_spec("sentence_transformers") is not None
 )
@@ -67,7 +97,7 @@ ANALYTICS_DB_PATH = get_analytics_db_path()
 DEFAULT_SEMANTIC_MODEL = "all-MiniLM-L6-v2"
 
 SERVER_HOST = os.environ.get("SERVER_HOST", "127.0.0.1")
-_raw_port = int(os.environ.get("SERVER_PORT", 8001))
+_raw_port = _safe_int("SERVER_PORT", 8001)
 SERVER_PORT = max(1, min(65535, _raw_port))
 if not (1 <= _raw_port <= 65535):
     print(
@@ -76,108 +106,79 @@ if not (1 <= _raw_port <= 65535):
     )
 SERVER_VERSION = "2.12.2"
 
-_raw_rpm = int(os.environ.get("MARM_RATE_LIMIT_RPM", "80"))
+_raw_rpm = _safe_int("MARM_RATE_LIMIT_RPM", 80)
 MARM_RATE_LIMIT_RPM = max(1, _raw_rpm)
 if _raw_rpm < 1:
-    print(
-        f"WARNING: MARM_RATE_LIMIT_RPM={_raw_rpm} below minimum 1, clamped to {MARM_RATE_LIMIT_RPM}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: MARM_RATE_LIMIT_RPM={_raw_rpm} below minimum 1, clamped to {MARM_RATE_LIMIT_RPM}", file=sys.stderr)
 
-_raw_rls = int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60"))
+_raw_rls = _safe_int("RATE_LIMIT_WINDOW_SECONDS", 60)
 RATE_LIMIT_WINDOW_SECONDS = max(1, _raw_rls)
 if _raw_rls < 1:
-    print(
-        f"WARNING: RATE_LIMIT_WINDOW_SECONDS={_raw_rls} below minimum 1, clamped to {RATE_LIMIT_WINDOW_SECONDS}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: RATE_LIMIT_WINDOW_SECONDS={_raw_rls} below minimum 1, clamped to {RATE_LIMIT_WINDOW_SECONDS}", file=sys.stderr)
 
-_raw_rbs = int(os.environ.get("RATE_LIMIT_BLOCK_SECONDS", "30"))
+_raw_rbs = _safe_int("RATE_LIMIT_BLOCK_SECONDS", 30)
 RATE_LIMIT_BLOCK_SECONDS = max(0, _raw_rbs)
 if _raw_rbs < 0:
-    print(
-        f"WARNING: RATE_LIMIT_BLOCK_SECONDS={_raw_rbs} below minimum 0, clamped to {RATE_LIMIT_BLOCK_SECONDS}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: RATE_LIMIT_BLOCK_SECONDS={_raw_rbs} below minimum 0, clamped to {RATE_LIMIT_BLOCK_SECONDS}", file=sys.stderr)
 
 WRITE_QUEUE_ENABLED = os.environ.get("WRITE_QUEUE_ENABLED", "1") == "1"
 
-_raw_mqs = int(os.environ.get("MAX_QUEUE_SIZE", "100"))
+_raw_mqs = _safe_int("MAX_QUEUE_SIZE", 100)
 MAX_QUEUE_SIZE = max(1, _raw_mqs)
 if _raw_mqs < 1:
-    print(
-        f"WARNING: MAX_QUEUE_SIZE={_raw_mqs} below minimum 1, clamped to {MAX_QUEUE_SIZE}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: MAX_QUEUE_SIZE={_raw_mqs} below minimum 1, clamped to {MAX_QUEUE_SIZE}", file=sys.stderr)
 
-_raw_rsl = int(os.environ.get("RECALL_SCAN_LIMIT", "10000"))
+_raw_rsl = _safe_int("RECALL_SCAN_LIMIT", 10000)
 RECALL_SCAN_LIMIT = max(1, _raw_rsl)
 if _raw_rsl < 1:
-    print(
-        f"WARNING: RECALL_SCAN_LIMIT={_raw_rsl} below minimum 1, clamped to {RECALL_SCAN_LIMIT}",
-        file=sys.stderr,
-    )
-_raw_hsw = float(os.environ.get("HYBRID_SEARCH_TEXT_WEIGHT", "0.35"))
-_raw_tw = float(os.environ.get("TEMPORAL_WEIGHT", "0.1"))
-_raw_hld = float(os.environ.get("TEMPORAL_HALF_LIFE_DAYS", "30"))
+    print(f"WARNING: RECALL_SCAN_LIMIT={_raw_rsl} below minimum 1, clamped to {RECALL_SCAN_LIMIT}", file=sys.stderr)
+
+_raw_hsw = _safe_float("HYBRID_SEARCH_TEXT_WEIGHT", 0.35)
+_raw_tw = _safe_float("TEMPORAL_WEIGHT", 0.1)
+_raw_hld = _safe_float("TEMPORAL_HALF_LIFE_DAYS", 30)
 HYBRID_SEARCH_TEXT_WEIGHT = max(0.0, min(1.0, _raw_hsw))
 TEMPORAL_WEIGHT = max(0.0, min(1.0, _raw_tw))
 TEMPORAL_HALF_LIFE_DAYS = max(1.0, _raw_hld)
 if not (0.0 <= _raw_hsw <= 1.0):
-    print(
-        f"WARNING: HYBRID_SEARCH_TEXT_WEIGHT={_raw_hsw} out of [0, 1], clamped to {HYBRID_SEARCH_TEXT_WEIGHT}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: HYBRID_SEARCH_TEXT_WEIGHT={_raw_hsw} out of [0, 1], clamped to {HYBRID_SEARCH_TEXT_WEIGHT}", file=sys.stderr)
 if not (0.0 <= _raw_tw <= 1.0):
-    print(
-        f"WARNING: TEMPORAL_WEIGHT={_raw_tw} out of [0, 1], clamped to {TEMPORAL_WEIGHT}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: TEMPORAL_WEIGHT={_raw_tw} out of [0, 1], clamped to {TEMPORAL_WEIGHT}", file=sys.stderr)
 if _raw_hld < 1.0:
-    print(
-        f"WARNING: TEMPORAL_HALF_LIFE_DAYS={_raw_hld} below minimum 1.0, clamped to {TEMPORAL_HALF_LIFE_DAYS}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: TEMPORAL_HALF_LIFE_DAYS={_raw_hld} below minimum 1.0, clamped to {TEMPORAL_HALF_LIFE_DAYS}", file=sys.stderr)
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
-_raw_ct = float(os.environ.get("CONSOLIDATION_THRESHOLD", "0.92"))
+_raw_ct = _safe_float("CONSOLIDATION_THRESHOLD", 0.92)
 CONSOLIDATION_THRESHOLD = max(0.0, min(1.0, _raw_ct))
 if not (0.0 <= _raw_ct <= 1.0):
-    print(
-        f"WARNING: CONSOLIDATION_THRESHOLD={_raw_ct} out of [0, 1], clamped to {CONSOLIDATION_THRESHOLD}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: CONSOLIDATION_THRESHOLD={_raw_ct} out of [0, 1], clamped to {CONSOLIDATION_THRESHOLD}", file=sys.stderr)
 
 COMPACTION_ENABLED = os.environ.get("COMPACTION_ENABLED", "0") == "1"
-_raw_cst = float(os.environ.get("COMPACTION_SIMILARITY_THRESHOLD", "0.88"))
+_raw_cst = _safe_float("COMPACTION_SIMILARITY_THRESHOLD", 0.88)
 COMPACTION_SIMILARITY_THRESHOLD = max(0.0, min(1.0, _raw_cst))
 if not (0.0 <= _raw_cst <= 1.0):
-    print(
-        f"WARNING: COMPACTION_SIMILARITY_THRESHOLD={_raw_cst} out of [0, 1], clamped to {COMPACTION_SIMILARITY_THRESHOLD}",
-        file=sys.stderr,
-    )
+    print(f"WARNING: COMPACTION_SIMILARITY_THRESHOLD={_raw_cst} out of [0, 1], clamped to {COMPACTION_SIMILARITY_THRESHOLD}", file=sys.stderr)
 
-_raw_ctc = int(os.environ.get("COMPACTION_TRIGGER_COUNT", "5"))
+_raw_ctc = _safe_int("COMPACTION_TRIGGER_COUNT", 5)
 COMPACTION_TRIGGER_COUNT = max(1, _raw_ctc)
 if _raw_ctc < 1:
     print(f"WARNING: COMPACTION_TRIGGER_COUNT={_raw_ctc} below minimum 1, clamped to {COMPACTION_TRIGGER_COUNT}", file=sys.stderr)
 
-_raw_cmcs = int(os.environ.get("COMPACTION_MIN_CLUSTER_SIZE", "3"))
+_raw_cmcs = _safe_int("COMPACTION_MIN_CLUSTER_SIZE", 3)
 COMPACTION_MIN_CLUSTER_SIZE = max(1, _raw_cmcs)
 if _raw_cmcs < 1:
     print(f"WARNING: COMPACTION_MIN_CLUSTER_SIZE={_raw_cmcs} below minimum 1, clamped to {COMPACTION_MIN_CLUSTER_SIZE}", file=sys.stderr)
 
-_raw_cmah = int(os.environ.get("COMPACTION_MIN_AGE_HOURS", "24"))
+_raw_cmah = _safe_int("COMPACTION_MIN_AGE_HOURS", 24)
 COMPACTION_MIN_AGE_HOURS = max(0, _raw_cmah)
 if _raw_cmah < 0:
     print(f"WARNING: COMPACTION_MIN_AGE_HOURS={_raw_cmah} below minimum 0, clamped to {COMPACTION_MIN_AGE_HOURS}", file=sys.stderr)
 
-_raw_casm = int(os.environ.get("COMPACTION_ACTIVE_SESSION_GRACE_MINUTES", "15"))
+_raw_casm = _safe_int("COMPACTION_ACTIVE_SESSION_GRACE_MINUTES", 15)
 COMPACTION_ACTIVE_SESSION_GRACE_MINUTES = max(0, _raw_casm)
 if _raw_casm < 0:
     print(f"WARNING: COMPACTION_ACTIVE_SESSION_GRACE_MINUTES={_raw_casm} below minimum 0, clamped to {COMPACTION_ACTIVE_SESSION_GRACE_MINUTES}", file=sys.stderr)
 
-_raw_csttl = int(os.environ.get("COMPACTION_STAGING_TTL_HOURS", "168"))
+_raw_csttl = _safe_int("COMPACTION_STAGING_TTL_HOURS", 168)
 COMPACTION_STAGING_TTL_HOURS = max(1, _raw_csttl)
 if _raw_csttl < 1:
     print(f"WARNING: COMPACTION_STAGING_TTL_HOURS={_raw_csttl} below minimum 1, clamped to {COMPACTION_STAGING_TTL_HOURS}", file=sys.stderr)
@@ -186,22 +187,22 @@ COMPACTION_AUTO_APPLY_ENABLED = (
     os.environ.get("COMPACTION_AUTO_APPLY_ENABLED", "0") == "1"
 )
 
-_raw_caai = int(os.environ.get("COMPACTION_AUTO_APPLY_INTERVAL_MINUTES", "60"))
+_raw_caai = _safe_int("COMPACTION_AUTO_APPLY_INTERVAL_MINUTES", 60)
 COMPACTION_AUTO_APPLY_INTERVAL_MINUTES = max(1, _raw_caai)
 if _raw_caai < 1:
     print(f"WARNING: COMPACTION_AUTO_APPLY_INTERVAL_MINUTES={_raw_caai} below minimum 1, clamped to {COMPACTION_AUTO_APPLY_INTERVAL_MINUTES}", file=sys.stderr)
 
-_raw_cmn = int(os.environ.get("COMPACTION_MAX_NUDGES", "5"))
+_raw_cmn = _safe_int("COMPACTION_MAX_NUDGES", 5)
 COMPACTION_MAX_NUDGES = max(1, _raw_cmn)
 if _raw_cmn < 1:
     print(f"WARNING: COMPACTION_MAX_NUDGES={_raw_cmn} below minimum 1, clamped to {COMPACTION_MAX_NUDGES}", file=sys.stderr)
 
-_raw_cncs = int(os.environ.get("COMPACTION_NUDGE_COOLDOWN_SECONDS", "2"))
+_raw_cncs = _safe_int("COMPACTION_NUDGE_COOLDOWN_SECONDS", 2)
 COMPACTION_NUDGE_COOLDOWN_SECONDS = max(0, _raw_cncs)
 if _raw_cncs < 0:
     print(f"WARNING: COMPACTION_NUDGE_COOLDOWN_SECONDS={_raw_cncs} below minimum 0, clamped to {COMPACTION_NUDGE_COOLDOWN_SECONDS}", file=sys.stderr)
 
-_raw_cibb = int(os.environ.get("COMPACTION_INJECTION_BYTE_BUDGET", "2048"))
+_raw_cibb = _safe_int("COMPACTION_INJECTION_BYTE_BUDGET", 2048)
 COMPACTION_INJECTION_BYTE_BUDGET = max(0, _raw_cibb)
 if _raw_cibb < 0:
     print(f"WARNING: COMPACTION_INJECTION_BYTE_BUDGET={_raw_cibb} below minimum 0, clamped to {COMPACTION_INJECTION_BYTE_BUDGET}", file=sys.stderr)

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -37,6 +37,7 @@ def _safe_float(env_key: str, default: float) -> float:
         )
         return default
 
+
 SEMANTIC_SEARCH_AVAILABLE = (
     importlib.util.find_spec("sentence_transformers") is not None
 )
@@ -109,29 +110,44 @@ SERVER_VERSION = "2.12.2"
 _raw_rpm = _safe_int("MARM_RATE_LIMIT_RPM", 80)
 MARM_RATE_LIMIT_RPM = max(1, _raw_rpm)
 if _raw_rpm < 1:
-    print(f"WARNING: MARM_RATE_LIMIT_RPM={_raw_rpm} below minimum 1, clamped to {MARM_RATE_LIMIT_RPM}", file=sys.stderr)
+    print(
+        f"WARNING: MARM_RATE_LIMIT_RPM={_raw_rpm} below minimum 1, clamped to {MARM_RATE_LIMIT_RPM}",
+        file=sys.stderr,
+    )
 
 _raw_rls = _safe_int("RATE_LIMIT_WINDOW_SECONDS", 60)
 RATE_LIMIT_WINDOW_SECONDS = max(1, _raw_rls)
 if _raw_rls < 1:
-    print(f"WARNING: RATE_LIMIT_WINDOW_SECONDS={_raw_rls} below minimum 1, clamped to {RATE_LIMIT_WINDOW_SECONDS}", file=sys.stderr)
+    print(
+        f"WARNING: RATE_LIMIT_WINDOW_SECONDS={_raw_rls} below minimum 1, clamped to {RATE_LIMIT_WINDOW_SECONDS}",
+        file=sys.stderr,
+    )
 
 _raw_rbs = _safe_int("RATE_LIMIT_BLOCK_SECONDS", 30)
 RATE_LIMIT_BLOCK_SECONDS = max(0, _raw_rbs)
 if _raw_rbs < 0:
-    print(f"WARNING: RATE_LIMIT_BLOCK_SECONDS={_raw_rbs} below minimum 0, clamped to {RATE_LIMIT_BLOCK_SECONDS}", file=sys.stderr)
+    print(
+        f"WARNING: RATE_LIMIT_BLOCK_SECONDS={_raw_rbs} below minimum 0, clamped to {RATE_LIMIT_BLOCK_SECONDS}",
+        file=sys.stderr,
+    )
 
 WRITE_QUEUE_ENABLED = os.environ.get("WRITE_QUEUE_ENABLED", "1") == "1"
 
 _raw_mqs = _safe_int("MAX_QUEUE_SIZE", 100)
 MAX_QUEUE_SIZE = max(1, _raw_mqs)
 if _raw_mqs < 1:
-    print(f"WARNING: MAX_QUEUE_SIZE={_raw_mqs} below minimum 1, clamped to {MAX_QUEUE_SIZE}", file=sys.stderr)
+    print(
+        f"WARNING: MAX_QUEUE_SIZE={_raw_mqs} below minimum 1, clamped to {MAX_QUEUE_SIZE}",
+        file=sys.stderr,
+    )
 
 _raw_rsl = _safe_int("RECALL_SCAN_LIMIT", 10000)
 RECALL_SCAN_LIMIT = max(1, _raw_rsl)
 if _raw_rsl < 1:
-    print(f"WARNING: RECALL_SCAN_LIMIT={_raw_rsl} below minimum 1, clamped to {RECALL_SCAN_LIMIT}", file=sys.stderr)
+    print(
+        f"WARNING: RECALL_SCAN_LIMIT={_raw_rsl} below minimum 1, clamped to {RECALL_SCAN_LIMIT}",
+        file=sys.stderr,
+    )
 
 _raw_hsw = _safe_float("HYBRID_SEARCH_TEXT_WEIGHT", 0.35)
 _raw_tw = _safe_float("TEMPORAL_WEIGHT", 0.1)
@@ -140,48 +156,78 @@ HYBRID_SEARCH_TEXT_WEIGHT = max(0.0, min(1.0, _raw_hsw))
 TEMPORAL_WEIGHT = max(0.0, min(1.0, _raw_tw))
 TEMPORAL_HALF_LIFE_DAYS = max(1.0, _raw_hld)
 if not (0.0 <= _raw_hsw <= 1.0):
-    print(f"WARNING: HYBRID_SEARCH_TEXT_WEIGHT={_raw_hsw} out of [0, 1], clamped to {HYBRID_SEARCH_TEXT_WEIGHT}", file=sys.stderr)
+    print(
+        f"WARNING: HYBRID_SEARCH_TEXT_WEIGHT={_raw_hsw} out of [0, 1], clamped to {HYBRID_SEARCH_TEXT_WEIGHT}",
+        file=sys.stderr,
+    )
 if not (0.0 <= _raw_tw <= 1.0):
-    print(f"WARNING: TEMPORAL_WEIGHT={_raw_tw} out of [0, 1], clamped to {TEMPORAL_WEIGHT}", file=sys.stderr)
+    print(
+        f"WARNING: TEMPORAL_WEIGHT={_raw_tw} out of [0, 1], clamped to {TEMPORAL_WEIGHT}",
+        file=sys.stderr,
+    )
 if _raw_hld < 1.0:
-    print(f"WARNING: TEMPORAL_HALF_LIFE_DAYS={_raw_hld} below minimum 1.0, clamped to {TEMPORAL_HALF_LIFE_DAYS}", file=sys.stderr)
+    print(
+        f"WARNING: TEMPORAL_HALF_LIFE_DAYS={_raw_hld} below minimum 1.0, clamped to {TEMPORAL_HALF_LIFE_DAYS}",
+        file=sys.stderr,
+    )
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
 _raw_ct = _safe_float("CONSOLIDATION_THRESHOLD", 0.92)
 CONSOLIDATION_THRESHOLD = max(0.0, min(1.0, _raw_ct))
 if not (0.0 <= _raw_ct <= 1.0):
-    print(f"WARNING: CONSOLIDATION_THRESHOLD={_raw_ct} out of [0, 1], clamped to {CONSOLIDATION_THRESHOLD}", file=sys.stderr)
+    print(
+        f"WARNING: CONSOLIDATION_THRESHOLD={_raw_ct} out of [0, 1], clamped to {CONSOLIDATION_THRESHOLD}",
+        file=sys.stderr,
+    )
 
 COMPACTION_ENABLED = os.environ.get("COMPACTION_ENABLED", "0") == "1"
 _raw_cst = _safe_float("COMPACTION_SIMILARITY_THRESHOLD", 0.88)
 COMPACTION_SIMILARITY_THRESHOLD = max(0.0, min(1.0, _raw_cst))
 if not (0.0 <= _raw_cst <= 1.0):
-    print(f"WARNING: COMPACTION_SIMILARITY_THRESHOLD={_raw_cst} out of [0, 1], clamped to {COMPACTION_SIMILARITY_THRESHOLD}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_SIMILARITY_THRESHOLD={_raw_cst} out of [0, 1], clamped to {COMPACTION_SIMILARITY_THRESHOLD}",
+        file=sys.stderr,
+    )
 
 _raw_ctc = _safe_int("COMPACTION_TRIGGER_COUNT", 5)
 COMPACTION_TRIGGER_COUNT = max(1, _raw_ctc)
 if _raw_ctc < 1:
-    print(f"WARNING: COMPACTION_TRIGGER_COUNT={_raw_ctc} below minimum 1, clamped to {COMPACTION_TRIGGER_COUNT}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_TRIGGER_COUNT={_raw_ctc} below minimum 1, clamped to {COMPACTION_TRIGGER_COUNT}",
+        file=sys.stderr,
+    )
 
 _raw_cmcs = _safe_int("COMPACTION_MIN_CLUSTER_SIZE", 3)
 COMPACTION_MIN_CLUSTER_SIZE = max(1, _raw_cmcs)
 if _raw_cmcs < 1:
-    print(f"WARNING: COMPACTION_MIN_CLUSTER_SIZE={_raw_cmcs} below minimum 1, clamped to {COMPACTION_MIN_CLUSTER_SIZE}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_MIN_CLUSTER_SIZE={_raw_cmcs} below minimum 1, clamped to {COMPACTION_MIN_CLUSTER_SIZE}",
+        file=sys.stderr,
+    )
 
 _raw_cmah = _safe_int("COMPACTION_MIN_AGE_HOURS", 24)
 COMPACTION_MIN_AGE_HOURS = max(0, _raw_cmah)
 if _raw_cmah < 0:
-    print(f"WARNING: COMPACTION_MIN_AGE_HOURS={_raw_cmah} below minimum 0, clamped to {COMPACTION_MIN_AGE_HOURS}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_MIN_AGE_HOURS={_raw_cmah} below minimum 0, clamped to {COMPACTION_MIN_AGE_HOURS}",
+        file=sys.stderr,
+    )
 
 _raw_casm = _safe_int("COMPACTION_ACTIVE_SESSION_GRACE_MINUTES", 15)
 COMPACTION_ACTIVE_SESSION_GRACE_MINUTES = max(0, _raw_casm)
 if _raw_casm < 0:
-    print(f"WARNING: COMPACTION_ACTIVE_SESSION_GRACE_MINUTES={_raw_casm} below minimum 0, clamped to {COMPACTION_ACTIVE_SESSION_GRACE_MINUTES}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_ACTIVE_SESSION_GRACE_MINUTES={_raw_casm} below minimum 0, clamped to {COMPACTION_ACTIVE_SESSION_GRACE_MINUTES}",
+        file=sys.stderr,
+    )
 
 _raw_csttl = _safe_int("COMPACTION_STAGING_TTL_HOURS", 168)
 COMPACTION_STAGING_TTL_HOURS = max(1, _raw_csttl)
 if _raw_csttl < 1:
-    print(f"WARNING: COMPACTION_STAGING_TTL_HOURS={_raw_csttl} below minimum 1, clamped to {COMPACTION_STAGING_TTL_HOURS}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_STAGING_TTL_HOURS={_raw_csttl} below minimum 1, clamped to {COMPACTION_STAGING_TTL_HOURS}",
+        file=sys.stderr,
+    )
 
 COMPACTION_AUTO_APPLY_ENABLED = (
     os.environ.get("COMPACTION_AUTO_APPLY_ENABLED", "0") == "1"
@@ -190,22 +236,34 @@ COMPACTION_AUTO_APPLY_ENABLED = (
 _raw_caai = _safe_int("COMPACTION_AUTO_APPLY_INTERVAL_MINUTES", 60)
 COMPACTION_AUTO_APPLY_INTERVAL_MINUTES = max(1, _raw_caai)
 if _raw_caai < 1:
-    print(f"WARNING: COMPACTION_AUTO_APPLY_INTERVAL_MINUTES={_raw_caai} below minimum 1, clamped to {COMPACTION_AUTO_APPLY_INTERVAL_MINUTES}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_AUTO_APPLY_INTERVAL_MINUTES={_raw_caai} below minimum 1, clamped to {COMPACTION_AUTO_APPLY_INTERVAL_MINUTES}",
+        file=sys.stderr,
+    )
 
 _raw_cmn = _safe_int("COMPACTION_MAX_NUDGES", 5)
 COMPACTION_MAX_NUDGES = max(1, _raw_cmn)
 if _raw_cmn < 1:
-    print(f"WARNING: COMPACTION_MAX_NUDGES={_raw_cmn} below minimum 1, clamped to {COMPACTION_MAX_NUDGES}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_MAX_NUDGES={_raw_cmn} below minimum 1, clamped to {COMPACTION_MAX_NUDGES}",
+        file=sys.stderr,
+    )
 
 _raw_cncs = _safe_int("COMPACTION_NUDGE_COOLDOWN_SECONDS", 2)
 COMPACTION_NUDGE_COOLDOWN_SECONDS = max(0, _raw_cncs)
 if _raw_cncs < 0:
-    print(f"WARNING: COMPACTION_NUDGE_COOLDOWN_SECONDS={_raw_cncs} below minimum 0, clamped to {COMPACTION_NUDGE_COOLDOWN_SECONDS}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_NUDGE_COOLDOWN_SECONDS={_raw_cncs} below minimum 0, clamped to {COMPACTION_NUDGE_COOLDOWN_SECONDS}",
+        file=sys.stderr,
+    )
 
 _raw_cibb = _safe_int("COMPACTION_INJECTION_BYTE_BUDGET", 2048)
 COMPACTION_INJECTION_BYTE_BUDGET = max(0, _raw_cibb)
 if _raw_cibb < 0:
-    print(f"WARNING: COMPACTION_INJECTION_BYTE_BUDGET={_raw_cibb} below minimum 0, clamped to {COMPACTION_INJECTION_BYTE_BUDGET}", file=sys.stderr)
+    print(
+        f"WARNING: COMPACTION_INJECTION_BYTE_BUDGET={_raw_cibb} below minimum 0, clamped to {COMPACTION_INJECTION_BYTE_BUDGET}",
+        file=sys.stderr,
+    )
 
 MARM_API_KEY = os.environ.get("MARM_API_KEY", "")
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -108,10 +108,11 @@ if not (1 <= _raw_port <= 65535):
 SERVER_VERSION = "2.12.2"
 
 _raw_rpm = _safe_int("MARM_RATE_LIMIT_RPM", 80)
-MARM_RATE_LIMIT_RPM = max(1, _raw_rpm)
-if _raw_rpm < 1:
+# 0 = disable rate limiting; negative values clamped to 0
+MARM_RATE_LIMIT_RPM = max(0, _raw_rpm)
+if _raw_rpm < 0:
     print(
-        f"WARNING: MARM_RATE_LIMIT_RPM={_raw_rpm} below minimum 1, clamped to {MARM_RATE_LIMIT_RPM}",
+        f"WARNING: MARM_RATE_LIMIT_RPM={_raw_rpm} below minimum 0, clamped to {MARM_RATE_LIMIT_RPM}",
         file=sys.stderr,
     )
 

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib.util
 import json
 import math
+import os
 import sqlite3
 import sys
 import threading
@@ -25,6 +26,19 @@ def _safe_print(msg: str) -> None:
     else:
         sys.stderr.write(msg + "\n")
         sys.stderr.flush()
+
+
+_RECALL_DEBUG = os.environ.get("MARM_RECALL_DEBUG", "0") == "1"
+
+
+def _recall_debug(msg: str) -> None:
+    """Lightweight debug logging for recall-path observability.
+
+    Only emits when MARM_RECALL_DEBUG=1. Writes to stderr to keep
+    STDIO stdout JSON-RPC clean.
+    """
+    if _RECALL_DEBUG:
+        _safe_print(f"[recall-debug] {msg}")
 
 
 def _strip_script_tags(text: str) -> str:
@@ -928,6 +942,7 @@ class MARMMemory:
 
         if query_vec is None:
             if not self._load_encoder_lazily():
+                _recall_debug("semantic model unavailable → text-search fallback")
                 return _wrap(
                     await self.recall_text_search(query, session, limit), False
                 )
@@ -952,6 +967,10 @@ class MARMMemory:
                     f"recall_similar: skipped {dim_skipped} memories with wrong embedding dimension (expected {len(query_embedding)})"
                 )
 
+            _recall_debug(
+                f"vector lane returned {len(similarities)} candidates, scan_truncated={scan_truncated}"
+            )
+
             fts_query = _safe_fts_query(query)
             fts_hits: dict[str, tuple] = {}
             if fts_query:
@@ -964,8 +983,10 @@ class MARMMemory:
                         limit * 2,
                     ):
                         fts_hits[row["id"]] = (row, fts_norm)
+                    _recall_debug(f"FTS hybrid pass: {len(fts_hits)} hits for query '{fts_query}'")
                 except Exception as e:
                     _safe_print(f"FTS5 hybrid pass failed, using vector-only: {e}")
+                    _recall_debug("FTS hybrid pass failed → vector-only results")
 
             combined: dict[str, tuple] = {}
             for mem, vec_norm in similarities:
@@ -993,6 +1014,15 @@ class MARMMemory:
                 :limit
             ]
 
+            # Observability: count results by source lane
+            vec_ids = {m["id"] for m, _ in similarities}
+            both = sum(1 for m, _ in similarities if m["id"] in fts_hits)
+            _recall_debug(
+                f"final: {len(similarities)} results | "
+                f"vec+fts={both}, vec-only={len(vec_ids) - both}, "
+                f"fts-only={len(combined) - len(vec_ids) - (len(fts_hits) - both)}"
+            )
+
             results = []
             for memory, similarity in similarities:
                 results.append(
@@ -1013,12 +1043,14 @@ class MARMMemory:
 
         except Exception as e:
             _safe_print(f"Semantic search failed: {e}")
+            _recall_debug(f"semantic search exception → text-search fallback: {e}")
             return _wrap(await self.recall_text_search(query, session, limit), False)
 
     async def recall_text_search(
         self, query: str, session: str = None, limit: int = 5
     ) -> List[Dict]:
         """Text search via FTS5 BM25 ranking, with LIKE fallback for unsanitizable queries."""
+        _recall_debug(f"text-search path: query='{query[:50]}', session={session}")
         fts_query = _safe_fts_query(query)
         if fts_query is not None:
             try:
@@ -1026,6 +1058,7 @@ class MARMMemory:
                     _fetch_and_score_fts_rows, self.db_path, session, fts_query, limit
                 )
                 if fts_rows:
+                    _recall_debug(f"FTS5 returned {len(fts_rows)} results")
                     return [
                         {
                             "id": row["id"],
@@ -1042,6 +1075,9 @@ class MARMMemory:
                     ]
             except Exception as e:
                 _safe_print(f"FTS5 search failed, falling back to LIKE: {e}")
+                _recall_debug("FTS5 failed → LIKE fallback")
+
+        _recall_debug("FTS5 returned 0 or query unsanitizable → LIKE fallback")
 
         with self.get_connection() as conn:
             if session is None:

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -1012,18 +1012,24 @@ class MARMMemory:
                         fts_row,
                         (1 - TEMPORAL_WEIGHT) * hybrid + TEMPORAL_WEIGHT * t_score,
                     )
+
+            # Observability: count results by source lane (before slicing)
+            vec_set = {m["id"] for m, _ in similarities}
+            fts_only_count = sum(
+                1 for mid in combined if mid not in vec_set and mid in fts_hits
+            )
+            both_count = sum(
+                1 for mid in combined if mid in vec_set and mid in fts_hits
+            )
+            _recall_debug(
+                f"candidates: {len(combined)} total | "
+                f"vec+fts={both_count}, vec-only={len(vec_set) - both_count}, "
+                f"fts-only={fts_only_count}"
+            )
+
             similarities = sorted(combined.values(), key=lambda x: x[1], reverse=True)[
                 :limit
             ]
-
-            # Observability: count results by source lane
-            vec_ids = {m["id"] for m, _ in similarities}
-            both = sum(1 for m, _ in similarities if m["id"] in fts_hits)
-            _recall_debug(
-                f"final: {len(similarities)} results | "
-                f"vec+fts={both}, vec-only={len(vec_ids) - both}, "
-                f"fts-only={len(combined) - len(vec_ids) - (len(fts_hits) - both)}"
-            )
 
             results = []
             for memory, similarity in similarities:

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -983,7 +983,9 @@ class MARMMemory:
                         limit * 2,
                     ):
                         fts_hits[row["id"]] = (row, fts_norm)
-                    _recall_debug(f"FTS hybrid pass: {len(fts_hits)} hits for query '{fts_query}'")
+                    _recall_debug(
+                        f"FTS hybrid pass: {len(fts_hits)} hits for query '{fts_query}'"
+                    )
                 except Exception as e:
                     _safe_print(f"FTS5 hybrid pass failed, using vector-only: {e}")
                     _recall_debug("FTS hybrid pass failed → vector-only results")

--- a/marm-mcp-server/tests/test_config_safety.py
+++ b/marm-mcp-server/tests/test_config_safety.py
@@ -1,56 +1,53 @@
 """Tests for config safety: clamping, warnings, and safe parsing."""
 
+import importlib
 import os
 import sys
 from unittest import mock
 
 
+def _reload_settings_with_env(env: dict[str, str]):
+    """Reload settings under a temporary env patch, then restore the original module."""
+    module_name = "marm_mcp_server.config.settings"
+    original = sys.modules.pop(module_name, None)
+
+    try:
+        with mock.patch.dict(os.environ, env, clear=False):
+            settings_mod = importlib.import_module(module_name)
+            return importlib.reload(settings_mod)
+    finally:
+        sys.modules.pop(module_name, None)
+        if original is not None:
+            sys.modules[module_name] = original
+
+
 def test_rate_limit_rpm_zero_disables_limiting():
     """MARM_RATE_LIMIT_RPM=0 should be preserved (0 = disable rate limiting)."""
-    with mock.patch.dict(os.environ, {"MARM_RATE_LIMIT_RPM": "0"}):
-        # Re-import to pick up the env var
-        import importlib
-        import marm_mcp_server.config.settings as settings_mod
-
-        importlib.reload(settings_mod)
-        assert settings_mod.MARM_RATE_LIMIT_RPM == 0
+    settings_mod = _reload_settings_with_env({"MARM_RATE_LIMIT_RPM": "0"})
+    assert settings_mod.MARM_RATE_LIMIT_RPM == 0
 
 
 def test_rate_limit_rpm_negative_clamped_to_zero():
     """Negative MARM_RATE_LIMIT_RPM should be clamped to 0 with a warning."""
-    with mock.patch.dict(os.environ, {"MARM_RATE_LIMIT_RPM": "-5"}):
-        import importlib
-        import marm_mcp_server.config.settings as settings_mod
-
-        importlib.reload(settings_mod)
-        assert settings_mod.MARM_RATE_LIMIT_RPM == 0
+    settings_mod = _reload_settings_with_env({"MARM_RATE_LIMIT_RPM": "-5"})
+    assert settings_mod.MARM_RATE_LIMIT_RPM == 0
 
 
 def test_malformed_int_env_falls_back_to_default():
     """Malformed int env var should fall back to default, not crash."""
-    with mock.patch.dict(os.environ, {"COMPACTION_TRIGGER_COUNT": "abc"}):
-        import importlib
-        import marm_mcp_server.config.settings as settings_mod
-
-        importlib.reload(settings_mod)
-        assert settings_mod.COMPACTION_TRIGGER_COUNT == 5  # default
+    settings_mod = _reload_settings_with_env({"COMPACTION_TRIGGER_COUNT": "abc"})
+    assert settings_mod.COMPACTION_TRIGGER_COUNT == 5  # default
 
 
 def test_malformed_float_env_falls_back_to_default():
     """Malformed float env var should fall back to default, not crash."""
-    with mock.patch.dict(os.environ, {"CONSOLIDATION_THRESHOLD": "not_a_number"}):
-        import importlib
-        import marm_mcp_server.config.settings as settings_mod
-
-        importlib.reload(settings_mod)
-        assert settings_mod.CONSOLIDATION_THRESHOLD == 0.92  # default
+    settings_mod = _reload_settings_with_env(
+        {"CONSOLIDATION_THRESHOLD": "not_a_number"}
+    )
+    assert settings_mod.CONSOLIDATION_THRESHOLD == 0.92  # default
 
 
 def test_consolidation_threshold_clamped_to_unit_range():
     """CONSOLIDATION_THRESHOLD > 1.0 should be clamped to [0, 1]."""
-    with mock.patch.dict(os.environ, {"CONSOLIDATION_THRESHOLD": "1.5"}):
-        import importlib
-        import marm_mcp_server.config.settings as settings_mod
-
-        importlib.reload(settings_mod)
-        assert settings_mod.CONSOLIDATION_THRESHOLD == 1.0
+    settings_mod = _reload_settings_with_env({"CONSOLIDATION_THRESHOLD": "1.5"})
+    assert settings_mod.CONSOLIDATION_THRESHOLD == 1.0

--- a/marm-mcp-server/tests/test_config_safety.py
+++ b/marm-mcp-server/tests/test_config_safety.py
@@ -1,0 +1,56 @@
+"""Tests for config safety: clamping, warnings, and safe parsing."""
+
+import os
+import sys
+from unittest import mock
+
+
+def test_rate_limit_rpm_zero_disables_limiting():
+    """MARM_RATE_LIMIT_RPM=0 should be preserved (0 = disable rate limiting)."""
+    with mock.patch.dict(os.environ, {"MARM_RATE_LIMIT_RPM": "0"}):
+        # Re-import to pick up the env var
+        import importlib
+        import marm_mcp_server.config.settings as settings_mod
+
+        importlib.reload(settings_mod)
+        assert settings_mod.MARM_RATE_LIMIT_RPM == 0
+
+
+def test_rate_limit_rpm_negative_clamped_to_zero():
+    """Negative MARM_RATE_LIMIT_RPM should be clamped to 0 with a warning."""
+    with mock.patch.dict(os.environ, {"MARM_RATE_LIMIT_RPM": "-5"}):
+        import importlib
+        import marm_mcp_server.config.settings as settings_mod
+
+        importlib.reload(settings_mod)
+        assert settings_mod.MARM_RATE_LIMIT_RPM == 0
+
+
+def test_malformed_int_env_falls_back_to_default():
+    """Malformed int env var should fall back to default, not crash."""
+    with mock.patch.dict(os.environ, {"COMPACTION_TRIGGER_COUNT": "abc"}):
+        import importlib
+        import marm_mcp_server.config.settings as settings_mod
+
+        importlib.reload(settings_mod)
+        assert settings_mod.COMPACTION_TRIGGER_COUNT == 5  # default
+
+
+def test_malformed_float_env_falls_back_to_default():
+    """Malformed float env var should fall back to default, not crash."""
+    with mock.patch.dict(os.environ, {"CONSOLIDATION_THRESHOLD": "not_a_number"}):
+        import importlib
+        import marm_mcp_server.config.settings as settings_mod
+
+        importlib.reload(settings_mod)
+        assert settings_mod.CONSOLIDATION_THRESHOLD == 0.92  # default
+
+
+def test_consolidation_threshold_clamped_to_unit_range():
+    """CONSOLIDATION_THRESHOLD > 1.0 should be clamped to [0, 1]."""
+    with mock.patch.dict(os.environ, {"CONSOLIDATION_THRESHOLD": "1.5"}):
+        import importlib
+        import marm_mcp_server.config.settings as settings_mod
+
+        importlib.reload(settings_mod)
+        assert settings_mod.CONSOLIDATION_THRESHOLD == 1.0

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -306,3 +306,96 @@ async def test_recall_similar_fts_failure_degrades_gracefully_to_vector_only(
     )
 
     assert isinstance(results, list)
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_debug_logs_source_lane_breakdown(monkeypatch, tmp_path):
+    from marm_mcp_server.core import memory as memory_module
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = False
+
+    vec_only_id = "vec-only"
+    both_id = "both"
+    fts_only_id = "fts-only"
+
+    query_vec = np.zeros(384, dtype=np.float32)
+    query_vec[0] = 1.0
+
+    vector_rows = [
+        (
+            {
+                "id": vec_only_id,
+                "session_name": "debug-lanes",
+                "content": "vector only memory",
+                "timestamp": "2026-01-01T00:00:01Z",
+                "context_type": "general",
+                "metadata": "{}",
+            },
+            0.9,
+        ),
+        (
+            {
+                "id": both_id,
+                "session_name": "debug-lanes",
+                "content": "shared keyword memory",
+                "timestamp": "2026-01-01T00:00:02Z",
+                "context_type": "general",
+                "metadata": "{}",
+            },
+            0.8,
+        ),
+    ]
+
+    fts_rows = [
+        (
+            {
+                "id": both_id,
+                "session_name": "debug-lanes",
+                "content": "shared keyword memory",
+                "timestamp": "2026-01-01T00:00:02Z",
+                "context_type": "general",
+                "metadata": "{}",
+            },
+            0.9,
+        ),
+        (
+            {
+                "id": fts_only_id,
+                "session_name": "debug-lanes",
+                "content": "shared keyword no embedding",
+                "timestamp": "2026-01-01T00:00:03Z",
+                "context_type": "general",
+                "metadata": "{}",
+            },
+            0.7,
+        ),
+    ]
+
+    monkeypatch.setattr(memory_module, "_RECALL_DEBUG", True)
+    monkeypatch.setitem(
+        memory.recall_similar.__func__.__globals__,
+        "_fetch_and_score_embedding_rows",
+        lambda *_: (vector_rows, 0, False),
+    )
+    monkeypatch.setitem(
+        memory.recall_similar.__func__.__globals__,
+        "_fetch_and_score_fts_rows",
+        lambda *_: fts_rows,
+    )
+
+    debug_lines: list[str] = []
+    monkeypatch.setattr(memory_module, "_safe_print", debug_lines.append)
+
+    results = await memory.recall_similar(
+        "shared keyword",
+        session="debug-lanes",
+        limit=5,
+        query_vec=query_vec,
+    )
+
+    assert {r["id"] for r in results} == {vec_only_id, both_id, fts_only_id}
+    assert any(
+        "candidates: 3 total | vec+fts=1, vec-only=1, fts-only=1" in line
+        for line in debug_lines
+    )


### PR DESCRIPTION
## Summary

Addresses both #53 (config safety) and #50 (recall observability).

### Issue #53 — Config Safety

Applied `max()`/`min()` clamping to all settings, matching the existing pattern used by `HYBRID_SEARCH_TEXT_WEIGHT`. Added stderr warnings when values are clamped out of range. Settings covered: `CONSOLIDATION_THRESHOLD`, `COMPACTION_SIMILARITY_THRESHOLD`, `SERVER_PORT`, all compaction parameters, rate limits, queue sizes.

### Issue #50 — Recall Observability

Added `MARM_RECALL_DEBUG` env flag (default off) for lightweight debug logging to stderr:
- Which recall lane answered (semantic model fallback, vector candidates, FTS hybrid hits)
- Final result breakdown: vec+fts / vec-only / fts-only
- Text-search path: FTS5 vs LIKE fallback
- Semantic search exceptions triggering fallback

All output goes to stderr (STDIO transport safe). No new MCP tools added.

Closes #53, Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server numeric settings now safely parse, validate and clamp to allowed ranges (ports, rate/window/block/queue/recall limits, compaction thresholds, search weights, etc.) and emit warnings when values are adjusted.

* **New Features**
  * Optional environment-controlled debug logging for semantic and text recall/search flows to surface fallback and candidate-selection details to stderr.

* **Tests**
  * Added tests verifying config parsing safety, clamping, and malformed-value fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->