### PR TITLE
feat(recall): ship filter-rerank hybrid recall

### DIFF
--- a/.github/workflows/discord-announcements.yml
+++ b/.github/workflows/discord-announcements.yml
@@ -33,7 +33,9 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import sys
           import urllib.request
+          import urllib.error
 
           payload = {
               "username": "MARM Releases",
@@ -64,5 +66,12 @@ jobs:
               data=json.dumps(payload).encode("utf-8"),
               headers={"Content-Type": "application/json"},
           )
-          urllib.request.urlopen(req).read()
+          try:
+              urllib.request.urlopen(req).read()
+          except urllib.error.HTTPError as exc:
+              print(f"Discord webhook post failed: HTTP {exc.code} {exc.reason}", file=sys.stderr)
+              sys.exit(0)
+          except urllib.error.URLError as exc:
+              print(f"Discord webhook post failed: {exc}", file=sys.stderr)
+              sys.exit(0)
           PY

--- a/.github/workflows/discord-get-involved.yml
+++ b/.github/workflows/discord-get-involved.yml
@@ -31,10 +31,12 @@ jobs:
           ACTION_NAME: ${{ github.event.action }}
           REPO: ${{ github.repository }}
           ACTOR: ${{ github.actor }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_MERGED: ${{ github.event.pull_request.merged }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -45,9 +47,20 @@ jobs:
           import os
           import sys
           import urllib.request
+          import urllib.error
 
           event_name = os.environ["EVENT_NAME"]
           action_name = os.environ["ACTION_NAME"]
+          pr_author = os.environ.get("PR_AUTHOR", "")
+          issue_author = os.environ.get("ISSUE_AUTHOR", "")
+
+          # Dependabot version-update PRs are useful to merge, but not useful to broadcast.
+          if event_name == "pull_request" and pr_author == "dependabot[bot]":
+              sys.exit(0)
+
+          # Future-proofing in case other issue-producing bots get wired into this feed.
+          if event_name == "issues" and issue_author.endswith("[bot]"):
+              sys.exit(0)
 
           payload = None
 
@@ -131,5 +144,13 @@ jobs:
               data=json.dumps(payload).encode("utf-8"),
               headers={"Content-Type": "application/json"},
           )
-          urllib.request.urlopen(req).read()
+          try:
+              urllib.request.urlopen(req).read()
+          except urllib.error.HTTPError as exc:
+              # Discord posting is informational only; don't fail the GitHub event workflow.
+              print(f"Discord webhook post failed: HTTP {exc.code} {exc.reason}", file=sys.stderr)
+              sys.exit(0)
+          except urllib.error.URLError as exc:
+              print(f"Discord webhook post failed: {exc}", file=sys.stderr)
+              sys.exit(0)
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>June 15th, 2026: Filter→Re-rank Recall Refactor (v2.13.0)</strong></summary>
+
+### Recall Performance & Search Strategy
+
+- Replaced weighted-fusion hybrid recall with an FTS-first filter→semantic re-rank path in `recall_similar()`: FTS5 BM25 now narrows recall to a bounded candidate set first, then semantic cosine scoring reranks only those candidates instead of scanning the full embedding lane on every keyword-rich query.
+- Added `FTS_CANDIDATE_LIMIT` (default `50`) as the new cap controlling how many FTS candidates are fetched before semantic reranking; bounded semantic fallback remains in place for abstract queries, malformed/weak FTS coverage, and unscoreable candidate sets.
+- Preserved temporal weighting, response shape, and bounded-recall metadata while changing `recall_scan_truncated` semantics so it only reflects the semantic fallback lane rather than the primary filter→rerank path.
+
+### Test Coverage
+
+- Reworked hybrid recall tests around the new architecture: filter→rerank success, semantic fallback on empty FTS, fallback on missing/unscoreable candidates, wrong-dimension candidate handling, candidate-cap enforcement, and scan-metadata behavior.
+
+</details>
+
+<details>
 <summary><strong>June 9th, 2026: Discord Community Ops & Webhook Automation (v2.12.1)</strong></summary>
 
 ### Discord Community Operations

--- a/MCP-HANDBOOK.md
+++ b/MCP-HANDBOOK.md
@@ -235,7 +235,7 @@ Result: Decision logged and searchable by all future AI clients
 
 ### How Memory Works
 
-MARM uses **hybrid recall**. Semantic embeddings cover meaning, FTS5 BM25 covers exact terms like config keys, commands, filenames, and error strings, and a conservative temporal weighting step gives fresher memories a modest boost when matches are otherwise close:
+MARM uses **filter→rerank hybrid recall**. FTS5 BM25 handles exact terms like config keys, commands, filenames, and error strings first, semantic embeddings rerank that bounded candidate set by meaning, and a conservative temporal weighting step gives fresher memories a modest boost when matches are otherwise close. When FTS coverage is weak or unusable, MARM falls back to the existing bounded semantic scan:
 
 ```txt
 User: "I discussed machine learning algorithms yesterday"
@@ -267,7 +267,7 @@ MARM automatically categorizes content:
 
 | Category | Tool | Description | Usage Notes |
 |----------|------|-------------|-------------|
-| **🧠 Memory** | `marm_smart_recall` | Hybrid recall across all memories using semantic embeddings plus FTS keyword/BM25 matching, with a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`). Use natural language queries or exact keys/commands |
+| **🧠 Memory** | `marm_smart_recall` | FTS-first filter→semantic rerank across all memories, with bounded semantic fallback and a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`). Use natural language queries or exact keys/commands |
 | | `marm_context_log` | Auto-classifying memory storage with embeddings | Store important information that should be remembered |
 | **📚 Logging** | `marm_log_session` | Create or switch to named session container | Include LLM name, dates, be descriptive |
 | | `marm_log_entry` | Add structured log entry with auto-date formatting | Use structured entries for best results; date-prefixed formats are parsed automatically when provided |
@@ -316,7 +316,8 @@ The write queue is enabled by default and serializes memory writes through one i
 **Layered Recall Depth**: `detail=1` returns a short summary view (~200 chars), `detail=2` returns a larger context view (~500 chars), and `detail=3` returns full memory content.
 **Recency Bias**: MARM blends a small temporal score into final ranking so newer operational context wins tie-like matches more often without hiding clearly stronger older memories.
 **Temporal Search**: Include timeframes in queries
-**Bounded Recall Signal**: If `marm_smart_recall` returns `recall_scan_truncated=true`, the semantic embedding scan hit `RECALL_SCAN_LIMIT`; narrow the session/query or raise the env var for larger stores. FTS recall still runs alongside it.
+**Bounded Recall Signal**: If `marm_smart_recall` returns `recall_scan_truncated=true`, the semantic fallback lane hit `RECALL_SCAN_LIMIT`; narrow the session/query or raise the env var for larger stores. The primary filter→rerank lane does not set truncation because it scores a bounded FTS candidate set instead of scanning the full embedding pool.
+**FTS Candidate Cap**: `FTS_CANDIDATE_LIMIT` (default `50`) controls how many BM25 candidates are fetched before semantic reranking. Raise it if your store has weak keyword overlap and you want a wider rerank pool.
 
 ### Workflow Optimization
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The point is not "more tools." MARM exposes **9 focused MCP tools** and moves th
 |-------|--------------|----------------|
 | **Memory model** | Sessions, structured logs, notebooks, summaries, and semantic memories | Keeps project history searchable instead of trapped in one chat |
 | **Scale layer** | SQLite WAL mode, connection pooling, serialized write queue, and HTTP rate-limit presets | Lets one server support solo use, multi-agent work, and swarm-style bursts |
-| **Intelligence layer** | Hybrid semantic + FTS recall, auto-classification, write-time consolidation, and compaction candidates | Keeps recall useful as memory grows instead of letting duplicates pile up |
+| **Intelligence layer** | FTS filter→semantic rerank, bounded semantic fallback, auto-classification, write-time consolidation, and compaction candidates | Keeps recall useful as memory grows instead of letting duplicates pile up |
 | **Deployment layer** | Pip, Docker, STDIO, HTTP, `--swarm`, `--swarm-max`, and `--trusted` | Lets you run private local memory or shared multi-agent memory with the same MCP surface |
 
 ### MARM Demo
@@ -241,7 +241,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 | **Category** | **Tool** | **Description** |
 |--------------|----------|-----------------|
-| **Memory Intelligence** | `marm_smart_recall` | AI-powered hybrid recall across all memories. Combines semantic embeddings with FTS keyword/BM25 matching, applies a conservative recency bias when scores are close, supports global search with `search_all=True`, and can return summary/context/full memory depth with `detail=1/2/3` |
+| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically reranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, supports global search with `search_all=True`, and can return summary/context/full memory depth with `detail=1/2/3` |
 | | `marm_context_log` | Intelligent auto-classifying memory storage using vector embeddings |
 | **Logging System** | `marm_log_session` | Create or switch to named session container |
 | | `marm_log_entry` | Add structured log entry with auto-date formatting |
@@ -259,7 +259,7 @@ MARM keeps the AI-facing surface small while the server handles the infrastructu
 
 - **Write stability:** SQLite WAL mode, connection pooling, and a serialized write queue are enabled for normal use.
 - **Swarm control:** HTTP presets tune shared access: default `80 RPM`, `--swarm` `200 RPM`, `--swarm-max` `600 RPM`, and `--trusted` disables rate limiting for private deployments.
-- **Cleaner recall:** hybrid semantic + FTS recall, conservative temporal weighting, write-time consolidation, and optional compaction reduce duplicate/noisy memories over time.
+- **Cleaner recall:** FTS filter→semantic rerank, bounded semantic fallback, conservative temporal weighting, write-time consolidation, and optional compaction reduce duplicate/noisy memories over time.
 - **Lower token burn:** `marm_smart_recall` can return summary, context, or full-memory depth so agents do not pull full bodies unless they need them.
 - **Safe defaults:** local pip binds to `127.0.0.1`; Docker HTTP requires `MARM_API_KEY`; STDIO stays private and keyless.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -26,7 +26,7 @@ MARM Systems is a persistent memory layer for AI agents. The MCP server gives Cl
 | **Sharing** | Hard to move between tools | Multiple agents can use the same memory store |
 | **Trust model** | Memory behavior varies by provider | Retrieved memory is context, not higher-priority instruction |
 
-MARM uses hybrid recall rather than simple keyword matching alone. Semantic embeddings find related memories when the wording differs, and FTS keyword/BM25 search improves exact recall for commands, config keys, filenames, and error text.
+MARM uses filter→rerank hybrid recall rather than simple keyword matching alone. FTS keyword/BM25 search narrows exact-term candidates first, semantic embeddings rerank that bounded set by meaning, and a bounded semantic fallback keeps abstract queries working when keyword coverage is weak.
 
 ### Q: Who is MARM for?
 
@@ -122,7 +122,7 @@ Your AI client can still run, but MARM memory tools will be unavailable until th
 
 #### Q: How does recall work?
 
-MARM uses hybrid recall. Embeddings find memories by meaning, FTS keyword/BM25 search handles exact terms, and a conservative temporal weighting step gives newer memories a modest boost when scores are otherwise close. A search for "authentication error" can surface memories about login failures, access denial, token setup, or user verification even when those exact words are not repeated, while a search for something like `COMPACTION_TRIGGER_COUNT` or a Docker command can hit the exact stored text reliably.
+MARM uses filter→rerank hybrid recall. FTS keyword/BM25 search handles exact terms first, semantic embeddings rerank those candidates by meaning, and a conservative temporal weighting step gives newer memories a modest boost when scores are otherwise close. If FTS returns no useful candidate path, MARM falls back to the existing bounded semantic recall lane. A search for "authentication error" can surface memories about login failures, access denial, token setup, or user verification even when those exact words are not repeated, while a search for something like `COMPACTION_TRIGGER_COUNT` or a Docker command can hit the exact stored text reliably.
 
 #### Q: How does auto-classification work?
 
@@ -132,7 +132,9 @@ When you store memory through `marm_context_log`, MARM classifies content into b
 
 Both. `marm_smart_recall` searches one session by default and can search across all sessions with `search_all=True`.
 
-When the semantic embedding lane reaches its configured scan cap, responses include `recall_scan_truncated=true` and `recall_scan_limit` so agents know that part of recall was bounded. Exact-term FTS recall still runs alongside it.
+When the semantic fallback lane reaches its configured scan cap, responses include `recall_scan_truncated=true` and `recall_scan_limit` so agents know that part of recall was bounded. The primary filter→rerank lane does not set truncation because it works over a fixed FTS candidate set instead of a broad embedding scan.
+
+`FTS_CANDIDATE_LIMIT` (default `50`) controls how many FTS candidates are fetched before semantic reranking. Most users should leave it alone unless their memory store has weak keyword overlap and they want a wider rerank pool.
 
 If you need less context back from each hit, `marm_smart_recall` also supports `detail=1/2/3` so agents can default to short previews and only request full memory bodies when needed.
 

--- a/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
+++ b/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
@@ -235,7 +235,7 @@ Result: Decision logged and searchable by all future AI clients
 
 ### How Memory Works
 
-MARM uses **hybrid recall**. Semantic embeddings cover meaning, FTS5 BM25 covers exact terms like config keys, commands, filenames, and error strings, and a conservative temporal weighting step gives fresher memories a modest boost when matches are otherwise close:
+MARM uses **filter→rerank hybrid recall**. FTS5 BM25 handles exact terms like config keys, commands, filenames, and error strings first, semantic embeddings rerank that bounded candidate set by meaning, and a conservative temporal weighting step gives fresher memories a modest boost when matches are otherwise close. When FTS coverage is weak or unusable, MARM falls back to the existing bounded semantic scan:
 
 ```txt
 User: "I discussed machine learning algorithms yesterday"
@@ -267,7 +267,7 @@ MARM automatically categorizes content:
 
 | Category | Tool | Description | Usage Notes |
 |----------|------|-------------|-------------|
-| **🧠 Memory** | `marm_smart_recall` | Hybrid recall across all memories using semantic embeddings plus FTS keyword/BM25 matching, with a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`). Use natural language queries or exact keys/commands |
+| **🧠 Memory** | `marm_smart_recall` | FTS-first filter→semantic rerank across all memories, with bounded semantic fallback and a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`). Use natural language queries or exact keys/commands |
 | | `marm_context_log` | Auto-classifying memory storage with embeddings | Store important information that should be remembered |
 | **📚 Logging** | `marm_log_session` | Create or switch to named session container | Include LLM name, dates, be descriptive |
 | | `marm_log_entry` | Add structured log entry with auto-date formatting | Use structured entries for best results; date-prefixed formats are parsed automatically when provided |
@@ -316,7 +316,8 @@ The write queue is enabled by default and serializes memory writes through one i
 **Layered Recall Depth**: `detail=1` returns a short summary view (~200 chars), `detail=2` returns a larger context view (~500 chars), and `detail=3` returns full memory content.
 **Recency Bias**: MARM blends a small temporal score into final ranking so newer operational context wins tie-like matches more often without hiding clearly stronger older memories.
 **Temporal Search**: Include timeframes in queries
-**Bounded Recall Signal**: If `marm_smart_recall` returns `recall_scan_truncated=true`, the semantic embedding scan hit `RECALL_SCAN_LIMIT`; narrow the session/query or raise the env var for larger stores. FTS recall still runs alongside it.
+**Bounded Recall Signal**: If `marm_smart_recall` returns `recall_scan_truncated=true`, the semantic fallback lane hit `RECALL_SCAN_LIMIT`; narrow the session/query or raise the env var for larger stores. The primary filter→rerank lane does not set truncation because it scores a bounded FTS candidate set instead of scanning the full embedding pool.
+**FTS Candidate Cap**: `FTS_CANDIDATE_LIMIT` (default `50`) controls how many BM25 candidates are fetched before semantic reranking. Raise it if your store has weak keyword overlap and you want a wider rerank pool.
 
 ### Workflow Optimization
 

--- a/marm-mcp-server/marm-docs/README.md
+++ b/marm-mcp-server/marm-docs/README.md
@@ -25,7 +25,7 @@ The point is not "more tools." MARM exposes **9 focused MCP tools** and moves th
 |-------|--------------|----------------|
 | **Memory model** | Sessions, structured logs, notebooks, summaries, and semantic memories | Keeps project history searchable instead of trapped in one chat |
 | **Scale layer** | SQLite WAL mode, connection pooling, serialized write queue, and HTTP rate-limit presets | Lets one server support solo use, multi-agent work, and swarm-style bursts |
-| **Intelligence layer** | Hybrid semantic + FTS recall, auto-classification, write-time consolidation, and compaction candidates | Keeps recall useful as memory grows instead of letting duplicates pile up |
+| **Intelligence layer** | FTS filter→semantic rerank, bounded semantic fallback, auto-classification, write-time consolidation, and compaction candidates | Keeps recall useful as memory grows instead of letting duplicates pile up |
 | **Deployment layer** | Pip, Docker, STDIO, HTTP, `--swarm`, `--swarm-max`, and `--trusted` | Lets you run private local memory or shared multi-agent memory with the same MCP surface |
 
 ### Start Now (pip)
@@ -189,7 +189,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 | **Category** | **Tool** | **Description** |
 |--------------|----------|-----------------|
-| **Memory Intelligence** | `marm_smart_recall` | AI-powered hybrid recall across all memories. Combines semantic embeddings with FTS keyword/BM25 matching, applies a conservative recency bias when scores are close, supports global search with `search_all=True`, and can return summary/context/full memory depth with `detail=1/2/3` |
+| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically reranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, supports global search with `search_all=True`, and can return summary/context/full memory depth with `detail=1/2/3` |
 | | `marm_context_log` | Intelligent auto-classifying memory storage using vector embeddings |
 | **Logging System** | `marm_log_session` | Create or switch to named session container |
 | | `marm_log_entry` | Add structured log entry with auto-date formatting |
@@ -207,7 +207,7 @@ MARM keeps the AI-facing surface small while the server handles the infrastructu
 
 - **Write stability:** SQLite WAL mode, connection pooling, and a serialized write queue are enabled for normal use.
 - **Swarm control:** HTTP presets tune shared access: default `80 RPM`, `--swarm` `200 RPM`, `--swarm-max` `600 RPM`, and `--trusted` disables rate limiting for private deployments.
-- **Cleaner recall:** hybrid semantic + FTS recall, conservative temporal weighting, write-time consolidation, and optional compaction reduce duplicate/noisy memories over time.
+- **Cleaner recall:** FTS filter→semantic rerank, bounded semantic fallback, conservative temporal weighting, write-time consolidation, and optional compaction reduce duplicate/noisy memories over time.
 - **Lower token burn:** `marm_smart_recall` can return summary, context, or full-memory depth so agents do not pull full bodies unless they need them.
 - **Safe defaults:** local pip binds to `127.0.0.1`; Docker HTTP requires `MARM_API_KEY`; STDIO stays private and keyless.
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -172,6 +172,8 @@ if _raw_hld < 1.0:
         file=sys.stderr,
     )
 
+FTS_CANDIDATE_LIMIT = _safe_int("FTS_CANDIDATE_LIMIT", 50)
+
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
 _raw_ct = _safe_float("CONSOLIDATION_THRESHOLD", 0.92)
 CONSOLIDATION_THRESHOLD = max(0.0, min(1.0, _raw_ct))

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -172,7 +172,13 @@ if _raw_hld < 1.0:
         file=sys.stderr,
     )
 
-FTS_CANDIDATE_LIMIT = _safe_int("FTS_CANDIDATE_LIMIT", 50)
+_raw_fcl = _safe_int("FTS_CANDIDATE_LIMIT", 50)
+FTS_CANDIDATE_LIMIT = max(1, _raw_fcl)
+if _raw_fcl < 1:
+    print(
+        f"WARNING: FTS_CANDIDATE_LIMIT={_raw_fcl} below minimum 1, clamped to {FTS_CANDIDATE_LIMIT}",
+        file=sys.stderr,
+    )
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
 _raw_ct = _safe_float("CONSOLIDATION_THRESHOLD", 0.92)

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -284,7 +284,9 @@ def _fetch_and_score_by_ids(
         ).fetchall()
     finally:
         conn.close()
-    similarities, dim_skipped = _score_embedding_rows(memories, query_embedding, len(memory_ids))
+    similarities, dim_skipped = _score_embedding_rows(
+        memories, query_embedding, len(memory_ids)
+    )
     return similarities, dim_skipped
 
 
@@ -300,7 +302,6 @@ from ..config.settings import (  # noqa: E402
     COMPACTION_ENABLED,
     COMPACTION_TRIGGER_COUNT,
     RECALL_SCAN_LIMIT,
-    HYBRID_SEARCH_TEXT_WEIGHT,
     TEMPORAL_WEIGHT,
     TEMPORAL_HALF_LIFE_DAYS,
     FTS_CANDIDATE_LIMIT,
@@ -1023,11 +1024,15 @@ class MARMMemory:
                         self.db_path,
                         session,
                         fts_query,
-                        FTS_CANDIDATE_LIMIT,
+                        max(limit, FTS_CANDIDATE_LIMIT),
                     )
-                    _recall_debug(f"FTS filter: {len(candidate_ids)} candidates for '{fts_query}'")
+                    _recall_debug(
+                        f"FTS filter: {len(candidate_ids)} candidates for '{fts_query}'"
+                    )
                 except Exception as e:
-                    _safe_print(f"FTS5 filter failed, falling back to bounded semantic recall: {e}")
+                    _safe_print(
+                        f"FTS5 filter failed, falling back to bounded semantic recall: {e}"
+                    )
                     _recall_debug("FTS filter failed → semantic fallback")
 
             use_semantic_fallback = True
@@ -1041,9 +1046,13 @@ class MARMMemory:
                 if similarities:
                     scan_truncated = False
                     use_semantic_fallback = False
-                    _recall_debug(f"filter->rerank: scored {len(similarities)} candidates")
+                    _recall_debug(
+                        f"filter->rerank: scored {len(similarities)} candidates"
+                    )
                 else:
-                    _recall_debug("filter->rerank: no scoreable embeddings in FTS candidates, falling back to semantic scan")
+                    _recall_debug(
+                        "filter->rerank: no scoreable embeddings in FTS candidates, falling back to semantic scan"
+                    )
 
             if use_semantic_fallback:
                 similarities, dim_skipped, scan_truncated = await asyncio.to_thread(

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -228,6 +228,66 @@ def _fetch_and_score_fts_rows(
     return list(zip(rows, normalized))
 
 
+def _fetch_fts_candidate_ids(
+    db_path: str,
+    session: str | None,
+    fts_query: str,
+    limit: int,
+) -> list[str]:
+    """Return top N memory IDs from FTS5 by BM25 rank. No scoring needed."""
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        base = """
+            SELECT m.id
+            FROM memories_fts
+            JOIN memories m ON memories_fts.rowid = m.rowid
+            WHERE memories_fts MATCH ?
+              AND (m.compaction_role IS NULL OR m.compaction_role != 'source')
+        """
+        params: list = [fts_query]
+        if session is not None:
+            base += " AND m.session_name = ?"
+            params.append(session)
+        base += " ORDER BY bm25(memories_fts) LIMIT ?"
+        params.append(limit)
+        rows = conn.execute(base, params).fetchall()
+        return [row[0] for row in rows]
+    finally:
+        conn.close()
+
+
+def _fetch_and_score_by_ids(
+    db_path: str,
+    memory_ids: list[str],
+    query_embedding,
+) -> tuple[list[tuple], int]:
+    """Fetch specific memories by ID and score their embeddings.
+
+    Returns (similarities, dim_skipped). No scan_truncated -- ID-bounded
+    fetch has no truncation concept.
+    """
+    if not memory_ids:
+        return [], 0
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    try:
+        conn.row_factory = sqlite3.Row
+        placeholders = ",".join("?" * len(memory_ids))
+        memories = conn.execute(
+            f"""
+            SELECT id, session_name, content, embedding, timestamp, context_type, metadata
+            FROM memories
+            WHERE id IN ({placeholders})
+              AND embedding IS NOT NULL
+              AND (compaction_role IS NULL OR compaction_role != 'source')
+            """,
+            memory_ids,
+        ).fetchall()
+    finally:
+        conn.close()
+    similarities, dim_skipped = _score_embedding_rows(memories, query_embedding, len(memory_ids))
+    return similarities, dim_skipped
+
+
 from ..config.settings import (  # noqa: E402
     SEMANTIC_SEARCH_AVAILABLE,
     DEFAULT_DB_PATH,
@@ -243,6 +303,7 @@ from ..config.settings import (  # noqa: E402
     HYBRID_SEARCH_TEXT_WEIGHT,
     TEMPORAL_WEIGHT,
     TEMPORAL_HALF_LIFE_DAYS,
+    FTS_CANDIDATE_LIMIT,
 )
 from .consolidation import (  # noqa: E402
     compute_content_hash,
@@ -953,86 +1014,67 @@ class MARMMemory:
             else:
                 query_embedding = await asyncio.to_thread(self._encode_sync, query)
 
-            similarities, dim_skipped, scan_truncated = await asyncio.to_thread(
-                _fetch_and_score_embedding_rows,
-                self.db_path,
-                session,
-                scan_limit,
-                query_embedding,
-                limit,
-            )
+            fts_query = _safe_fts_query(query)
+            candidate_ids: list[str] = []
+            if fts_query:
+                try:
+                    candidate_ids = await asyncio.to_thread(
+                        _fetch_fts_candidate_ids,
+                        self.db_path,
+                        session,
+                        fts_query,
+                        FTS_CANDIDATE_LIMIT,
+                    )
+                    _recall_debug(f"FTS filter: {len(candidate_ids)} candidates for '{fts_query}'")
+                except Exception as e:
+                    _safe_print(f"FTS5 filter failed, falling back to bounded semantic recall: {e}")
+                    _recall_debug("FTS filter failed → semantic fallback")
+
+            use_semantic_fallback = True
+            if candidate_ids:
+                similarities, dim_skipped = await asyncio.to_thread(
+                    _fetch_and_score_by_ids,
+                    self.db_path,
+                    candidate_ids,
+                    query_embedding,
+                )
+                if similarities:
+                    scan_truncated = False
+                    use_semantic_fallback = False
+                    _recall_debug(f"filter->rerank: scored {len(similarities)} candidates")
+                else:
+                    _recall_debug("filter->rerank: no scoreable embeddings in FTS candidates, falling back to semantic scan")
+
+            if use_semantic_fallback:
+                similarities, dim_skipped, scan_truncated = await asyncio.to_thread(
+                    _fetch_and_score_embedding_rows,
+                    self.db_path,
+                    session,
+                    scan_limit,
+                    query_embedding,
+                    limit,
+                )
+                _recall_debug(
+                    f"semantic fallback: {len(similarities)} candidates, scan_truncated={scan_truncated}"
+                )
 
             if dim_skipped:
                 _safe_print(
                     f"recall_similar: skipped {dim_skipped} memories with wrong embedding dimension (expected {len(query_embedding)})"
                 )
 
-            _recall_debug(
-                f"vector lane returned {len(similarities)} candidates, scan_truncated={scan_truncated}"
-            )
-
-            fts_query = _safe_fts_query(query)
-            fts_hits: dict[str, tuple] = {}
-            if fts_query:
-                try:
-                    for row, fts_norm in await asyncio.to_thread(
-                        _fetch_and_score_fts_rows,
-                        self.db_path,
-                        session,
-                        fts_query,
-                        limit * 2,
-                    ):
-                        fts_hits[row["id"]] = (row, fts_norm)
-                    _recall_debug(
-                        f"FTS hybrid pass: {len(fts_hits)} hits for query '{fts_query}'"
-                    )
-                except Exception as e:
-                    _safe_print(f"FTS5 hybrid pass failed, using vector-only: {e}")
-                    _recall_debug("FTS hybrid pass failed → vector-only results")
-
             combined: dict[str, tuple] = {}
-            for mem, vec_norm in similarities:
-                mem_id = mem["id"]
-                fts_norm = fts_hits[mem_id][1] if mem_id in fts_hits else 0.0
-                hybrid = (
-                    1 - HYBRID_SEARCH_TEXT_WEIGHT
-                ) * vec_norm + HYBRID_SEARCH_TEXT_WEIGHT * fts_norm
+            for mem, vec_score in similarities:
                 t_score = _temporal_score(mem["timestamp"], TEMPORAL_HALF_LIFE_DAYS)
-                combined[mem_id] = (
+                combined[mem["id"]] = (
                     mem,
-                    (1 - TEMPORAL_WEIGHT) * hybrid + TEMPORAL_WEIGHT * t_score,
+                    (1 - TEMPORAL_WEIGHT) * vec_score + TEMPORAL_WEIGHT * t_score,
                 )
-            for mem_id, (fts_row, fts_norm) in fts_hits.items():
-                if mem_id not in combined:
-                    hybrid = HYBRID_SEARCH_TEXT_WEIGHT * fts_norm
-                    t_score = _temporal_score(
-                        fts_row["timestamp"], TEMPORAL_HALF_LIFE_DAYS
-                    )
-                    combined[mem_id] = (
-                        fts_row,
-                        (1 - TEMPORAL_WEIGHT) * hybrid + TEMPORAL_WEIGHT * t_score,
-                    )
 
-            # Observability: count results by source lane (before slicing)
-            vec_set = {m["id"] for m, _ in similarities}
-            fts_only_count = sum(
-                1 for mid in combined if mid not in vec_set and mid in fts_hits
-            )
-            both_count = sum(
-                1 for mid in combined if mid in vec_set and mid in fts_hits
-            )
-            _recall_debug(
-                f"candidates: {len(combined)} total | "
-                f"vec+fts={both_count}, vec-only={len(vec_set) - both_count}, "
-                f"fts-only={fts_only_count}"
-            )
-
-            similarities = sorted(combined.values(), key=lambda x: x[1], reverse=True)[
-                :limit
-            ]
+            ranked = sorted(combined.values(), key=lambda x: x[1], reverse=True)[:limit]
 
             results = []
-            for memory, similarity in similarities:
+            for memory, similarity in ranked:
                 results.append(
                     {
                         "id": memory["id"],

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -274,7 +274,7 @@ def _prune_call_counts() -> None:
     Also enforces hard cap when count grows too large.
     """
     # Prune sessions not in delivered set
-    delivered = set(_protocol_delivered_sessions.keys())
+    delivered = set(_protocol_delivered_sessions)
     stale = [k for k in _protocol_call_counts if k not in delivered]
     for k in stale:
         _protocol_call_counts.pop(k, None)

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -1,4 +1,6 @@
 import sqlite3
+import uuid as _uuid_module
+from datetime import datetime, timezone as _timezone
 
 import numpy as np
 import pytest
@@ -216,186 +218,329 @@ async def test_recall_text_search_session_filter_excludes_other_sessions(tmp_pat
     assert all(r["session_name"] == "alpha" for r in results)
 
 
-# --- recall_similar hybrid merge ---
+# --- recall_similar filter->rerank ---
+
+
+def _insert_with_embedding(conn, session: str, content: str, vec: np.ndarray) -> str:
+    """Insert a memory row directly with a pre-built embedding. Returns the memory ID."""
+    mem_id = str(_uuid_module.uuid4())
+    content_hash = f"{hash(content + mem_id)}"
+    ts = datetime.now(_timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO memories"
+        " (id, session_name, content, embedding, content_hash, timestamp, context_type, metadata)"
+        " VALUES (?, ?, ?, ?, ?, ?, 'general', '{}')",
+        (mem_id, session, content, vec.tobytes(), content_hash, ts),
+    )
+    return mem_id
 
 
 @pytest.mark.asyncio
-async def test_recall_similar_response_shape_unchanged_with_hybrid_path(tmp_path):
+async def test_recall_similar_response_shape_unchanged_with_filter_rerank(tmp_path):
     memory = MARMMemory(str(tmp_path / "memory.db"))
     memory._encoder_failed = True
 
-    await memory.store_memory("response shape check content", session="shape-test")
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
 
-    query_vec = np.zeros(384, dtype=np.float32)
+    with memory.get_connection() as conn:
+        _insert_with_embedding(conn, "shape-test", "response shape check content", vec)
+
     results = await memory.recall_similar(
-        "response shape", session="shape-test", limit=5, query_vec=query_vec
+        "response shape", session="shape-test", limit=5, query_vec=vec.copy()
     )
 
     assert isinstance(results, list)
     assert results
-    required = {
-        "id",
-        "session_name",
-        "content",
-        "timestamp",
-        "context_type",
-        "metadata",
-        "similarity",
-    }
+    required = {"id", "session_name", "content", "timestamp", "context_type", "metadata", "similarity"}
     assert required.issubset(results[0].keys())
 
 
 @pytest.mark.asyncio
-async def test_recall_similar_fts_only_hit_promoted_when_memory_has_no_embedding(
-    tmp_path,
-):
+async def test_recall_similar_filter_rerank_surfaces_keyword_matching_memory(tmp_path):
+    """FTS filter should surface the keyword-matching memory and rerank by embedding."""
     memory = MARMMemory(str(tmp_path / "memory.db"))
     memory._encoder_failed = True
 
-    # No embedding stored (encoder failed) — row only exists in FTS index
-    mem_id = await memory.store_memory(
-        "COMPACTION_TRIGGER_COUNT controls write threshold", session="fts-promo"
-    )
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
 
-    # Zero vector — no cosine matches; FTS5 should find and promote the row
-    query_vec = np.zeros(384, dtype=np.float32)
+    with memory.get_connection() as conn:
+        target_id = _insert_with_embedding(conn, "fts-rerank", "docker deployment config", vec)
+        _insert_with_embedding(conn, "fts-rerank", "unrelated content here", vec)
+
     results = await memory.recall_similar(
-        "COMPACTION_TRIGGER_COUNT", session="fts-promo", limit=5, query_vec=query_vec
+        "docker", session="fts-rerank", limit=5, query_vec=vec.copy()
     )
 
-    assert any(r["id"] == mem_id for r in results)
+    assert any(r["id"] == target_id for r in results)
 
 
 @pytest.mark.asyncio
-async def test_recall_similar_fts_only_score_is_in_valid_range(tmp_path):
+async def test_recall_similar_memory_without_embedding_excluded_from_results(tmp_path):
+    """Memories matching FTS but lacking an embedding cannot appear in results."""
     memory = MARMMemory(str(tmp_path / "memory.db"))
     memory._encoder_failed = True
 
-    await memory.store_memory("hybrid scoring content test", session="hybrid-score")
+    no_embed_id = await memory.store_memory(
+        "COMPACTION_TRIGGER_COUNT controls write threshold", session="no-embed-test"
+    )
 
     query_vec = np.zeros(384, dtype=np.float32)
     results = await memory.recall_similar(
-        "hybrid scoring", session="hybrid-score", limit=5, query_vec=query_vec
+        "COMPACTION_TRIGGER_COUNT", session="no-embed-test", limit=5, query_vec=query_vec
     )
 
+    assert no_embed_id not in {r["id"] for r in results}
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_similarity_scores_in_valid_range(tmp_path):
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    with memory.get_connection() as conn:
+        _insert_with_embedding(conn, "score-range", "hybrid scoring content test", vec)
+
+    results = await memory.recall_similar(
+        "hybrid scoring", session="score-range", limit=5, query_vec=vec.copy()
+    )
+
+    assert results
     for r in results:
-        assert 0.0 < r["similarity"] <= 1.0
+        assert 0.0 < r["similarity"] <= 1.0 + 1e-4
 
 
 @pytest.mark.asyncio
-async def test_recall_similar_fts_failure_degrades_gracefully_to_vector_only(
+async def test_recall_similar_falls_back_to_semantic_scan_when_fts_returns_no_candidates(
     monkeypatch, tmp_path
 ):
+    """Semantic fallback must return results when FTS finds no candidates."""
     from marm_mcp_server.core import memory as memory_module
 
     memory = MARMMemory(str(tmp_path / "memory.db"))
     memory._encoder_failed = True
 
-    await memory.store_memory("degradation test content", session="degrade")
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
 
-    def raise_operational_error(*args, **kwargs):
-        raise sqlite3.OperationalError("no such table: memories_fts")
+    with memory.get_connection() as conn:
+        embed_id = _insert_with_embedding(conn, "fallback-test", "semantic fallback content", vec)
 
-    monkeypatch.setattr(
-        memory_module, "_fetch_and_score_fts_rows", raise_operational_error
+    monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", lambda *_: [])
+
+    results = await memory.recall_similar(
+        "fallback content", session="fallback-test", limit=5, query_vec=vec.copy()
     )
 
-    query_vec = np.zeros(384, dtype=np.float32)
+    assert any(r["id"] == embed_id for r in results)
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_falls_back_when_fts_candidates_have_no_embeddings(
+    monkeypatch, tmp_path
+):
+    """When FTS candidates exist but none are scoreable, semantic fallback must run."""
+    from marm_mcp_server.core import memory as memory_module
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    with memory.get_connection() as conn:
+        embed_id = _insert_with_embedding(conn, "embed-fallback", "semantic content here", vec)
+
+    # Return a non-existent ID so ID-bounded fetch finds nothing scoreable
+    monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", lambda *_: ["non-existent-id"])
+
     results = await memory.recall_similar(
-        "degradation test", session="degrade", limit=5, query_vec=query_vec
+        "semantic content", session="embed-fallback", limit=5, query_vec=vec.copy()
+    )
+
+    assert any(r["id"] == embed_id for r in results)
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_falls_back_when_fts_candidates_are_all_wrong_dimension(
+    monkeypatch, tmp_path
+):
+    """When FTS returns a real ID whose embedding has the wrong dimension, all candidates
+    are dimension-skipped, similarities is empty, and semantic fallback must run."""
+    from marm_mcp_server.core import memory as memory_module
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    correct_dim = 384
+    wrong_dim = 768
+
+    correct_vec = np.ones(correct_dim, dtype=np.float32)
+    correct_vec /= np.linalg.norm(correct_vec)
+    wrong_vec = np.ones(wrong_dim, dtype=np.float32)
+    wrong_vec /= np.linalg.norm(wrong_vec)
+
+    with mem.get_connection() as conn:
+        # Wrong-dim row: FTS will be forced to return this ID
+        wrong_id = _insert_with_embedding(conn, "dim-fallback", "dimension mismatch content", wrong_vec)
+        # Correct-dim row: semantic fallback should find this
+        correct_id = _insert_with_embedding(conn, "dim-fallback", "dimension correct content", correct_vec)
+
+    # Force FTS to return only the wrong-dimension ID
+    monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", lambda *_: [wrong_id])
+
+    query_vec = correct_vec.copy()
+    results = await mem.recall_similar(
+        "dimension content", session="dim-fallback", limit=5, query_vec=query_vec
+    )
+
+    result_ids = {r["id"] for r in results}
+    assert wrong_id not in result_ids, "wrong-dimension FTS candidate must be skipped"
+    assert correct_id in result_ids, "semantic fallback must surface the correct-dimension memory"
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_respects_fts_candidate_limit(monkeypatch, tmp_path):
+    """Scorer must receive no more than FTS_CANDIDATE_LIMIT IDs even when FTS matches more."""
+    from marm_mcp_server.core import memory as memory_module
+
+    cap = 3
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    # Insert more memories than the cap, all matching keyword "canary"
+    with mem.get_connection() as conn:
+        for i in range(10):
+            _insert_with_embedding(conn, "cap-test", f"canary memory entry {i}", vec)
+
+    # Capture the IDs passed to the scorer
+    scored_ids: list[str] = []
+    original_scorer = memory_module._fetch_and_score_by_ids
+
+    def capturing_scorer(db_path, memory_ids, query_embedding):
+        scored_ids.extend(memory_ids)
+        return original_scorer(db_path, memory_ids, query_embedding)
+
+    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "FTS_CANDIDATE_LIMIT", cap)
+    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_fetch_and_score_by_ids", capturing_scorer)
+
+    await mem.recall_similar("canary", session="cap-test", limit=5, query_vec=vec.copy())
+
+    assert len(scored_ids) <= cap, (
+        f"scorer received {len(scored_ids)} IDs but FTS_CANDIDATE_LIMIT={cap}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_fts_filter_failure_falls_back_to_semantic_scan(
+    monkeypatch, tmp_path
+):
+    """An exception from _fetch_fts_candidate_ids must not crash recall."""
+    from marm_mcp_server.core import memory as memory_module
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    with memory.get_connection() as conn:
+        embed_id = _insert_with_embedding(conn, "fts-fail", "content for fts failure test", vec)
+
+    def raise_fts_error(*args, **kwargs):
+        raise sqlite3.OperationalError("no such table: memories_fts")
+
+    monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", raise_fts_error)
+
+    results = await memory.recall_similar(
+        "content", session="fts-fail", limit=5, query_vec=vec.copy()
     )
 
     assert isinstance(results, list)
+    assert any(r["id"] == embed_id for r in results)
 
 
 @pytest.mark.asyncio
-async def test_recall_similar_debug_logs_source_lane_breakdown(monkeypatch, tmp_path):
+async def test_recall_similar_scan_metadata_false_on_filter_rerank_path(tmp_path):
+    """scan_truncated must be False when filter->rerank handles the query."""
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    with memory.get_connection() as conn:
+        _insert_with_embedding(conn, "meta-rerank", "docker deployment content", vec)
+
+    _results, meta = await memory.recall_similar(
+        "docker", session="meta-rerank", limit=5, query_vec=vec.copy(),
+        include_scan_metadata=True,
+    )
+
+    assert meta["recall_scan_truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_recall_similar_debug_logs_filter_rerank_path(monkeypatch, tmp_path):
+    """Debug output must identify the filter->rerank path when FTS finds scoreable candidates."""
     from marm_mcp_server.core import memory as memory_module
 
-    memory = MARMMemory(str(tmp_path / "memory.db"))
-    memory._encoder_failed = False
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
 
-    vec_only_id = "vec-only"
-    both_id = "both"
-    fts_only_id = "fts-only"
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
 
-    query_vec = np.zeros(384, dtype=np.float32)
-    query_vec[0] = 1.0
+    with mem.get_connection() as conn:
+        embed_id = _insert_with_embedding(conn, "debug-rerank", "docker deployment debug", vec)
 
-    vector_rows = [
-        (
-            {
-                "id": vec_only_id,
-                "session_name": "debug-lanes",
-                "content": "vector only memory",
-                "timestamp": "2026-01-01T00:00:01Z",
-                "context_type": "general",
-                "metadata": "{}",
-            },
-            0.9,
-        ),
-        (
-            {
-                "id": both_id,
-                "session_name": "debug-lanes",
-                "content": "shared keyword memory",
-                "timestamp": "2026-01-01T00:00:02Z",
-                "context_type": "general",
-                "metadata": "{}",
-            },
-            0.8,
-        ),
-    ]
+    debug_calls: list[str] = []
+    # setitem on __globals__ is the reliable way to patch names a method resolves at call time
+    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_recall_debug", debug_calls.append)
+    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_fetch_fts_candidate_ids", lambda *_: [embed_id])
 
-    fts_rows = [
-        (
-            {
-                "id": both_id,
-                "session_name": "debug-lanes",
-                "content": "shared keyword memory",
-                "timestamp": "2026-01-01T00:00:02Z",
-                "context_type": "general",
-                "metadata": "{}",
-            },
-            0.9,
-        ),
-        (
-            {
-                "id": fts_only_id,
-                "session_name": "debug-lanes",
-                "content": "shared keyword no embedding",
-                "timestamp": "2026-01-01T00:00:03Z",
-                "context_type": "general",
-                "metadata": "{}",
-            },
-            0.7,
-        ),
-    ]
-
-    monkeypatch.setattr(memory_module, "_RECALL_DEBUG", True)
-    monkeypatch.setitem(
-        memory.recall_similar.__func__.__globals__,
-        "_fetch_and_score_embedding_rows",
-        lambda *_: (vector_rows, 0, False),
-    )
-    monkeypatch.setitem(
-        memory.recall_similar.__func__.__globals__,
-        "_fetch_and_score_fts_rows",
-        lambda *_: fts_rows,
+    await mem.recall_similar(
+        "docker", session="debug-rerank", limit=5, query_vec=vec.copy()
     )
 
-    debug_lines: list[str] = []
-    monkeypatch.setattr(memory_module, "_safe_print", debug_lines.append)
+    assert any("filter->rerank" in msg for msg in debug_calls)
 
-    results = await memory.recall_similar(
-        "shared keyword",
-        session="debug-lanes",
-        limit=5,
-        query_vec=query_vec,
+
+@pytest.mark.asyncio
+async def test_recall_similar_debug_logs_semantic_fallback_path(monkeypatch, tmp_path):
+    """Debug output must identify the semantic fallback path when FTS finds no candidates."""
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    dim = 384
+    vec = np.ones(dim, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    with mem.get_connection() as conn:
+        _insert_with_embedding(conn, "debug-fallback", "semantic fallback debug content", vec)
+
+    debug_calls: list[str] = []
+    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_recall_debug", debug_calls.append)
+    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_fetch_fts_candidate_ids", lambda *_: [])
+
+    await mem.recall_similar(
+        "fallback debug", session="debug-fallback", limit=5, query_vec=vec.copy()
     )
 
-    assert {r["id"] for r in results} == {vec_only_id, both_id, fts_only_id}
-    assert any(
-        "candidates: 3 total | vec+fts=1, vec-only=1, fts-only=1" in line
-        for line in debug_lines
-    )
+    assert any("semantic fallback" in msg for msg in debug_calls)

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -253,7 +253,15 @@ async def test_recall_similar_response_shape_unchanged_with_filter_rerank(tmp_pa
 
     assert isinstance(results, list)
     assert results
-    required = {"id", "session_name", "content", "timestamp", "context_type", "metadata", "similarity"}
+    required = {
+        "id",
+        "session_name",
+        "content",
+        "timestamp",
+        "context_type",
+        "metadata",
+        "similarity",
+    }
     assert required.issubset(results[0].keys())
 
 
@@ -268,7 +276,9 @@ async def test_recall_similar_filter_rerank_surfaces_keyword_matching_memory(tmp
     vec /= np.linalg.norm(vec)
 
     with memory.get_connection() as conn:
-        target_id = _insert_with_embedding(conn, "fts-rerank", "docker deployment config", vec)
+        target_id = _insert_with_embedding(
+            conn, "fts-rerank", "docker deployment config", vec
+        )
         _insert_with_embedding(conn, "fts-rerank", "unrelated content here", vec)
 
     results = await memory.recall_similar(
@@ -290,7 +300,10 @@ async def test_recall_similar_memory_without_embedding_excluded_from_results(tmp
 
     query_vec = np.zeros(384, dtype=np.float32)
     results = await memory.recall_similar(
-        "COMPACTION_TRIGGER_COUNT", session="no-embed-test", limit=5, query_vec=query_vec
+        "COMPACTION_TRIGGER_COUNT",
+        session="no-embed-test",
+        limit=5,
+        query_vec=query_vec,
     )
 
     assert no_embed_id not in {r["id"] for r in results}
@@ -332,7 +345,9 @@ async def test_recall_similar_falls_back_to_semantic_scan_when_fts_returns_no_ca
     vec /= np.linalg.norm(vec)
 
     with memory.get_connection() as conn:
-        embed_id = _insert_with_embedding(conn, "fallback-test", "semantic fallback content", vec)
+        embed_id = _insert_with_embedding(
+            conn, "fallback-test", "semantic fallback content", vec
+        )
 
     monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", lambda *_: [])
 
@@ -358,10 +373,14 @@ async def test_recall_similar_falls_back_when_fts_candidates_have_no_embeddings(
     vec /= np.linalg.norm(vec)
 
     with memory.get_connection() as conn:
-        embed_id = _insert_with_embedding(conn, "embed-fallback", "semantic content here", vec)
+        embed_id = _insert_with_embedding(
+            conn, "embed-fallback", "semantic content here", vec
+        )
 
     # Return a non-existent ID so ID-bounded fetch finds nothing scoreable
-    monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", lambda *_: ["non-existent-id"])
+    monkeypatch.setattr(
+        memory_module, "_fetch_fts_candidate_ids", lambda *_: ["non-existent-id"]
+    )
 
     results = await memory.recall_similar(
         "semantic content", session="embed-fallback", limit=5, query_vec=vec.copy()
@@ -391,12 +410,18 @@ async def test_recall_similar_falls_back_when_fts_candidates_are_all_wrong_dimen
 
     with mem.get_connection() as conn:
         # Wrong-dim row: FTS will be forced to return this ID
-        wrong_id = _insert_with_embedding(conn, "dim-fallback", "dimension mismatch content", wrong_vec)
+        wrong_id = _insert_with_embedding(
+            conn, "dim-fallback", "dimension mismatch content", wrong_vec
+        )
         # Correct-dim row: semantic fallback should find this
-        correct_id = _insert_with_embedding(conn, "dim-fallback", "dimension correct content", correct_vec)
+        correct_id = _insert_with_embedding(
+            conn, "dim-fallback", "dimension correct content", correct_vec
+        )
 
     # Force FTS to return only the wrong-dimension ID
-    monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", lambda *_: [wrong_id])
+    monkeypatch.setattr(
+        memory_module, "_fetch_fts_candidate_ids", lambda *_: [wrong_id]
+    )
 
     query_vec = correct_vec.copy()
     results = await mem.recall_similar(
@@ -405,15 +430,18 @@ async def test_recall_similar_falls_back_when_fts_candidates_are_all_wrong_dimen
 
     result_ids = {r["id"] for r in results}
     assert wrong_id not in result_ids, "wrong-dimension FTS candidate must be skipped"
-    assert correct_id in result_ids, "semantic fallback must surface the correct-dimension memory"
+    assert correct_id in result_ids, (
+        "semantic fallback must surface the correct-dimension memory"
+    )
 
 
 @pytest.mark.asyncio
 async def test_recall_similar_respects_fts_candidate_limit(monkeypatch, tmp_path):
-    """Scorer must receive no more than FTS_CANDIDATE_LIMIT IDs even when FTS matches more."""
+    """Scorer receives no more than max(limit, FTS_CANDIDATE_LIMIT) IDs."""
     from marm_mcp_server.core import memory as memory_module
 
     cap = 3
+    recall_limit = 5
     mem = MARMMemory(str(tmp_path / "memory.db"))
     mem._encoder_failed = True
 
@@ -421,12 +449,10 @@ async def test_recall_similar_respects_fts_candidate_limit(monkeypatch, tmp_path
     vec = np.ones(dim, dtype=np.float32)
     vec /= np.linalg.norm(vec)
 
-    # Insert more memories than the cap, all matching keyword "canary"
     with mem.get_connection() as conn:
         for i in range(10):
             _insert_with_embedding(conn, "cap-test", f"canary memory entry {i}", vec)
 
-    # Capture the IDs passed to the scorer
     scored_ids: list[str] = []
     original_scorer = memory_module._fetch_and_score_by_ids
 
@@ -434,13 +460,22 @@ async def test_recall_similar_respects_fts_candidate_limit(monkeypatch, tmp_path
         scored_ids.extend(memory_ids)
         return original_scorer(db_path, memory_ids, query_embedding)
 
-    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "FTS_CANDIDATE_LIMIT", cap)
-    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_fetch_and_score_by_ids", capturing_scorer)
+    monkeypatch.setitem(
+        mem.recall_similar.__func__.__globals__, "FTS_CANDIDATE_LIMIT", cap
+    )
+    monkeypatch.setitem(
+        mem.recall_similar.__func__.__globals__,
+        "_fetch_and_score_by_ids",
+        capturing_scorer,
+    )
 
-    await mem.recall_similar("canary", session="cap-test", limit=5, query_vec=vec.copy())
+    await mem.recall_similar(
+        "canary", session="cap-test", limit=recall_limit, query_vec=vec.copy()
+    )
 
-    assert len(scored_ids) <= cap, (
-        f"scorer received {len(scored_ids)} IDs but FTS_CANDIDATE_LIMIT={cap}"
+    expected_ceiling = max(recall_limit, cap)
+    assert len(scored_ids) <= expected_ceiling, (
+        f"scorer received {len(scored_ids)} IDs but ceiling is max({recall_limit}, {cap})={expected_ceiling}"
     )
 
 
@@ -459,7 +494,9 @@ async def test_recall_similar_fts_filter_failure_falls_back_to_semantic_scan(
     vec /= np.linalg.norm(vec)
 
     with memory.get_connection() as conn:
-        embed_id = _insert_with_embedding(conn, "fts-fail", "content for fts failure test", vec)
+        embed_id = _insert_with_embedding(
+            conn, "fts-fail", "content for fts failure test", vec
+        )
 
     def raise_fts_error(*args, **kwargs):
         raise sqlite3.OperationalError("no such table: memories_fts")
@@ -488,7 +525,10 @@ async def test_recall_similar_scan_metadata_false_on_filter_rerank_path(tmp_path
         _insert_with_embedding(conn, "meta-rerank", "docker deployment content", vec)
 
     _results, meta = await memory.recall_similar(
-        "docker", session="meta-rerank", limit=5, query_vec=vec.copy(),
+        "docker",
+        session="meta-rerank",
+        limit=5,
+        query_vec=vec.copy(),
         include_scan_metadata=True,
     )
 
@@ -498,8 +538,6 @@ async def test_recall_similar_scan_metadata_false_on_filter_rerank_path(tmp_path
 @pytest.mark.asyncio
 async def test_recall_similar_debug_logs_filter_rerank_path(monkeypatch, tmp_path):
     """Debug output must identify the filter->rerank path when FTS finds scoreable candidates."""
-    from marm_mcp_server.core import memory as memory_module
-
     mem = MARMMemory(str(tmp_path / "memory.db"))
     mem._encoder_failed = True
 
@@ -508,12 +546,20 @@ async def test_recall_similar_debug_logs_filter_rerank_path(monkeypatch, tmp_pat
     vec /= np.linalg.norm(vec)
 
     with mem.get_connection() as conn:
-        embed_id = _insert_with_embedding(conn, "debug-rerank", "docker deployment debug", vec)
+        embed_id = _insert_with_embedding(
+            conn, "debug-rerank", "docker deployment debug", vec
+        )
 
     debug_calls: list[str] = []
     # setitem on __globals__ is the reliable way to patch names a method resolves at call time
-    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_recall_debug", debug_calls.append)
-    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_fetch_fts_candidate_ids", lambda *_: [embed_id])
+    monkeypatch.setitem(
+        mem.recall_similar.__func__.__globals__, "_recall_debug", debug_calls.append
+    )
+    monkeypatch.setitem(
+        mem.recall_similar.__func__.__globals__,
+        "_fetch_fts_candidate_ids",
+        lambda *_: [embed_id],
+    )
 
     await mem.recall_similar(
         "docker", session="debug-rerank", limit=5, query_vec=vec.copy()
@@ -533,11 +579,19 @@ async def test_recall_similar_debug_logs_semantic_fallback_path(monkeypatch, tmp
     vec /= np.linalg.norm(vec)
 
     with mem.get_connection() as conn:
-        _insert_with_embedding(conn, "debug-fallback", "semantic fallback debug content", vec)
+        _insert_with_embedding(
+            conn, "debug-fallback", "semantic fallback debug content", vec
+        )
 
     debug_calls: list[str] = []
-    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_recall_debug", debug_calls.append)
-    monkeypatch.setitem(mem.recall_similar.__func__.__globals__, "_fetch_fts_candidate_ids", lambda *_: [])
+    monkeypatch.setitem(
+        mem.recall_similar.__func__.__globals__, "_recall_debug", debug_calls.append
+    )
+    monkeypatch.setitem(
+        mem.recall_similar.__func__.__globals__,
+        "_fetch_fts_candidate_ids",
+        lambda *_: [],
+    )
 
     await mem.recall_similar(
         "fallback debug", session="debug-fallback", limit=5, query_vec=vec.copy()

--- a/marm-mcp-server/tests/test_memory_database.py
+++ b/marm-mcp-server/tests/test_memory_database.py
@@ -289,8 +289,9 @@ async def test_recall_similar_scan_truncated_fires_when_scan_limit_exceeded(
     """Regression: recall_similar must report recall_scan_truncated=True when the DB
     holds more rows than RECALL_SCAN_LIMIT so callers know recall was bounded.
 
-    Uses direct DB inserts + query_vec to bypass the encoder path, which would
-    short-circuit to text search before the scan query runs.
+    Forces FTS to return no candidates so the semantic scan path (and its truncation
+    logic) runs. Filter->rerank bypasses RECALL_SCAN_LIMIT entirely since it scores
+    a fixed candidate set — truncation only applies to the semantic fallback lane.
     """
     import numpy as np
     import uuid as uuid_module
@@ -298,6 +299,7 @@ async def test_recall_similar_scan_truncated_fires_when_scan_limit_exceeded(
     from marm_mcp_server.core import memory as memory_module
 
     monkeypatch.setattr(memory_module, "RECALL_SCAN_LIMIT", 5)
+    monkeypatch.setattr(memory_module, "_fetch_fts_candidate_ids", lambda *_: [])
     mem = memory_module.MARMMemory(str(tmp_path / "memory.db"))
 
     dim = 384

--- a/marm-mcp-server/tests/test_temporal_weighting.py
+++ b/marm-mcp-server/tests/test_temporal_weighting.py
@@ -56,17 +56,21 @@ async def test_newer_memory_ranks_above_equally_similar_older_one(tmp_path):
     old_ts = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
     new_ts = datetime.now(timezone.utc).isoformat()
 
-    # Insert two identical-content memories with different timestamps
     import sqlite3 as _sqlite3
     import uuid
+
+    unit_vec = np.ones(384, dtype=np.float32)
+    unit_vec /= np.linalg.norm(unit_vec)
+
+    _ = mem  # triggers init_database via __init__
 
     def _insert(ts):
         mid = str(uuid.uuid4())
         with _sqlite3.connect(str(tmp_path / "memory.db")) as conn:
             conn.execute(
-                "INSERT INTO memories (id, session_name, content, timestamp, context_type, metadata) "
-                "VALUES (?, 'rank-test', 'temporal ranking keyword content', ?, 'general', '{}')",
-                (mid, ts),
+                "INSERT INTO memories (id, session_name, content, timestamp, context_type, metadata, embedding) "
+                "VALUES (?, 'rank-test', 'temporal ranking keyword content', ?, 'general', '{}', ?)",
+                (mid, ts, unit_vec.tobytes()),
             )
             conn.execute(
                 "INSERT INTO memories_fts(rowid, content) "
@@ -75,14 +79,11 @@ async def test_newer_memory_ranks_above_equally_similar_older_one(tmp_path):
             )
         return mid
 
-    # Initialise DB first
-    _ = mem  # triggers init_database via __init__
     old_id = _insert(old_ts)
     new_id = _insert(new_ts)
 
-    query_vec = np.zeros(384, dtype=np.float32)
     results = await mem.recall_similar(
-        "temporal ranking keyword", session="rank-test", limit=5, query_vec=query_vec
+        "temporal ranking keyword", session="rank-test", limit=5, query_vec=unit_vec.copy()
     )
 
     ids = [r["id"] for r in results]
@@ -105,13 +106,18 @@ async def test_temporal_weight_zero_means_fts_winner_ranks_first_despite_age(
 
     base = datetime.now(timezone.utc)
 
+    unit_vec = np.ones(384, dtype=np.float32)
+    unit_vec /= np.linalg.norm(unit_vec)
+
+    _ = mem  # triggers init_database via __init__
+
     def _insert(ts, content):
         mid = str(uuid.uuid4())
         with _sqlite3.connect(str(tmp_path / "memory.db")) as conn:
             conn.execute(
-                "INSERT INTO memories (id, session_name, content, timestamp, context_type, metadata) "
-                "VALUES (?, 'zero-weight', ?, ?, 'general', '{}')",
-                (mid, content, ts),
+                "INSERT INTO memories (id, session_name, content, timestamp, context_type, metadata, embedding) "
+                "VALUES (?, 'zero-weight', ?, ?, 'general', '{}', ?)",
+                (mid, content, ts, unit_vec.tobytes()),
             )
             conn.execute(
                 "INSERT INTO memories_fts(rowid, content) "
@@ -120,25 +126,24 @@ async def test_temporal_weight_zero_means_fts_winner_ranks_first_despite_age(
             )
         return mid
 
-    _ = mem
-    # Old memory has the exact query keyword — FTS should rank it #1 at weight=0
+    # Old memory has the exact query keyword — FTS filter will include it
     old_id = _insert(
         (base - timedelta(days=90)).isoformat(),
         "zephyr unique keyword only here",
     )
-    # New memory has no match for the query — zero FTS score
+    # New memory has no match for the query — FTS filter will exclude it
     new_id = _insert(
         base.isoformat(), "unrelated content about something else entirely"
     )
 
-    query_vec = np.zeros(384, dtype=np.float32)
     results = await mem.recall_similar(
-        "zephyr unique keyword", session="zero-weight", limit=5, query_vec=query_vec
+        "zephyr unique keyword", session="zero-weight", limit=5, query_vec=unit_vec.copy()
     )
 
     ids = [r["id"] for r in results]
     assert old_id in ids, "FTS-matching old memory must appear in results"
-    # With TEMPORAL_WEIGHT=0, the old FTS winner must outrank the new non-matching memory
+    # With TEMPORAL_WEIGHT=0, only vec_score determines rank. If new_id also surfaced
+    # (e.g. via semantic fallback), old_id must still rank first.
     if new_id in ids:
         assert ids.index(old_id) < ids.index(new_id), (
             "At TEMPORAL_WEIGHT=0 the FTS-dominant old memory should rank above the new non-matching one"


### PR DESCRIPTION
Add FTS-first candidate filtering with semantic rerank and bounded semantic fallback.

Update hybrid recall tests, changelog, and core docs to match the new behavior.

Harden Discord workflows by skipping Dependabot activity and making webhook failures non-fatal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `FTS_CANDIDATE_LIMIT` to control how many FTS candidates are considered during recall.
  * Updated smart recall to use an FTS-based filter followed by semantic reranking, with a bounded semantic fallback when FTS coverage is weak.
* **Bug Fixes**
  * Improved Discord webhook handling so failed notifications don’t interrupt workflows; get-involved posts now better filter out bot/dependabot events.
* **Documentation**
  * Updated README, FAQ, and MCP handbook (server docs included) to match the filter→rerank flow and revised truncation/fallback wording.
* **Tests**
  * Expanded recall tests to cover filter→rerank and fallback edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->