### PR TITLE
feat(attribution): add project and platform scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>June 20th, 2026: Project & Platform Attribution (v2.14.2)</strong></summary>
+
+### Project & Platform Metadata
+
+- Added nullable `project` and `platform` attribution columns to memories, log entries, and notebook entries so MARM can distinguish work from different repositories, clients, and agent surfaces without splitting the local SQLite database.
+- Added `MARM_PROJECT` and `MARM_PLATFORM` settings with safe auto-detection plus explicit environment overrides for Docker, servers, and custom client setups.
+- Tagged new memory, log, and notebook writes with detected attribution metadata while preserving existing untagged rows as global/unscoped history.
+
+### Scoped Recall & Consolidation Safety
+
+- Extended `marm_smart_recall` with optional `project` and `platform` filters across HTTP and STDIO, including memory recall and `include_logs=True` log search.
+- Applied attribution filters through FTS candidate fetches, FTS scoring, semantic fallback scoring, and LIKE fallback so scoped recall stays consistent across retrieval lanes.
+- Scoped exact duplicate detection and semantic write-time merge checks to the current project/platform pair to prevent accidental cross-project or cross-client consolidation.
+
+### Tests & Docs
+
+- Added focused coverage for project/platform schema migrations, write tagging, scoped recall, HTTP request handling, log filtering, notebook attribution, scoring filters, and consolidation isolation.
+- Updated README, MCP handbook, FAQ, contributing guidance, packaged docs, and project architecture references with the new attribution behavior.
+
+</details>
+
+<details>
 <summary><strong>June 17th, 2026: Docs, Assets & Community (v2.14.1)</strong></summary>
 
 ### Documentation & README

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ If `SERVER_HOST=0.0.0.0`, MARM requires a key. When no key is provided, the sett
 
 MARM uses a local SQLite database under `~/.marm/` by default. Tool behavior depends on specific tables for sessions, log entries, notebook entries, memories, compaction staging, and analytics.
 
+Memory, log, and notebook rows can carry nullable `project` and `platform` attribution columns. When changing write paths, recall filters, consolidation, or schema migrations, keep these fields aligned across HTTP, STDIO, tests, and docs.
+
 Do not rename fields, move data between tables, or change date/session parsing behavior without updating HTTP tools, STDIO tools, tests, smoke scripts, and docs together.
 
 **Retired features stay retired unless re-scoped**

--- a/MCP-HANDBOOK.md
+++ b/MCP-HANDBOOK.md
@@ -2,7 +2,7 @@
 
 ## Complete Usage Guide for Memory-Augmented AI
 
-**MARM v2.14.1 - Universal MCP Server for AI Memory Intelligence**
+**MARM v2.14.2 - Universal MCP Server for AI Memory Intelligence**
 
 ---
 
@@ -267,7 +267,7 @@ MARM automatically categorizes content:
 
 | Category | Tool | Description | Usage Notes |
 |----------|------|-------------|-------------|
-| **🧠 Memory** | `marm_smart_recall` | FTS-first filter→semantic rerank across all memories, with bounded semantic fallback, chunk-aware long-memory scoring, and a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`). Use natural language queries or exact keys/commands |
+| **🧠 Memory** | `marm_smart_recall` | FTS-first filter→semantic rerank across all memories, with bounded semantic fallback, chunk-aware long-memory scoring, project/platform attribution filters, and a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`), `project` (optional), `platform` (optional). Use natural language queries or exact keys/commands |
 | **📚 Logging** | `marm_log_entry` | Add structured session log entries | Use structured entries for best results. Session/topic routing, context-summary preparation, and summary-cache invalidation are handled by the server |
 | | `marm_log_show` | Display all entries and sessions with filtering | `session_name` (optional) |
 | | `marm_delete` | Delete a log session, log entry, or notebook entry | `type="log"` or `type="notebook"`, `target` (required), `session_name` (optional for log entries) |
@@ -276,6 +276,8 @@ MARM automatically categorizes content:
 | **🧹 Maintenance** | `marm_compaction` | Agent-assisted memory compaction | `action="status"`, `"candidates"`, `"review"`, `"stage"`, `"apply"`, or `"discard"`. Used when MARM detects duplicate memory clusters and asks the agent to summarize them |
 
 **Internal automation:** lifecycle initialization, protocol delivery with periodic protocol-lite refresh, documentation refresh, current date context, summary-cache maintenance, serialized write queue handling, and system checks are no longer AI-facing tools. Documentation refresh uses `doc_index` hash tracking to avoid duplicate `marm_system` memories across restarts. Use the dashboard health panel for live server status, or `curl http://localhost:8001/health` for terminal checks.
+
+**Project/platform attribution:** MARM stores nullable `project` and `platform` columns on memories, log entries, and notebook entries. `MARM_PROJECT` overrides the detected working-directory project, while `MARM_PLATFORM` overrides client/platform detection. `marm_smart_recall(project=..., platform=...)` scopes memory recall and `include_logs=True` log search without changing the default unfiltered behavior.
 
 **Swarm / multi-agent modes:** Use CLI presets when starting an HTTP server shared by multiple agents:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
      width="700"
      height="400">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.14.1</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.14.2</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/MARM-Systems/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -239,9 +239,11 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 **Architecture note:** MARM groups related operations behind a single dispatching tooling to keep MCP discovery lean without hiding behavior. Domain-specific tools such as `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)` group closely related operations behind explicit parameters, while recall, logging, and summaries stay separate so agents still choose the right capability clearly. This design keeps the MCP schema compact while preserving full functionality.
 
+**Project/platform attribution:** new memories, logs, and notebook entries are tagged with nullable `project` and `platform` metadata when MARM can detect them. `MARM_PROJECT` can override the detected working-directory project, and `MARM_PLATFORM` can override the detected client/platform. `marm_smart_recall` accepts optional `project` and `platform` filters, including when `include_logs=True`, so agents can ask for context from a specific project or client without losing normal cross-project search.
+
 | **Category** | **Tool** | **Description** |
 |--------------|----------|-----------------|
-| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically re-ranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, and scores long memories through chunked embeddings while still returning one parent memory result. Supports global search with `search_all=True` and can return summary/context/full memory depth with `detail=1/2/3` |
+| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically re-ranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, and scores long memories through chunked embeddings while still returning one parent memory result. Supports global search with `search_all=True`, attribution filters with `project`/`platform`, and summary/context/full memory depth with `detail=1/2/3` |
 | **Logging System** | `marm_log_entry` | Add structured session log entries. Session/topic routing, summary-cache invalidation, and context summary preparation are handled by the server |
 | | `marm_log_show` | Display all entries and sessions (filterable) |
 | | `marm_delete` | Delete a log session, log entry, or notebook entry (`type="log"\|"notebook"`) |

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -132,6 +132,8 @@ MARM uses filter→rerank hybrid recall. FTS keyword/BM25 search handles exact t
 
 Both. `marm_smart_recall` searches one session by default and can search across all sessions with `search_all=True`.
 
+It can also filter by `project` and `platform` when those metadata fields are available. New memories, logs, and notebook entries are tagged from detected settings or explicit `MARM_PROJECT` / `MARM_PLATFORM` environment variables. Leaving those filters unset keeps the current broad search behavior.
+
 When the semantic fallback lane reaches its configured scan cap, responses include `recall_scan_truncated=true` and `recall_scan_limit` so agents know that part of recall was bounded. The primary filter→rerank lane does not set truncation because it works over a fixed FTS candidate set instead of a broad embedding scan.
 
 `FTS_CANDIDATE_LIMIT` (default `50`) controls how many FTS candidates are fetched before semantic reranking. Most users should leave it alone unless their memory store has weak keyword overlap and they want a wider rerank pool.
@@ -150,7 +152,7 @@ Be selective. Log decisions, solutions, insights, requirements, constraints, and
 
 #### Q: How do I organize memories for team collaboration?
 
-Use consistent session names, include project or workstream names, and rely on cross-session search for broad recall. For shared agent workflows, prefer HTTP mode so one server coordinates writes.
+Use consistent session names, include project or workstream names, and rely on cross-session search for broad recall. MARM also records nullable `project` and `platform` metadata on new memories, logs, and notebook entries, so agents can scope recall to a project or client when needed. For shared agent workflows, prefer HTTP mode so one server coordinates writes.
 
 #### Q: Does MARM clean up duplicate memories automatically?
 

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.14.1** - Memory Accurate Response Mode
+**MARM v2.14.2** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.14.1** - Memory Accurate Response Mode
+**MARM v2.14.2** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -320,7 +320,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.14.1 MCP Server - Platform Integration Guide
+# MARM v2.14.2 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.14.1** - Memory Accurate Response Mode
+**MARM v2.14.2** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -293,7 +293,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -38,7 +38,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.14.1"
+LABEL org.opencontainers.image.version="2.14.2"
 LABEL org.opencontainers.image.authors="Ryan Lyell - MARM Systems"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/MARM-Systems"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -6,7 +6,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="700"
      height="400">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.14.1</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.14.2</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/MARM-Systems/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -15,9 +15,11 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/marm-mcp-server?period=total&units=NONE&left_color=GREY&right_color=BLUE&left_text=pip-downloads)](https://pepy.tech/projects/marm-mcp-server)
 [![PyPI Version](https://img.shields.io/pypi/v/marm-mcp-server)](https://pypi.org/project/marm-mcp-server/)
 [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-LIVE-blue)](https://registry.modelcontextprotocol.io/?q=marm-mcp)
+
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/nhyJWPz2cf)
 [![Publish](https://github.com/Lyellr88/MARM-Systems/actions/workflows/publish-mcp.yml/badge.svg?branch=MARM-main)](https://github.com/Lyellr88/MARM-Systems/actions/workflows/publish-mcp.yml)
 [![CodeQL](https://github.com/Lyellr88/MARM-Systems/actions/workflows/github-code-scanning/codeql/badge.svg?branch=MARM-main)](https://github.com/Lyellr88/MARM-Systems/security/code-scanning)
+[![MARM-Systems MCP server](https://glama.ai/mcp/servers/Lyellr88/MARM-Systems/badges/score.svg)](https://glama.ai/mcp/servers/Lyellr88/MARM-Systems)
 
 > Contributions welcome! Browse [open issues](https://github.com/Lyellr88/MARM-Systems/issues) to contribute, or join the [MARM Discord](https://discord.gg/nhyJWPz2cf) to share workflows, get setup help, and connect with other builders.
 
@@ -239,9 +241,11 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 **Architecture note:** MARM groups related operations behind a single dispatching tooling to keep MCP discovery lean without hiding behavior. Domain-specific tools such as `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)` group closely related operations behind explicit parameters, while recall, logging, and summaries stay separate so agents still choose the right capability clearly. This design keeps the MCP schema compact while preserving full functionality.
 
+**Project/platform attribution:** new memories, logs, and notebook entries are tagged with nullable `project` and `platform` metadata when MARM can detect them. `MARM_PROJECT` can override the detected working-directory project, and `MARM_PLATFORM` can override the detected client/platform. `marm_smart_recall` accepts optional `project` and `platform` filters, including when `include_logs=True`, so agents can ask for context from a specific project or client without losing normal cross-project search.
+
 | **Category** | **Tool** | **Description** |
 |--------------|----------|-----------------|
-| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically re-ranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, and scores long memories through chunked embeddings while still returning one parent memory result. Supports global search with `search_all=True` and can return summary/context/full memory depth with `detail=1/2/3` |
+| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically re-ranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, and scores long memories through chunked embeddings while still returning one parent memory result. Supports global search with `search_all=True`, attribution filters with `project`/`platform`, and summary/context/full memory depth with `detail=1/2/3` |
 | **Logging System** | `marm_log_entry` | Add structured session log entries. Session/topic routing, summary-cache invalidation, and context summary preparation are handled by the server |
 | | `marm_log_show` | Display all entries and sessions (filterable) |
 | | `marm_delete` | Delete a log session, log entry, or notebook entry (`type="log"\|"notebook"`) |

--- a/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
+++ b/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
@@ -2,7 +2,7 @@
 
 ## Complete Usage Guide for Memory-Augmented AI
 
-**MARM v2.14.1 - Universal MCP Server for AI Memory Intelligence**
+**MARM v2.14.2 - Universal MCP Server for AI Memory Intelligence**
 
 ---
 
@@ -267,7 +267,7 @@ MARM automatically categorizes content:
 
 | Category | Tool | Description | Usage Notes |
 |----------|------|-------------|-------------|
-| **🧠 Memory** | `marm_smart_recall` | FTS-first filter→semantic rerank across all memories, with bounded semantic fallback, chunk-aware long-memory scoring, and a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`). Use natural language queries or exact keys/commands |
+| **🧠 Memory** | `marm_smart_recall` | FTS-first filter→semantic rerank across all memories, with bounded semantic fallback, chunk-aware long-memory scoring, project/platform attribution filters, and a conservative recency bias in final ranking | `query` (required), `limit` (default: 5), `session_name` (optional), `detail` (default: `1`), `project` (optional), `platform` (optional). Use natural language queries or exact keys/commands |
 | **📚 Logging** | `marm_log_entry` | Add structured session log entries | Use structured entries for best results. Session/topic routing, context-summary preparation, and summary-cache invalidation are handled by the server |
 | | `marm_log_show` | Display all entries and sessions with filtering | `session_name` (optional) |
 | | `marm_delete` | Delete a log session, log entry, or notebook entry | `type="log"` or `type="notebook"`, `target` (required), `session_name` (optional for log entries) |
@@ -276,6 +276,8 @@ MARM automatically categorizes content:
 | **🧹 Maintenance** | `marm_compaction` | Agent-assisted memory compaction | `action="status"`, `"candidates"`, `"review"`, `"stage"`, `"apply"`, or `"discard"`. Used when MARM detects duplicate memory clusters and asks the agent to summarize them |
 
 **Internal automation:** lifecycle initialization, protocol delivery with periodic protocol-lite refresh, documentation refresh, current date context, summary-cache maintenance, serialized write queue handling, and system checks are no longer AI-facing tools. Documentation refresh uses `doc_index` hash tracking to avoid duplicate `marm_system` memories across restarts. Use the dashboard health panel for live server status, or `curl http://localhost:8001/health` for terminal checks.
+
+**Project/platform attribution:** MARM stores nullable `project` and `platform` columns on memories, log entries, and notebook entries. `MARM_PROJECT` overrides the detected working-directory project, while `MARM_PLATFORM` overrides client/platform detection. `marm_smart_recall(project=..., platform=...)` scopes memory recall and `include_logs=True` log search without changing the default unfiltered behavior.
 
 **Swarm / multi-agent modes:** Use CLI presets when starting an HTTP server shared by multiple agents:
 

--- a/marm-mcp-server/marm-docs/README.md
+++ b/marm-mcp-server/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.14.1
+# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.14.2
 
 > Contributions welcome! Browse [open issues](https://github.com/Lyellr88/MARM-Systems/issues) to contribute, or join the [MARM Discord](https://discord.gg/nhyJWPz2cf) to share workflows, get setup help, and connect with other builders.
 
@@ -196,9 +196,11 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 **Architecture note:** MARM groups related operations behind a single dispatching tooling to keep MCP discovery lean without hiding behavior. Domain-specific tools such as `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)` group closely related operations behind explicit parameters, while recall, logging, and summaries stay separate so agents still choose the right capability clearly. This design keeps the MCP schema compact while preserving full functionality.
 
+**Project/platform attribution:** new memories, logs, and notebook entries are tagged with nullable `project` and `platform` metadata when MARM can detect them. `MARM_PROJECT` can override the detected working-directory project, and `MARM_PLATFORM` can override the detected client/platform. `marm_smart_recall` accepts optional `project` and `platform` filters, including when `include_logs=True`, so agents can ask for context from a specific project or client without losing normal cross-project search.
+
 | **Category** | **Tool** | **Description** |
 |--------------|----------|-----------------|
-| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically re-ranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, and scores long memories through chunked embeddings while still returning one parent memory result. Supports global search with `search_all=True` and can return summary/context/full memory depth with `detail=1/2/3` |
+| **Memory Intelligence** | `marm_smart_recall` | AI-powered recall across all memories. Uses FTS5 BM25 to filter exact-term candidates first, semantically re-ranks that bounded set by embedding similarity, falls back to bounded semantic scanning when FTS coverage is weak, and scores long memories through chunked embeddings while still returning one parent memory result. Supports global search with `search_all=True`, attribution filters with `project`/`platform`, and summary/context/full memory depth with `detail=1/2/3` |
 | **Logging System** | `marm_log_entry` | Add structured session log entries. Session/topic routing, summary-cache invalidation, and context summary preparation are handled by the server |
 | | `marm_log_show` | Display all entries and sessions (filterable) |
 | | `marm_delete` | Delete a log session, log entry, or notebook entry (`type="log"\|"notebook"`) |

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,10 +14,10 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - MARM Systems
-Version: 2.14.1
+Version: 2.14.2
 """
 
-__version__ = "2.14.1"
+__version__ = "2.14.2"
 __author__ = "Ryan Lyell"
 __email__ = "lyell@marmsystems.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -105,7 +105,42 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.14.1"
+SERVER_VERSION = "2.14.2"
+
+
+def _detect_project() -> str:
+    explicit = os.environ.get("MARM_PROJECT", "")
+    if explicit:
+        return explicit.lower().replace(" ", "-")
+    cwd = Path.cwd()
+    unsafe = {Path.home(), Path.home().parent, Path("/")}
+    if sys.platform == "win32":
+        unsafe.add(Path("C:\\"))
+    if cwd in unsafe:
+        return ""
+    return cwd.name.lower().replace(" ", "-")
+
+
+MARM_PROJECT = _detect_project()
+
+
+def _detect_platform() -> str:
+    explicit = os.environ.get("MARM_PLATFORM", "")
+    if explicit:
+        return explicit.lower()
+    if os.environ.get("CLAUDE_CODE_ENTRYPOINT"):
+        return "claude-code"
+    term = os.environ.get("TERM_PROGRAM", "").lower()
+    if term in ("vscode", "cursor", "windsurf"):
+        return term
+    if os.environ.get("VSCODE_PID"):
+        return "vscode"
+    if os.environ.get("CURSOR_TRACE_ID"):
+        return "cursor"
+    return ""
+
+
+MARM_PLATFORM = _detect_platform()
 
 _raw_rpm = _safe_int("MARM_RATE_LIMIT_RPM", 80)
 # 0 = disable rate limiting; negative values clamped to 0

--- a/marm-mcp-server/marm_mcp_server/core/consolidation.py
+++ b/marm-mcp-server/marm_mcp_server/core/consolidation.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 from typing import Optional
 
+from ..config.settings import MARM_PROJECT, MARM_PLATFORM
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +28,8 @@ def find_exact_duplicate(
     as a new row rather than silently deduplicating different content.
     """
     rows = conn.execute(
-        "SELECT id, content FROM memories WHERE content_hash = ? AND session_name = ?",
-        (content_hash, session_name),
+        "SELECT id, content FROM memories WHERE content_hash = ? AND session_name = ? AND project IS ? AND platform IS ?",
+        (content_hash, session_name, MARM_PROJECT or None, MARM_PLATFORM or None),
     ).fetchall()
     for row_id, row_content in rows:
         if normalize_content(row_content) == normalized_content:
@@ -48,7 +49,12 @@ async def find_semantic_duplicate(
         if query_vec is None and not memory._load_encoder_lazily():
             return None
         results = await memory.recall_similar(
-            content, session=session_name, limit=1, query_vec=query_vec
+            content,
+            session=session_name,
+            limit=1,
+            query_vec=query_vec,
+            project=MARM_PROJECT or None,
+            platform=MARM_PLATFORM or None,
         )
         if results and results[0]["similarity"] >= threshold:
             return results[0]["id"]

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -259,15 +259,31 @@ class MARMMemory:
         limit: int = 5,
         query_vec=None,
         include_scan_metadata: bool = False,
+        project: str = None,
+        platform: str = None,
     ):
         return await _recall_similar(
-            self, query, session, limit, query_vec, include_scan_metadata
+            self,
+            query,
+            session,
+            limit,
+            query_vec,
+            include_scan_metadata,
+            project,
+            platform,
         )
 
     async def recall_text_search(
-        self, query: str, session: str = None, limit: int = 5
+        self,
+        query: str,
+        session: str = None,
+        limit: int = 5,
+        project: str = None,
+        platform: str = None,
     ) -> List[Dict]:
-        return await _recall_text_search(self, query, session, limit)
+        return await _recall_text_search(
+            self, query, session, limit, project=project, platform=platform
+        )
 
 
 memory = MARMMemory()

--- a/marm-mcp-server/marm_mcp_server/core/memory_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_db.py
@@ -173,6 +173,33 @@ def init_database(db_path: str) -> None:
             conn.execute("ALTER TABLE memories ADD COLUMN compaction_role TEXT")
         if "compacted_into" not in mem_cols:
             conn.execute("ALTER TABLE memories ADD COLUMN compacted_into TEXT")
+        if "project" not in mem_cols:
+            conn.execute("ALTER TABLE memories ADD COLUMN project TEXT DEFAULT NULL")
+        if "platform" not in mem_cols:
+            conn.execute("ALTER TABLE memories ADD COLUMN platform TEXT DEFAULT NULL")
+
+        log_cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(log_entries)").fetchall()
+        }
+        if "project" not in log_cols:
+            conn.execute("ALTER TABLE log_entries ADD COLUMN project TEXT DEFAULT NULL")
+        if "platform" not in log_cols:
+            conn.execute(
+                "ALTER TABLE log_entries ADD COLUMN platform TEXT DEFAULT NULL"
+            )
+
+        nb_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(notebook_entries)").fetchall()
+        }
+        if "project" not in nb_cols:
+            conn.execute(
+                "ALTER TABLE notebook_entries ADD COLUMN project TEXT DEFAULT NULL"
+            )
+        if "platform" not in nb_cols:
+            conn.execute(
+                "ALTER TABLE notebook_entries ADD COLUMN platform TEXT DEFAULT NULL"
+            )
 
         conn.execute("""
             CREATE TABLE IF NOT EXISTS compaction_staging (

--- a/marm-mcp-server/marm_mcp_server/core/memory_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_db.py
@@ -133,9 +133,11 @@ def init_database(db_path: str) -> None:
 
         conn.execute("""
             CREATE TABLE IF NOT EXISTS notebook_entries (
-                name TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
                 data TEXT NOT NULL,
                 embedding BLOB,
+                project TEXT DEFAULT NULL,
+                platform TEXT DEFAULT NULL,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT DEFAULT CURRENT_TIMESTAMP
             )
@@ -188,10 +190,8 @@ def init_database(db_path: str) -> None:
                 "ALTER TABLE log_entries ADD COLUMN platform TEXT DEFAULT NULL"
             )
 
-        nb_cols = {
-            row[1]
-            for row in conn.execute("PRAGMA table_info(notebook_entries)").fetchall()
-        }
+        nb_info = conn.execute("PRAGMA table_info(notebook_entries)").fetchall()
+        nb_cols = {row[1] for row in nb_info}
         if "project" not in nb_cols:
             conn.execute(
                 "ALTER TABLE notebook_entries ADD COLUMN project TEXT DEFAULT NULL"
@@ -200,6 +200,39 @@ def init_database(db_path: str) -> None:
             conn.execute(
                 "ALTER TABLE notebook_entries ADD COLUMN platform TEXT DEFAULT NULL"
             )
+        if any(row[1] == "name" and row[5] for row in nb_info):
+            conn.execute("ALTER TABLE notebook_entries RENAME TO notebook_entries_old")
+            conn.execute("""
+                CREATE TABLE notebook_entries (
+                    name TEXT NOT NULL,
+                    data TEXT NOT NULL,
+                    embedding BLOB,
+                    project TEXT DEFAULT NULL,
+                    platform TEXT DEFAULT NULL,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            old_cols = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(notebook_entries_old)"
+                ).fetchall()
+            }
+            project_expr = "project" if "project" in old_cols else "NULL"
+            platform_expr = "platform" if "platform" in old_cols else "NULL"
+            conn.execute(f"""
+                INSERT INTO notebook_entries
+                    (name, data, embedding, project, platform, created_at, updated_at)
+                SELECT name, data, embedding, {project_expr}, {platform_expr},
+                       created_at, updated_at
+                FROM notebook_entries_old
+            """)
+            conn.execute("DROP TABLE notebook_entries_old")
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_notebook_entries_scope_unique "
+            "ON notebook_entries(name, COALESCE(project, ''), COALESCE(platform, ''))"
+        )
 
         conn.execute("""
             CREATE TABLE IF NOT EXISTS compaction_staging (

--- a/marm-mcp-server/marm_mcp_server/core/memory_ops.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_ops.py
@@ -13,6 +13,8 @@ from ..config.settings import (
     TEMPORAL_WEIGHT,
     TEMPORAL_HALF_LIFE_DAYS,
     FTS_CANDIDATE_LIMIT,
+    MARM_PROJECT,
+    MARM_PLATFORM,
 )
 from .memory_utils import (
     _safe_print,
@@ -180,8 +182,8 @@ async def _store_memory(
 
         conn.execute(
             """
-            INSERT INTO memories (id, session_name, content, embedding, content_hash, timestamp, context_type, metadata)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO memories (id, session_name, content, embedding, content_hash, timestamp, context_type, metadata, project, platform)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
             (
                 memory_id,
@@ -192,6 +194,8 @@ async def _store_memory(
                 timestamp,
                 context_type,
                 json.dumps(metadata),
+                MARM_PROJECT or None,
+                MARM_PLATFORM or None,
             ),
         )
 
@@ -221,6 +225,8 @@ async def _recall_similar(
     limit: int = 5,
     query_vec=None,
     include_scan_metadata: bool = False,
+    project: str = None,
+    platform: str = None,
 ):
     """Find semantically similar memories.
 
@@ -241,7 +247,12 @@ async def _recall_similar(
     if query_vec is None:
         if not mem._load_encoder_lazily():
             _recall_debug("semantic model unavailable → text-search fallback")
-            return _wrap(await _recall_text_search(mem, query, session, limit), False)
+            return _wrap(
+                await _recall_text_search(
+                    mem, query, session, limit, project=project, platform=platform
+                ),
+                False,
+            )
 
     try:
         if query_vec is not None:
@@ -259,6 +270,8 @@ async def _recall_similar(
                     session,
                     fts_query,
                     max(limit, FTS_CANDIDATE_LIMIT),
+                    project,
+                    platform,
                 )
                 _recall_debug(
                     f"FTS filter: {len(candidate_ids)} candidates for '{fts_query}'"
@@ -294,6 +307,8 @@ async def _recall_similar(
                 scan_limit,
                 query_embedding,
                 limit,
+                project,
+                platform,
             )
             _recall_debug(
                 f"semantic fallback: {len(similarities)} candidates, scan_truncated={scan_truncated}"
@@ -327,6 +342,8 @@ async def _recall_similar(
                     if memory["metadata"]
                     else {},
                     "similarity": float(similarity),
+                    "project": memory["project"],
+                    "platform": memory["platform"],
                 }
             )
 
@@ -335,11 +352,21 @@ async def _recall_similar(
     except Exception as e:
         _safe_print(f"Semantic search failed: {e}")
         _recall_debug(f"semantic search exception → text-search fallback: {e}")
-        return _wrap(await _recall_text_search(mem, query, session, limit), False)
+        return _wrap(
+            await _recall_text_search(
+                mem, query, session, limit, project=project, platform=platform
+            ),
+            False,
+        )
 
 
 async def _recall_text_search(
-    mem, query: str, session: str = None, limit: int = 5
+    mem,
+    query: str,
+    session: str = None,
+    limit: int = 5,
+    project: str = None,
+    platform: str = None,
 ) -> List[Dict]:
     """Text search via FTS5 BM25 ranking, with LIKE fallback for unsanitizable queries."""
     _recall_debug(f"text-search path: query='{query[:50]}', session={session}")
@@ -347,7 +374,13 @@ async def _recall_text_search(
     if fts_query is not None:
         try:
             fts_rows = await asyncio.to_thread(
-                _fetch_and_score_fts_rows, mem.db_path, session, fts_query, limit
+                _fetch_and_score_fts_rows,
+                mem.db_path,
+                session,
+                fts_query,
+                limit,
+                project,
+                platform,
             )
             if fts_rows:
                 _recall_debug(f"FTS5 returned {len(fts_rows)} results")
@@ -362,6 +395,8 @@ async def _recall_text_search(
                         if row["metadata"]
                         else {},
                         "similarity": float(score),
+                        "project": row["project"],
+                        "platform": row["platform"],
                     }
                     for row, score in fts_rows
                 ]
@@ -372,31 +407,25 @@ async def _recall_text_search(
     _recall_debug("FTS5 returned 0 or query unsanitizable → LIKE fallback")
 
     with mem.get_connection() as conn:
-        if session is None:
-            cursor = conn.execute(
-                """
-                SELECT id, session_name, content, timestamp, context_type, metadata
-                FROM memories
-                WHERE content LIKE ?
-                  AND (compaction_role IS NULL OR compaction_role != 'source')
-                ORDER BY timestamp DESC
-                LIMIT ?
-            """,
-                (f"%{query}%", limit),
-            )
-        else:
-            cursor = conn.execute(
-                """
-                SELECT id, session_name, content, timestamp, context_type, metadata
-                FROM memories
-                WHERE content LIKE ?
-                  AND session_name = ?
-                  AND (compaction_role IS NULL OR compaction_role != 'source')
-                ORDER BY timestamp DESC
-                LIMIT ?
-            """,
-                (f"%{query}%", session, limit),
-            )
+        base = """
+            SELECT id, session_name, content, timestamp, context_type, metadata, project, platform
+            FROM memories
+            WHERE content LIKE ?
+              AND (compaction_role IS NULL OR compaction_role != 'source')
+        """
+        params: list = [f"%{query}%"]
+        if session is not None:
+            base += " AND session_name = ?"
+            params.append(session)
+        if project is not None:
+            base += " AND project = ?"
+            params.append(project)
+        if platform is not None:
+            base += " AND platform = ?"
+            params.append(platform)
+        base += " ORDER BY timestamp DESC LIMIT ?"
+        params.append(limit)
+        cursor = conn.execute(base, params)
 
         results = []
         for row in cursor.fetchall():
@@ -409,6 +438,8 @@ async def _recall_text_search(
                     "context_type": row[4],
                     "metadata": json.loads(row[5]) if row[5] else {},
                     "similarity": 0.8,
+                    "project": row[6],
+                    "platform": row[7],
                 }
             )
 

--- a/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
@@ -117,35 +117,31 @@ def _fetch_and_score_embedding_rows(
     scan_limit: int,
     query_embedding,
     limit: int,
+    project: str | None = None,
+    platform: str | None = None,
 ):
     conn = sqlite3.connect(db_path, timeout=30.0)
     try:
         conn.row_factory = sqlite3.Row
-        if session is None:
-            memories = conn.execute(
-                """
-                SELECT id, session_name, content, embedding, timestamp, context_type, metadata
-                FROM memories
-                WHERE embedding IS NOT NULL
-                  AND (compaction_role IS NULL OR compaction_role != 'source')
-                ORDER BY timestamp DESC
-                LIMIT ?
-                """,
-                (scan_limit + 1,),
-            ).fetchall()
-        else:
-            memories = conn.execute(
-                """
-                SELECT id, session_name, content, embedding, timestamp, context_type, metadata
-                FROM memories
-                WHERE embedding IS NOT NULL
-                  AND session_name = ?
-                  AND (compaction_role IS NULL OR compaction_role != 'source')
-                ORDER BY timestamp DESC
-                LIMIT ?
-                """,
-                (session, scan_limit + 1),
-            ).fetchall()
+        base = """
+            SELECT id, session_name, content, embedding, timestamp, context_type, metadata, project, platform
+            FROM memories
+            WHERE embedding IS NOT NULL
+              AND (compaction_role IS NULL OR compaction_role != 'source')
+        """
+        params: list = []
+        if session is not None:
+            base += " AND session_name = ?"
+            params.append(session)
+        if project is not None:
+            base += " AND project = ?"
+            params.append(project)
+        if platform is not None:
+            base += " AND platform = ?"
+            params.append(platform)
+        base += " ORDER BY timestamp DESC LIMIT ?"
+        params.append(scan_limit + 1)
+        memories = conn.execute(base, params).fetchall()
 
         scan_truncated = len(memories) > scan_limit
         memories = memories[:scan_limit]
@@ -173,13 +169,15 @@ def _fetch_and_score_fts_rows(
     session: str | None,
     fts_query: str,
     limit: int,
+    project: str | None = None,
+    platform: str | None = None,
 ) -> list[tuple]:
     conn = sqlite3.connect(db_path, timeout=30.0)
     try:
         conn.row_factory = sqlite3.Row
         base = """
             SELECT m.id, m.session_name, m.content, m.timestamp,
-                   m.context_type, m.metadata,
+                   m.context_type, m.metadata, m.project, m.platform,
                    bm25(memories_fts) AS score
             FROM memories_fts
             JOIN memories m ON memories_fts.rowid = m.rowid
@@ -190,6 +188,12 @@ def _fetch_and_score_fts_rows(
         if session is not None:
             base += " AND m.session_name = ?"
             params.append(session)
+        if project is not None:
+            base += " AND m.project = ?"
+            params.append(project)
+        if platform is not None:
+            base += " AND m.platform = ?"
+            params.append(platform)
         base += " ORDER BY score LIMIT ?"
         params.append(limit)
         rows = conn.execute(base, params).fetchall()
@@ -214,6 +218,8 @@ def _fetch_fts_candidate_ids(
     session: str | None,
     fts_query: str,
     limit: int,
+    project: str | None = None,
+    platform: str | None = None,
 ) -> list[str]:
     """Return top N memory IDs from FTS5 by BM25 rank. No scoring needed."""
     conn = sqlite3.connect(db_path, timeout=30.0)
@@ -229,6 +235,12 @@ def _fetch_fts_candidate_ids(
         if session is not None:
             base += " AND m.session_name = ?"
             params.append(session)
+        if project is not None:
+            base += " AND m.project = ?"
+            params.append(project)
+        if platform is not None:
+            base += " AND m.platform = ?"
+            params.append(platform)
         base += " ORDER BY bm25(memories_fts) LIMIT ?"
         params.append(limit)
         rows = conn.execute(base, params).fetchall()
@@ -255,7 +267,7 @@ def _fetch_and_score_by_ids(
         placeholders = ",".join("?" * len(memory_ids))
         memories = conn.execute(
             f"""
-            SELECT id, session_name, content, embedding, timestamp, context_type, metadata
+            SELECT id, session_name, content, embedding, timestamp, context_type, metadata, project, platform
             FROM memories
             WHERE id IN ({placeholders})
               AND (compaction_role IS NULL OR compaction_role != 'source')

--- a/marm-mcp-server/marm_mcp_server/core/models.py
+++ b/marm-mcp-server/marm_mcp_server/core/models.py
@@ -52,6 +52,14 @@ class SmartRecallRequest(BaseModel):
         le=3,
         description="Retrieval depth: 1=summary (~200 chars), 2=context (~500 chars), 3=full content",
     )
+    project: Optional[str] = Field(
+        default=None,
+        description="Filter to a specific project name (e.g. 'marm-systems'); omit to search all",
+    )
+    platform: Optional[str] = Field(
+        default=None,
+        description="Filter to a specific platform (e.g. 'claude-code', 'cursor'); omit to search all",
+    )
 
 
 class DeleteRequest(BaseModel):

--- a/marm-mcp-server/marm_mcp_server/endpoints/logging.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/logging.py
@@ -10,6 +10,7 @@ from typing import Optional
 from ..core.models import LogEntryRequest, DeleteRequest
 from ..core.memory import memory
 from ..core.events import events
+from ..config.settings import MARM_PROJECT, MARM_PLATFORM
 
 router = APIRouter(prefix="", tags=["Logging"])
 
@@ -56,8 +57,8 @@ async def marm_log_entry(request: LogEntryRequest):
                     conn.execute(
                         """
                         INSERT INTO log_entries
-                            (id, session_name, entry_date, topic, summary, full_entry)
-                        VALUES (?, ?, ?, ?, ?, ?)
+                            (id, session_name, entry_date, topic, summary, full_entry, project, platform)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             marker_id,
@@ -66,6 +67,8 @@ async def marm_log_entry(request: LogEntryRequest):
                             "session_start",
                             base_name,
                             formatted_entry,
+                            MARM_PROJECT or None,
+                            MARM_PLATFORM or None,
                         ),
                     )
                     try:
@@ -140,10 +143,19 @@ async def marm_log_entry(request: LogEntryRequest):
         with memory.get_connection() as conn:
             conn.execute(
                 """
-                INSERT INTO log_entries (id, session_name, entry_date, topic, summary, full_entry)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO log_entries (id, session_name, entry_date, topic, summary, full_entry, project, platform)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (entry_id, session, entry_date, topic, summary, formatted_entry),
+                (
+                    entry_id,
+                    session,
+                    entry_date,
+                    topic,
+                    summary,
+                    formatted_entry,
+                    MARM_PROJECT or None,
+                    MARM_PLATFORM or None,
+                ),
             )
             conn.execute(
                 """

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -102,46 +102,43 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
         log_results = []
         if request.include_logs:
             with memory.get_connection() as conn:
-                if request.search_all:
-                    cursor = conn.execute(
-                        """
-                        SELECT session_name, topic, summary, entry_date
-                        FROM log_entries
-                        WHERE topic LIKE ? OR summary LIKE ?
-                        ORDER BY entry_date DESC
-                        LIMIT ?
-                        """,
-                        (f"%{request.query}%", f"%{request.query}%", request.limit),
-                    )
-                else:
-                    cursor = conn.execute(
-                        """
-                        SELECT session_name, topic, summary, entry_date
-                        FROM log_entries
-                        WHERE (topic LIKE ? OR summary LIKE ?) AND session_name = ?
-                        ORDER BY entry_date DESC
-                        LIMIT ?
-                        """,
-                        (
-                            f"%{request.query}%",
-                            f"%{request.query}%",
-                            request.session_name,
-                            request.limit,
-                        ),
-                    )
+                log_base = """
+                    SELECT session_name, topic, summary, entry_date, project, platform
+                    FROM log_entries
+                    WHERE (topic LIKE ? OR summary LIKE ?)
+                """
+                log_params: list = [f"%{request.query}%", f"%{request.query}%"]
+                if not request.search_all:
+                    log_base += " AND session_name = ?"
+                    log_params.append(request.session_name)
+                if request.project is not None:
+                    log_base += " AND project = ?"
+                    log_params.append(request.project)
+                if request.platform is not None:
+                    log_base += " AND platform = ?"
+                    log_params.append(request.platform)
+                log_base += " ORDER BY entry_date DESC LIMIT ?"
+                log_params.append(request.limit)
                 log_results = [
                     {
                         "session_name": r[0],
                         "topic": r[1],
                         "summary": r[2],
                         "entry_date": r[3],
+                        "project": r[4],
+                        "platform": r[5],
                         "type": "log",
                     }
-                    for r in cursor.fetchall()
+                    for r in conn.execute(log_base, log_params).fetchall()
                 ]
 
         similar_memories, scan_meta = await memory.recall_similar(
-            request.query, search_session, request.limit, include_scan_metadata=True
+            request.query,
+            search_session,
+            request.limit,
+            include_scan_metadata=True,
+            project=request.project,
+            platform=request.platform,
         )
 
         if not similar_memories:

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - MARM Systems
-Version: 2.14.1
+Version: 2.14.2
 """
 
 import asyncio

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -184,6 +184,8 @@ from marm_mcp_server.config.settings import (  # noqa: E402
     SERVER_VERSION,
     DEFAULT_DB_PATH,
     SEMANTIC_SEARCH_AVAILABLE,
+    MARM_PROJECT,
+    MARM_PLATFORM,
 )
 
 mcp = FastMCP("MARM MCP Server")
@@ -198,6 +200,8 @@ async def marm_smart_recall(
     search_all: bool = False,
     include_logs: bool = False,
     detail: int = 1,
+    project: Optional[str] = None,
+    platform: Optional[str] = None,
 ) -> dict:
     """
     🧠 Recall memories by semantic similarity or keyword match.
@@ -215,11 +219,20 @@ async def marm_smart_recall(
         1 = summary only (~200 chars)
         2 = extended context (~500 chars)
         3 = full content
+    - project: filter results to a specific project (e.g. "marm-systems"); omit to search all
+    - platform: filter results to a specific platform (e.g. "claude-code", "cursor"); omit to search all
 
-    Returns: status, results list with id/content/score, results_count
+    Returns: status, results list with id/content/score/project/platform, results_count
     """
     return await smart_recall(
-        query, session_name, limit, search_all, include_logs, detail
+        query,
+        session_name,
+        limit,
+        search_all,
+        include_logs,
+        detail,
+        project=project,
+        platform=platform,
     )
 
 
@@ -278,8 +291,8 @@ async def marm_log_entry(
                     conn.execute(
                         """
                         INSERT INTO log_entries
-                            (id, session_name, entry_date, topic, summary, full_entry)
-                        VALUES (?, ?, ?, ?, ?, ?)
+                            (id, session_name, entry_date, topic, summary, full_entry, project, platform)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             marker_id,
@@ -288,6 +301,8 @@ async def marm_log_entry(
                             "session_start",
                             base_name,
                             formatted_entry,
+                            MARM_PROJECT or None,
+                            MARM_PLATFORM or None,
                         ),
                     )
                     try:
@@ -362,10 +377,19 @@ async def marm_log_entry(
         with memory.get_connection() as conn:
             conn.execute(
                 """
-                INSERT INTO log_entries (id, session_name, entry_date, topic, summary, full_entry)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO log_entries (id, session_name, entry_date, topic, summary, full_entry, project, platform)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (entry_id, session, entry_date, topic, summary, formatted_entry),
+                (
+                    entry_id,
+                    session,
+                    entry_date,
+                    topic,
+                    summary,
+                    formatted_entry,
+                    MARM_PROJECT or None,
+                    MARM_PLATFORM or None,
+                ),
             )
             conn.execute(
                 """

--- a/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
+++ b/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
@@ -126,7 +126,8 @@ async def apply_compaction_write(memory_store, candidate_id: str) -> str:
             snapshot = json.loads(snapshot_json)
             placeholders = ",".join("?" * len(source_ids))
             current_rows = conn.execute(
-                f"SELECT id, session_name, content_hash, compaction_role, metadata "
+                f"SELECT id, session_name, content_hash, compaction_role, "
+                f"metadata, project, platform "
                 f"FROM memories WHERE id IN ({placeholders})",
                 source_ids,
             ).fetchall()
@@ -171,7 +172,21 @@ async def apply_compaction_write(memory_store, candidate_id: str) -> str:
                     f"source memories already compacted: {already_compacted}"
                 )
 
-            for mem_id, _, content_hash, _, _ in current_rows:
+            source_scopes = {(r[5], r[6]) for r in current_rows}
+            if len(source_scopes) != 1:
+                conn.execute(
+                    "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
+                    "WHERE id = ?",
+                    (now, candidate_id),
+                )
+                conn.execute("COMMIT")
+                _committed = True
+                raise RuntimeError(
+                    f"source memories span multiple project/platform scopes: {source_scopes}"
+                )
+            summary_project, summary_platform = next(iter(source_scopes))
+
+            for mem_id, _, content_hash, _, _, _, _ in current_rows:
                 if snapshot.get(mem_id) != content_hash:
                     conn.execute(
                         "UPDATE compaction_staging SET status = 'stale', updated_at = ? "
@@ -204,14 +219,16 @@ async def apply_compaction_write(memory_store, candidate_id: str) -> str:
                 "source_count": len(source_ids),
                 "compacted_at": compacted_at,
                 "strategy": "semantic_cluster_summary",
+                "project": summary_project,
+                "platform": summary_platform,
             }
 
             conn.execute(
                 """
                 INSERT INTO memories
                     (id, session_name, content, embedding, content_hash, timestamp,
-                     context_type, metadata, compaction_role)
-                VALUES (?, ?, ?, ?, ?, ?, 'general', ?, 'summary')
+                     context_type, metadata, compaction_role, project, platform)
+                VALUES (?, ?, ?, ?, ?, ?, 'general', ?, 'summary', ?, ?)
                 """,
                 (
                     summary_id,
@@ -221,10 +238,12 @@ async def apply_compaction_write(memory_store, candidate_id: str) -> str:
                     summary_content_hash,
                     compacted_at,
                     json.dumps(summary_metadata),
+                    summary_project,
+                    summary_platform,
                 ),
             )
 
-            for mem_id, _, _, _, metadata_json in current_rows:
+            for mem_id, _, _, _, metadata_json, _, _ in current_rows:
                 existing_meta = json.loads(metadata_json) if metadata_json else {}
                 existing_meta.update(
                     {

--- a/marm-mcp-server/marm_mcp_server/services/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/services/notebook.py
@@ -23,18 +23,27 @@ async def _add(name: Optional[str], data: Optional[str], **_) -> dict:
             embedding_bytes = embedding.tobytes()
         except Exception:
             pass
+    project = MARM_PROJECT or None
+    platform = MARM_PLATFORM or None
+    now = datetime.now(timezone.utc).isoformat()
     with memory.get_connection() as conn:
-        conn.execute(
-            "INSERT OR REPLACE INTO notebook_entries (name, data, embedding, updated_at, project, platform) VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                name,
-                data,
-                embedding_bytes,
-                datetime.now(timezone.utc).isoformat(),
-                MARM_PROJECT or None,
-                MARM_PLATFORM or None,
-            ),
+        cursor = conn.execute(
+            """
+            UPDATE notebook_entries
+            SET data = ?, embedding = ?, updated_at = ?
+            WHERE name = ? AND project IS ? AND platform IS ?
+            """,
+            (data, embedding_bytes, now, name, project, platform),
         )
+        if cursor.rowcount == 0:
+            conn.execute(
+                """
+                INSERT INTO notebook_entries
+                    (name, data, embedding, updated_at, project, platform)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (name, data, embedding_bytes, now, project, platform),
+            )
         conn.commit()
     await events.emit("notebook_entry_added", {"name": name, "data": data})
     return {
@@ -50,13 +59,27 @@ async def _use(names: Optional[str], session_name: str = "main", **_) -> dict:
     name_list = [n.strip() for n in names.split(",") if n.strip()]
     if not name_list:
         return {"status": "error", "message": "names is required for action='use'"}
+    project = MARM_PROJECT or None
+    platform = MARM_PLATFORM or None
     activated_entries = []
     with memory.get_connection() as conn:
         for n in name_list:
             cursor = conn.execute(
-                "SELECT name, data FROM notebook_entries WHERE name = ?", (n,)
+                """
+                SELECT name, data FROM notebook_entries
+                WHERE name = ? AND project IS ? AND platform IS ?
+                """,
+                (n, project, platform),
             )
             result = cursor.fetchone()
+            if result is None and (project is not None or platform is not None):
+                result = conn.execute(
+                    """
+                    SELECT name, data FROM notebook_entries
+                    WHERE name = ? AND project IS NULL AND platform IS NULL
+                    """,
+                    (n,),
+                ).fetchone()
             if result:
                 activated_entries.append({"name": result[0], "data": result[1]})
     memory.set_active_notebook_entries(session_name, activated_entries)

--- a/marm-mcp-server/marm_mcp_server/services/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/services/notebook.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from ..core.memory import memory
 from ..core.events import events
+from ..config.settings import MARM_PROJECT, MARM_PLATFORM
 
 
 async def _add(name: Optional[str], data: Optional[str], **_) -> dict:
@@ -24,8 +25,15 @@ async def _add(name: Optional[str], data: Optional[str], **_) -> dict:
             pass
     with memory.get_connection() as conn:
         conn.execute(
-            "INSERT OR REPLACE INTO notebook_entries (name, data, embedding, updated_at) VALUES (?, ?, ?, ?)",
-            (name, data, embedding_bytes, datetime.now(timezone.utc).isoformat()),
+            "INSERT OR REPLACE INTO notebook_entries (name, data, embedding, updated_at, project, platform) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                name,
+                data,
+                embedding_bytes,
+                datetime.now(timezone.utc).isoformat(),
+                MARM_PROJECT or None,
+                MARM_PLATFORM or None,
+            ),
         )
         conn.commit()
     await events.emit("notebook_entry_added", {"name": name, "data": data})

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -22,6 +22,8 @@ async def smart_recall(
     search_all: bool = False,
     include_logs: bool = False,
     detail: int = 1,
+    project: str = None,
+    platform: str = None,
 ) -> dict:
     try:
         search_session = None if search_all else session_name
@@ -29,41 +31,44 @@ async def smart_recall(
         log_results = []
         if include_logs:
             with memory.get_connection() as conn:
-                if search_all:
-                    log_rows = conn.execute(
-                        """
-                        SELECT session_name, topic, summary, entry_date
-                        FROM log_entries
-                        WHERE topic LIKE ? OR summary LIKE ?
-                        ORDER BY entry_date DESC
-                        LIMIT ?
-                        """,
-                        (f"%{query}%", f"%{query}%", limit),
-                    ).fetchall()
-                else:
-                    log_rows = conn.execute(
-                        """
-                        SELECT session_name, topic, summary, entry_date
-                        FROM log_entries
-                        WHERE (topic LIKE ? OR summary LIKE ?) AND session_name = ?
-                        ORDER BY entry_date DESC
-                        LIMIT ?
-                        """,
-                        (f"%{query}%", f"%{query}%", session_name, limit),
-                    ).fetchall()
+                log_base = """
+                    SELECT session_name, topic, summary, entry_date, project, platform
+                    FROM log_entries
+                    WHERE (topic LIKE ? OR summary LIKE ?)
+                """
+                log_params: list = [f"%{query}%", f"%{query}%"]
+                if not search_all:
+                    log_base += " AND session_name = ?"
+                    log_params.append(session_name)
+                if project is not None:
+                    log_base += " AND project = ?"
+                    log_params.append(project)
+                if platform is not None:
+                    log_base += " AND platform = ?"
+                    log_params.append(platform)
+                log_base += " ORDER BY entry_date DESC LIMIT ?"
+                log_params.append(limit)
+                log_rows = conn.execute(log_base, log_params).fetchall()
             log_results = [
                 {
                     "session_name": r[0],
                     "topic": r[1],
                     "summary": r[2],
                     "entry_date": r[3],
+                    "project": r[4],
+                    "platform": r[5],
                     "type": "log",
                 }
                 for r in log_rows
             ]
 
         similar_memories, scan_meta = await memory.recall_similar(
-            query, session=search_session, limit=limit, include_scan_metadata=True
+            query,
+            session=search_session,
+            limit=limit,
+            include_scan_metadata=True,
+            project=project,
+            platform=platform,
         )
 
         if not similar_memories:
@@ -122,6 +127,8 @@ async def smart_recall(
                 "similarity": mem.get("similarity", 0.0),
                 "timestamp": mem.get("timestamp"),
                 "context_type": mem.get("context_type", "general"),
+                "project": mem.get("project"),
+                "platform": mem.get("platform"),
             }
             for mem in similar_memories
         ]

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -83,7 +83,11 @@ async def smart_recall(
             }
             if not search_all:
                 system_memories = await memory.recall_similar(
-                    query, session="marm_system", limit=limit
+                    query,
+                    session="marm_system",
+                    limit=limit,
+                    project=project,
+                    platform=platform,
                 )
                 if system_memories:
                     response["message"] = (

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.14.1"
+version = "2.14.2"
 description = "MARM-Systems is a complete protocol and platform—combining an advanced memory backend, modular semantic search, and agent-to-agent coordination with a scientifically structured, community-vetted methodology for reasoning, session recall, and collaborative AI workflows. More then just a set of tools, it's a complete AI memory ecosystem"
 readme = "README.md"
 authors = [

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "author": "Ryan Lyell - MARM Systems",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.14.1",
+      "version": "2.14.2",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.14.1",
+      "identifier": "lyellr88/marm-mcp-server:2.14.2",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_consolidation_write_time.py
+++ b/marm-mcp-server/tests/test_consolidation_write_time.py
@@ -128,7 +128,7 @@ async def test_find_semantic_duplicate_returns_id_when_similarity_above_threshol
 
     monkeypatched_recall_called = []
 
-    async def mock_recall(query, session=None, limit=5, query_vec=None):
+    async def mock_recall(query, session=None, limit=5, query_vec=None, **kwargs):
         monkeypatched_recall_called.append(query)
         return [{"id": "existing-id", "similarity": 0.95, "content": "similar content"}]
 
@@ -149,7 +149,7 @@ async def test_find_semantic_duplicate_returns_none_when_similarity_below_thresh
 ):
     mem = MARMMemory(str(tmp_path / "memory.db"))
 
-    async def mock_recall(query, session=None, limit=5, query_vec=None):
+    async def mock_recall(query, session=None, limit=5, query_vec=None, **kwargs):
         return [{"id": "existing-id", "similarity": 0.85, "content": "similar content"}]
 
     mem._load_encoder_lazily = lambda: True
@@ -164,7 +164,7 @@ async def test_find_semantic_duplicate_returns_none_when_similarity_below_thresh
 async def test_find_semantic_duplicate_returns_none_when_no_results(tmp_path):
     mem = MARMMemory(str(tmp_path / "memory.db"))
 
-    async def mock_recall(query, session=None, limit=5, query_vec=None):
+    async def mock_recall(query, session=None, limit=5, query_vec=None, **kwargs):
         return []
 
     mem._load_encoder_lazily = lambda: True
@@ -315,7 +315,7 @@ async def test_find_semantic_duplicate_passes_correct_session_to_recall(tmp_path
 
     sessions_seen = []
 
-    async def mock_recall(query, session=None, limit=5, query_vec=None):
+    async def mock_recall(query, session=None, limit=5, query_vec=None, **kwargs):
         sessions_seen.append(session)
         return []
 

--- a/marm-mcp-server/tests/test_project_platform_tagging.py
+++ b/marm-mcp-server/tests/test_project_platform_tagging.py
@@ -8,8 +8,11 @@ Covers:
 - Log entry write tagging and include_logs filtering
 """
 
+import json
 import pytest
 import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
 
 from marm_mcp_server.core.memory import MARMMemory
 
@@ -25,8 +28,7 @@ def _direct_insert_memory(
     conn, session: str, content: str, project=None, platform=None
 ):
     """Insert a memory row directly with explicit project/platform values."""
-    import uuid
-    from datetime import datetime, timezone
+    memory_id = str(uuid.uuid4())
 
     conn.execute(
         """
@@ -36,7 +38,7 @@ def _direct_insert_memory(
         VALUES (?, ?, ?, NULL, ?, ?, 'general', '{}', ?, ?)
         """,
         (
-            str(uuid.uuid4()),
+            memory_id,
             session,
             content,
             content,
@@ -46,12 +48,11 @@ def _direct_insert_memory(
         ),
     )
     conn.commit()
+    return memory_id
 
 
 def _direct_insert_log(conn, session: str, topic: str, project=None, platform=None):
     """Insert a log_entry row directly with explicit project/platform values."""
-    import uuid
-    from datetime import datetime, timezone
 
     conn.execute(
         """
@@ -71,6 +72,40 @@ def _direct_insert_log(conn, session: str, topic: str, project=None, platform=No
         ),
     )
     conn.commit()
+
+
+def _stage_compaction_candidate(conn, session: str, source_ids: list[str]) -> str:
+    """Create a ready-to-apply compaction candidate for source memories."""
+    candidate_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    rows = conn.execute(
+        f"SELECT id, content_hash FROM memories WHERE id IN ({','.join('?' * len(source_ids))})",
+        source_ids,
+    ).fetchall()
+    snapshot = {row[0]: row[1] for row in rows}
+    conn.execute(
+        """
+        INSERT INTO compaction_staging
+            (id, session_name, source_memory_ids, preview, suggested_summary,
+             status, candidate_hash, source_updated_at_snapshot, expires_at,
+             created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, 'summary_staged', ?, ?, ?, ?, ?)
+        """,
+        (
+            candidate_id,
+            session,
+            json.dumps(source_ids),
+            "preview",
+            "compacted project summary",
+            "candidate-hash",
+            json.dumps(snapshot),
+            (now + timedelta(hours=1)).isoformat(),
+            now.isoformat(),
+            now.isoformat(),
+        ),
+    )
+    conn.commit()
+    return candidate_id
 
 
 # ---------------------------------------------------------------------------
@@ -403,6 +438,35 @@ def test_http_smart_recall_results_include_project_and_platform_fields(
     assert r["platform"] == "vscode"
 
 
+@pytest.mark.asyncio
+async def test_scoped_smart_recall_filters_system_fallback(monkeypatch, tmp_path):
+    from marm_mcp_server.services import recall as recall_module
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+    monkeypatch.setattr(recall_module, "memory", mem)
+
+    with mem.get_connection() as conn:
+        _direct_insert_memory(
+            conn,
+            "marm_system",
+            "fallback system canary",
+            project=None,
+            platform=None,
+        )
+
+    result = await recall_module.smart_recall(
+        "canary",
+        session_name="empty-session",
+        project="proj-a",
+        platform="claude-code",
+        detail=3,
+    )
+
+    assert result["status"] == "no_results"
+    assert "system_results" not in result
+
+
 # ---------------------------------------------------------------------------
 # 5. Log entry tagging and include_logs filtering
 # ---------------------------------------------------------------------------
@@ -673,7 +737,62 @@ async def test_semantic_dedup_does_not_match_across_project_boundary(
 
 
 # ---------------------------------------------------------------------------
-# 8. Notebook tagging
+# 8. Compaction scope preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compaction_summary_inherits_source_project_and_platform(tmp_path):
+    from marm_mcp_server.services.compaction_apply import apply_compaction_write
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    with mem.get_connection() as conn:
+        source_a = _direct_insert_memory(
+            conn, "session-a", "source one", project="proj-a", platform="claude-code"
+        )
+        source_b = _direct_insert_memory(
+            conn, "session-a", "source two", project="proj-a", platform="claude-code"
+        )
+        candidate_id = _stage_compaction_candidate(
+            conn, "session-a", [source_a, source_b]
+        )
+
+    summary_id = await apply_compaction_write(mem, candidate_id)
+
+    with mem.get_connection() as conn:
+        row = conn.execute(
+            "SELECT project, platform FROM memories WHERE id = ?", (summary_id,)
+        ).fetchone()
+
+    assert row == ("proj-a", "claude-code")
+
+
+@pytest.mark.asyncio
+async def test_compaction_rejects_mixed_project_or_platform_sources(tmp_path):
+    from marm_mcp_server.services.compaction_apply import apply_compaction_write
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    with mem.get_connection() as conn:
+        source_a = _direct_insert_memory(
+            conn, "session-a", "source one", project="proj-a", platform="claude-code"
+        )
+        source_b = _direct_insert_memory(
+            conn, "session-a", "source two", project="proj-b", platform="claude-code"
+        )
+        candidate_id = _stage_compaction_candidate(
+            conn, "session-a", [source_a, source_b]
+        )
+
+    with pytest.raises(RuntimeError, match="multiple project/platform scopes"):
+        await apply_compaction_write(mem, candidate_id)
+
+
+# ---------------------------------------------------------------------------
+# 9. Notebook tagging
 # ---------------------------------------------------------------------------
 
 
@@ -729,3 +848,69 @@ async def test_notebook_add_null_tags_when_detection_empty(monkeypatch, tmp_path
     assert row is not None
     assert row[0] is None
     assert row[1] is None
+
+
+@pytest.mark.asyncio
+async def test_notebook_same_name_can_exist_in_different_scopes(monkeypatch, tmp_path):
+    from marm_mcp_server.services import notebook as nb_module
+
+    mem = MARMMemory(str(tmp_path / "nb-test.db"))
+    mem._encoder_failed = True
+    monkeypatch.setattr(nb_module, "memory", mem)
+
+    monkeypatch.setattr(nb_module, "MARM_PROJECT", "proj-a")
+    monkeypatch.setattr(nb_module, "MARM_PLATFORM", "claude-code")
+    await nb_module.notebook_dispatch(
+        action="add", name="shared-rule", data="project a rule"
+    )
+
+    monkeypatch.setattr(nb_module, "MARM_PROJECT", "proj-b")
+    monkeypatch.setattr(nb_module, "MARM_PLATFORM", "claude-code")
+    await nb_module.notebook_dispatch(
+        action="add", name="shared-rule", data="project b rule"
+    )
+
+    with sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
+        rows = conn.execute(
+            """
+            SELECT data, project, platform
+            FROM notebook_entries
+            WHERE name = 'shared-rule'
+            ORDER BY project
+            """
+        ).fetchall()
+
+    assert rows == [
+        ("project a rule", "proj-a", "claude-code"),
+        ("project b rule", "proj-b", "claude-code"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notebook_use_prefers_current_project_scope(monkeypatch, tmp_path):
+    from marm_mcp_server.services import notebook as nb_module
+
+    mem = MARMMemory(str(tmp_path / "nb-test.db"))
+    mem._encoder_failed = True
+    monkeypatch.setattr(nb_module, "memory", mem)
+
+    monkeypatch.setattr(nb_module, "MARM_PROJECT", "proj-a")
+    monkeypatch.setattr(nb_module, "MARM_PLATFORM", "claude-code")
+    await nb_module.notebook_dispatch(
+        action="add", name="shared-rule", data="project a rule"
+    )
+
+    monkeypatch.setattr(nb_module, "MARM_PROJECT", "proj-b")
+    monkeypatch.setattr(nb_module, "MARM_PLATFORM", "claude-code")
+    await nb_module.notebook_dispatch(
+        action="add", name="shared-rule", data="project b rule"
+    )
+
+    result = await nb_module.notebook_dispatch(
+        action="use", names="shared-rule", session_name="main"
+    )
+
+    assert result["status"] == "success"
+    assert result["entries"] == [
+        {"name": "shared-rule", "data": "project b rule"}
+    ]

--- a/marm-mcp-server/tests/test_project_platform_tagging.py
+++ b/marm-mcp-server/tests/test_project_platform_tagging.py
@@ -108,6 +108,26 @@ def _stage_compaction_candidate(conn, session: str, source_ids: list[str]) -> st
     return candidate_id
 
 
+def _patch_memory_write_scope(monkeypatch, project, platform) -> None:
+    """Patch scope constants on the exact write/consolidation functions under test.
+
+    Some HTTP tests reload marm_mcp_server modules mid-suite. This test module's
+    top-level MARMMemory import can then point at a different function graph than
+    a fresh import by module name.
+    """
+    store_globals = MARMMemory.store_memory.__globals__["_store_memory"].__globals__
+    monkeypatch.setitem(store_globals, "MARM_PROJECT", project)
+    monkeypatch.setitem(store_globals, "MARM_PLATFORM", platform)
+
+    exact_globals = store_globals["find_exact_duplicate"].__globals__
+    monkeypatch.setitem(exact_globals, "MARM_PROJECT", project)
+    monkeypatch.setitem(exact_globals, "MARM_PLATFORM", platform)
+
+    semantic_globals = store_globals["find_semantic_duplicate"].__globals__
+    monkeypatch.setitem(semantic_globals, "MARM_PROJECT", project)
+    monkeypatch.setitem(semantic_globals, "MARM_PLATFORM", platform)
+
+
 # ---------------------------------------------------------------------------
 # 1. Write tagging — memory
 # ---------------------------------------------------------------------------
@@ -115,10 +135,7 @@ def _stage_compaction_candidate(conn, session: str, source_ids: list[str]) -> st
 
 @pytest.mark.asyncio
 async def test_memory_insert_tags_project_and_platform(monkeypatch, tmp_path):
-    from marm_mcp_server.core import memory_ops as ops
-
-    monkeypatch.setattr(ops, "MARM_PROJECT", "test-project")
-    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
+    _patch_memory_write_scope(monkeypatch, "test-project", "claude-code")
 
     mem = MARMMemory(str(tmp_path / "memory.db"))
     mem._encoder_failed = True
@@ -138,10 +155,7 @@ async def test_memory_insert_tags_project_and_platform(monkeypatch, tmp_path):
 async def test_memory_insert_null_tags_when_no_project_or_platform(
     monkeypatch, tmp_path
 ):
-    from marm_mcp_server.core import memory_ops as ops
-
-    monkeypatch.setattr(ops, "MARM_PROJECT", "")
-    monkeypatch.setattr(ops, "MARM_PLATFORM", "")
+    _patch_memory_write_scope(monkeypatch, "", "")
 
     mem = MARMMemory(str(tmp_path / "memory.db"))
     mem._encoder_failed = True
@@ -251,23 +265,15 @@ async def test_recall_project_and_platform_combined_filter(monkeypatch, tmp_path
 
 @pytest.mark.asyncio
 async def test_exact_dedup_does_not_cross_project_boundary(monkeypatch, tmp_path):
-    from marm_mcp_server.core import memory_ops as ops
-    from marm_mcp_server.core import consolidation as cons
-
-    monkeypatch.setattr(ops, "CONSOLIDATION_ENABLED", True)
+    store_globals = MARMMemory.store_memory.__globals__["_store_memory"].__globals__
+    monkeypatch.setitem(store_globals, "CONSOLIDATION_ENABLED", True)
     mem = MARMMemory(str(tmp_path / "memory.db"))
     mem._encoder_failed = True
 
-    monkeypatch.setattr(ops, "MARM_PROJECT", "project-a")
-    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
-    monkeypatch.setattr(cons, "MARM_PROJECT", "project-a")
-    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    _patch_memory_write_scope(monkeypatch, "project-a", "claude-code")
     id_a = await mem.store_memory("identical content", "session-x")
 
-    monkeypatch.setattr(ops, "MARM_PROJECT", "project-b")
-    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
-    monkeypatch.setattr(cons, "MARM_PROJECT", "project-b")
-    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    _patch_memory_write_scope(monkeypatch, "project-b", "claude-code")
     id_b = await mem.store_memory("identical content", "session-x")
 
     # Different projects — must not deduplicate
@@ -281,23 +287,15 @@ async def test_exact_dedup_does_not_cross_project_boundary(monkeypatch, tmp_path
 
 @pytest.mark.asyncio
 async def test_exact_dedup_does_not_cross_platform_boundary(monkeypatch, tmp_path):
-    from marm_mcp_server.core import memory_ops as ops
-    from marm_mcp_server.core import consolidation as cons
-
-    monkeypatch.setattr(ops, "CONSOLIDATION_ENABLED", True)
+    store_globals = MARMMemory.store_memory.__globals__["_store_memory"].__globals__
+    monkeypatch.setitem(store_globals, "CONSOLIDATION_ENABLED", True)
     mem = MARMMemory(str(tmp_path / "memory.db"))
     mem._encoder_failed = True
 
-    monkeypatch.setattr(ops, "MARM_PROJECT", "proj-x")
-    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
-    monkeypatch.setattr(cons, "MARM_PROJECT", "proj-x")
-    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    _patch_memory_write_scope(monkeypatch, "proj-x", "claude-code")
     id_a = await mem.store_memory("shared content", "session-x")
 
-    monkeypatch.setattr(ops, "MARM_PROJECT", "proj-x")
-    monkeypatch.setattr(ops, "MARM_PLATFORM", "cursor")
-    monkeypatch.setattr(cons, "MARM_PROJECT", "proj-x")
-    monkeypatch.setattr(cons, "MARM_PLATFORM", "cursor")
+    _patch_memory_write_scope(monkeypatch, "proj-x", "cursor")
     id_b = await mem.store_memory("shared content", "session-x")
 
     # Same project but different platform — must not deduplicate
@@ -313,16 +311,12 @@ async def test_exact_dedup_does_not_cross_platform_boundary(monkeypatch, tmp_pat
 async def test_exact_dedup_still_works_within_same_project_and_platform(
     monkeypatch, tmp_path
 ):
-    from marm_mcp_server.core import memory_ops as ops
-    from marm_mcp_server.core import consolidation as cons
-
-    monkeypatch.setattr(ops, "CONSOLIDATION_ENABLED", True)
+    store_globals = MARMMemory.store_memory.__globals__["_store_memory"].__globals__
+    monkeypatch.setitem(store_globals, "CONSOLIDATION_ENABLED", True)
     mem = MARMMemory(str(tmp_path / "memory.db"))
     mem._encoder_failed = True
 
-    for module in (ops, cons):
-        monkeypatch.setattr(module, "MARM_PROJECT", "proj-x")
-        monkeypatch.setattr(module, "MARM_PLATFORM", "claude-code")
+    _patch_memory_write_scope(monkeypatch, "proj-x", "claude-code")
 
     id_a = await mem.store_memory("deduplicated content", "session-x")
     id_b = await mem.store_memory("deduplicated content", "session-x")
@@ -911,6 +905,4 @@ async def test_notebook_use_prefers_current_project_scope(monkeypatch, tmp_path)
     )
 
     assert result["status"] == "success"
-    assert result["entries"] == [
-        {"name": "shared-rule", "data": "project b rule"}
-    ]
+    assert result["entries"] == [{"name": "shared-rule", "data": "project b rule"}]

--- a/marm-mcp-server/tests/test_project_platform_tagging.py
+++ b/marm-mcp-server/tests/test_project_platform_tagging.py
@@ -1,0 +1,731 @@
+"""Tests for project/platform schema additions.
+
+Covers:
+- Memory write tagging (project and platform columns populated)
+- Scoped recall excludes rows from other projects/platforms
+- Consolidation dedup does not cross project/platform boundaries
+- HTTP marm_smart_recall schema accepts and filters by project/platform
+- Log entry write tagging and include_logs filtering
+"""
+
+import pytest
+import sqlite3
+
+from marm_mcp_server.core.memory import MARMMemory
+
+from conftest import load_isolated_server, local_client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _direct_insert_memory(
+    conn, session: str, content: str, project=None, platform=None
+):
+    """Insert a memory row directly with explicit project/platform values."""
+    import uuid
+    from datetime import datetime, timezone
+
+    conn.execute(
+        """
+        INSERT INTO memories
+            (id, session_name, content, embedding, content_hash, timestamp,
+             context_type, metadata, project, platform)
+        VALUES (?, ?, ?, NULL, ?, ?, 'general', '{}', ?, ?)
+        """,
+        (
+            str(uuid.uuid4()),
+            session,
+            content,
+            content,
+            datetime.now(timezone.utc).isoformat(),
+            project,
+            platform,
+        ),
+    )
+    conn.commit()
+
+
+def _direct_insert_log(conn, session: str, topic: str, project=None, platform=None):
+    """Insert a log_entry row directly with explicit project/platform values."""
+    import uuid
+    from datetime import datetime, timezone
+
+    conn.execute(
+        """
+        INSERT INTO log_entries
+            (id, session_name, entry_date, topic, summary, full_entry, project, platform)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(uuid.uuid4()),
+            session,
+            datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            topic,
+            topic,
+            topic,
+            project,
+            platform,
+        ),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# 1. Write tagging — memory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_insert_tags_project_and_platform(monkeypatch, tmp_path):
+    from marm_mcp_server.core import memory_ops as ops
+
+    monkeypatch.setattr(ops, "MARM_PROJECT", "test-project")
+    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    mid = await mem.store_memory("testing tagging", "session-a")
+
+    with mem.get_connection() as conn:
+        row = conn.execute(
+            "SELECT project, platform FROM memories WHERE id = ?", (mid,)
+        ).fetchone()
+
+    assert row[0] == "test-project"
+    assert row[1] == "claude-code"
+
+
+@pytest.mark.asyncio
+async def test_memory_insert_null_tags_when_no_project_or_platform(
+    monkeypatch, tmp_path
+):
+    from marm_mcp_server.core import memory_ops as ops
+
+    monkeypatch.setattr(ops, "MARM_PROJECT", "")
+    monkeypatch.setattr(ops, "MARM_PLATFORM", "")
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    mid = await mem.store_memory("untagged memory", "session-a")
+
+    with mem.get_connection() as conn:
+        row = conn.execute(
+            "SELECT project, platform FROM memories WHERE id = ?", (mid,)
+        ).fetchone()
+
+    assert row[0] is None
+    assert row[1] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Scoped recall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_project_filter_excludes_other_projects(monkeypatch, tmp_path):
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    with mem.get_connection() as conn:
+        _direct_insert_memory(
+            conn, "session-a", "alpha content", project="project-alpha"
+        )
+        _direct_insert_memory(conn, "session-a", "beta content", project="project-beta")
+
+    results = await mem.recall_text_search(
+        "content", session=None, limit=10, project="project-alpha"
+    )
+
+    assert len(results) == 1
+    assert results[0]["content"] == "alpha content"
+    assert results[0]["project"] == "project-alpha"
+
+
+@pytest.mark.asyncio
+async def test_recall_platform_filter_excludes_other_platforms(monkeypatch, tmp_path):
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    with mem.get_connection() as conn:
+        _direct_insert_memory(
+            conn, "session-a", "claude memory", platform="claude-code"
+        )
+        _direct_insert_memory(conn, "session-a", "cursor memory", platform="cursor")
+
+    results = await mem.recall_text_search(
+        "memory", session=None, limit=10, platform="claude-code"
+    )
+
+    assert len(results) == 1
+    assert results[0]["content"] == "claude memory"
+    assert results[0]["platform"] == "claude-code"
+
+
+@pytest.mark.asyncio
+async def test_recall_unfiltered_returns_all_projects(monkeypatch, tmp_path):
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    with mem.get_connection() as conn:
+        _direct_insert_memory(
+            conn, "session-a", "alpha content", project="project-alpha"
+        )
+        _direct_insert_memory(conn, "session-a", "beta content", project="project-beta")
+        _direct_insert_memory(conn, "session-a", "untagged content", project=None)
+
+    results = await mem.recall_text_search("content", session=None, limit=10)
+
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_recall_project_and_platform_combined_filter(monkeypatch, tmp_path):
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    with mem.get_connection() as conn:
+        _direct_insert_memory(
+            conn, "s", "match", project="proj-a", platform="claude-code"
+        )
+        _direct_insert_memory(
+            conn, "s", "wrong platform", project="proj-a", platform="cursor"
+        )
+        _direct_insert_memory(
+            conn, "s", "wrong project", project="proj-b", platform="claude-code"
+        )
+
+    results = await mem.recall_text_search(
+        "match", session=None, limit=10, project="proj-a", platform="claude-code"
+    )
+
+    # Only the first row matches both filters
+    assert len(results) == 1
+    assert results[0]["content"] == "match"
+
+
+# ---------------------------------------------------------------------------
+# 3. Consolidation does not cross project/platform boundaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exact_dedup_does_not_cross_project_boundary(monkeypatch, tmp_path):
+    from marm_mcp_server.core import memory_ops as ops
+    from marm_mcp_server.core import consolidation as cons
+
+    monkeypatch.setattr(ops, "CONSOLIDATION_ENABLED", True)
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    monkeypatch.setattr(ops, "MARM_PROJECT", "project-a")
+    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
+    monkeypatch.setattr(cons, "MARM_PROJECT", "project-a")
+    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    id_a = await mem.store_memory("identical content", "session-x")
+
+    monkeypatch.setattr(ops, "MARM_PROJECT", "project-b")
+    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
+    monkeypatch.setattr(cons, "MARM_PROJECT", "project-b")
+    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    id_b = await mem.store_memory("identical content", "session-x")
+
+    # Different projects — must not deduplicate
+    assert id_a != id_b
+
+    with mem.get_connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_exact_dedup_does_not_cross_platform_boundary(monkeypatch, tmp_path):
+    from marm_mcp_server.core import memory_ops as ops
+    from marm_mcp_server.core import consolidation as cons
+
+    monkeypatch.setattr(ops, "CONSOLIDATION_ENABLED", True)
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    monkeypatch.setattr(ops, "MARM_PROJECT", "proj-x")
+    monkeypatch.setattr(ops, "MARM_PLATFORM", "claude-code")
+    monkeypatch.setattr(cons, "MARM_PROJECT", "proj-x")
+    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    id_a = await mem.store_memory("shared content", "session-x")
+
+    monkeypatch.setattr(ops, "MARM_PROJECT", "proj-x")
+    monkeypatch.setattr(ops, "MARM_PLATFORM", "cursor")
+    monkeypatch.setattr(cons, "MARM_PROJECT", "proj-x")
+    monkeypatch.setattr(cons, "MARM_PLATFORM", "cursor")
+    id_b = await mem.store_memory("shared content", "session-x")
+
+    # Same project but different platform — must not deduplicate
+    assert id_a != id_b
+
+    with mem.get_connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_exact_dedup_still_works_within_same_project_and_platform(
+    monkeypatch, tmp_path
+):
+    from marm_mcp_server.core import memory_ops as ops
+    from marm_mcp_server.core import consolidation as cons
+
+    monkeypatch.setattr(ops, "CONSOLIDATION_ENABLED", True)
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._encoder_failed = True
+
+    for module in (ops, cons):
+        monkeypatch.setattr(module, "MARM_PROJECT", "proj-x")
+        monkeypatch.setattr(module, "MARM_PLATFORM", "claude-code")
+
+    id_a = await mem.store_memory("deduplicated content", "session-x")
+    id_b = await mem.store_memory("deduplicated content", "session-x")
+
+    # Same project + platform + session — must deduplicate
+    assert id_a == id_b
+
+    with mem.get_connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. HTTP — schema and filtering
+# ---------------------------------------------------------------------------
+
+
+def test_http_smart_recall_accepts_project_and_platform_fields(monkeypatch, tmp_path):
+    monkeypatch.setenv("MARM_PROJECT", "test-proj")
+    monkeypatch.setenv("MARM_PLATFORM", "claude-code")
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    resp = client.post(
+        "/marm_smart_recall",
+        json={
+            "query": "anything",
+            "session_name": "main",
+            "project": "test-proj",
+            "platform": "claude-code",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] in ("success", "no_results")
+
+
+def test_http_smart_recall_project_filter_returns_only_matching_project(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("MARM_PROJECT", "proj-a")
+    monkeypatch.setenv("MARM_PLATFORM", "claude-code")
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    db_path = str(tmp_path / "marm_memory.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = None
+        _direct_insert_memory(conn, "main", "alpha recall content", project="proj-a")
+        _direct_insert_memory(conn, "main", "beta recall content", project="proj-b")
+
+    resp = client.post(
+        "/marm_smart_recall",
+        json={"query": "content", "search_all": True, "project": "proj-a", "detail": 3},
+    )
+    assert resp.status_code == 200
+    results = resp.json().get("results", [])
+    assert all(r["project"] == "proj-a" for r in results)
+    assert any("alpha" in r["content"] for r in results)
+    assert not any("beta" in r["content"] for r in results)
+
+
+def test_http_smart_recall_platform_filter_returns_only_matching_platform(
+    monkeypatch, tmp_path
+):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    db_path = str(tmp_path / "marm_memory.db")
+    with sqlite3.connect(db_path) as conn:
+        _direct_insert_memory(conn, "main", "claude work", platform="claude-code")
+        _direct_insert_memory(conn, "main", "cursor work", platform="cursor")
+
+    resp = client.post(
+        "/marm_smart_recall",
+        json={
+            "query": "work",
+            "search_all": True,
+            "platform": "claude-code",
+            "detail": 3,
+        },
+    )
+    assert resp.status_code == 200
+    results = resp.json().get("results", [])
+    assert all(r["platform"] == "claude-code" for r in results)
+    assert not any(r["platform"] == "cursor" for r in results)
+
+
+def test_http_smart_recall_results_include_project_and_platform_fields(
+    monkeypatch, tmp_path
+):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    db_path = str(tmp_path / "marm_memory.db")
+    with sqlite3.connect(db_path) as conn:
+        _direct_insert_memory(
+            conn, "main", "tagged memory", project="my-proj", platform="vscode"
+        )
+
+    resp = client.post(
+        "/marm_smart_recall",
+        json={"query": "tagged", "search_all": True, "detail": 3},
+    )
+    assert resp.status_code == 200
+    results = resp.json().get("results", [])
+    assert len(results) >= 1
+    r = results[0]
+    assert "project" in r
+    assert "platform" in r
+    assert r["project"] == "my-proj"
+    assert r["platform"] == "vscode"
+
+
+# ---------------------------------------------------------------------------
+# 5. Log entry tagging and include_logs filtering
+# ---------------------------------------------------------------------------
+
+
+def test_log_entry_tags_project_and_platform_on_write(monkeypatch, tmp_path):
+    monkeypatch.setenv("MARM_PROJECT", "log-proj")
+    monkeypatch.setenv("MARM_PLATFORM", "claude-code")
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    resp = client.post(
+        "/marm_log_entry",
+        json={
+            "session_name": "main",
+            "entry": "2026-06-18-testing-project platform log tagging",
+        },
+    )
+    assert resp.status_code == 200
+
+    db_path = str(tmp_path / "marm_memory.db")
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT project, platform FROM log_entries WHERE session_name = 'main'"
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "log-proj"
+    assert row[1] == "claude-code"
+
+
+def test_include_logs_platform_filter_excludes_other_platforms(monkeypatch, tmp_path):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    db_path = str(tmp_path / "marm_memory.db")
+    with sqlite3.connect(db_path) as conn:
+        _direct_insert_log(conn, "main", "claude log entry", platform="claude-code")
+        _direct_insert_log(conn, "main", "cursor log entry", platform="cursor")
+
+    resp = client.post(
+        "/marm_smart_recall",
+        json={
+            "query": "log entry",
+            "search_all": True,
+            "include_logs": True,
+            "platform": "claude-code",
+        },
+    )
+    assert resp.status_code == 200
+    log_results = resp.json().get("log_results", [])
+    assert all(r["platform"] == "claude-code" for r in log_results)
+    assert not any(r["platform"] == "cursor" for r in log_results)
+
+
+def test_include_logs_project_filter_excludes_other_projects(monkeypatch, tmp_path):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    db_path = str(tmp_path / "marm_memory.db")
+    with sqlite3.connect(db_path) as conn:
+        _direct_insert_log(conn, "main", "alpha log", project="proj-alpha")
+        _direct_insert_log(conn, "main", "beta log", project="proj-beta")
+
+    resp = client.post(
+        "/marm_smart_recall",
+        json={
+            "query": "log",
+            "search_all": True,
+            "include_logs": True,
+            "project": "proj-alpha",
+        },
+    )
+    assert resp.status_code == 200
+    log_results = resp.json().get("log_results", [])
+    assert all(r["project"] == "proj-alpha" for r in log_results)
+    assert not any(r["project"] == "proj-beta" for r in log_results)
+
+
+def test_include_logs_results_contain_project_and_platform_fields(
+    monkeypatch, tmp_path
+):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    db_path = str(tmp_path / "marm_memory.db")
+    with sqlite3.connect(db_path) as conn:
+        _direct_insert_log(
+            conn, "main", "tagged log", project="my-proj", platform="vscode"
+        )
+
+    resp = client.post(
+        "/marm_smart_recall",
+        json={"query": "tagged", "search_all": True, "include_logs": True},
+    )
+    assert resp.status_code == 200
+    log_results = resp.json().get("log_results", [])
+    assert len(log_results) >= 1
+    r = log_results[0]
+    assert r["project"] == "my-proj"
+    assert r["platform"] == "vscode"
+
+
+# ---------------------------------------------------------------------------
+# 6. FTS and embedding-level scoring function filters
+# ---------------------------------------------------------------------------
+
+
+def _direct_insert_memory_with_embedding(
+    conn, session: str, content: str, project=None, platform=None
+):
+    """Insert a memory row with a real (fake) embedding blob so semantic scoring fires."""
+    import uuid
+    from datetime import datetime, timezone
+    import numpy as np
+
+    embed_bytes = np.ones(384, dtype=np.float32).tobytes()
+    conn.execute(
+        """
+        INSERT INTO memories
+            (id, session_name, content, embedding, content_hash, timestamp,
+             context_type, metadata, project, platform)
+        VALUES (?, ?, ?, ?, ?, ?, 'general', '{}', ?, ?)
+        """,
+        (
+            str(uuid.uuid4()),
+            session,
+            content,
+            embed_bytes,
+            content,
+            datetime.now(timezone.utc).isoformat(),
+            project,
+            platform,
+        ),
+    )
+    conn.commit()
+
+
+def test_fts_candidate_ids_filter_respects_project(tmp_path):
+    from marm_mcp_server.core.memory_scoring import _fetch_fts_candidate_ids
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    with mem.get_connection() as conn:
+        _direct_insert_memory(conn, "s", "python debugging session", project="proj-a")
+        _direct_insert_memory(conn, "s", "python debugging notes", project="proj-b")
+
+    ids = _fetch_fts_candidate_ids(
+        mem.db_path, None, "python debugging", 10, project="proj-a"
+    )
+    assert len(ids) == 1
+
+    ids_all = _fetch_fts_candidate_ids(mem.db_path, None, "python debugging", 10)
+    assert len(ids_all) == 2
+
+
+def test_fts_rows_scoring_filter_respects_platform(tmp_path):
+    from marm_mcp_server.core.memory_scoring import _fetch_and_score_fts_rows
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    with mem.get_connection() as conn:
+        _direct_insert_memory(
+            conn, "s", "refactor session notes", platform="claude-code"
+        )
+        _direct_insert_memory(conn, "s", "refactor cursor notes", platform="cursor")
+
+    rows = _fetch_and_score_fts_rows(
+        mem.db_path, None, "refactor", 10, platform="claude-code"
+    )
+    assert len(rows) == 1
+    assert rows[0][0]["platform"] == "claude-code"
+
+
+def test_embedding_rows_filter_respects_project(tmp_path):
+    import numpy as np
+    from marm_mcp_server.core.memory_scoring import _fetch_and_score_embedding_rows
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    with mem.get_connection() as conn:
+        _direct_insert_memory_with_embedding(
+            conn, "s", "embedding alpha", project="proj-a"
+        )
+        _direct_insert_memory_with_embedding(
+            conn, "s", "embedding beta", project="proj-b"
+        )
+
+    query_vec = np.ones(384, dtype=np.float32)
+    results, _, _ = _fetch_and_score_embedding_rows(
+        mem.db_path, None, 1000, query_vec, 10, project="proj-a"
+    )
+    assert len(results) == 1
+    assert results[0][0]["project"] == "proj-a"
+
+    results_all, _, _ = _fetch_and_score_embedding_rows(
+        mem.db_path, None, 1000, query_vec, 10
+    )
+    assert len(results_all) == 2
+
+
+# ---------------------------------------------------------------------------
+# 7. Semantic consolidation isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semantic_dedup_passes_project_and_platform_to_recall(
+    monkeypatch, tmp_path
+):
+    from marm_mcp_server.core import consolidation as cons
+    from marm_mcp_server.core.consolidation import find_semantic_duplicate
+
+    monkeypatch.setattr(cons, "MARM_PROJECT", "proj-x")
+    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+
+    captured_kwargs = {}
+
+    async def mock_recall(query, session=None, limit=5, query_vec=None, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+    mem._load_encoder_lazily = lambda: True
+    mem.recall_similar = mock_recall
+
+    await find_semantic_duplicate(mem, "some content", "session-a", 0.92)
+
+    assert captured_kwargs.get("project") == "proj-x"
+    assert captured_kwargs.get("platform") == "claude-code"
+
+
+@pytest.mark.asyncio
+async def test_semantic_dedup_does_not_match_across_project_boundary(
+    monkeypatch, tmp_path
+):
+    import numpy as np
+    from marm_mcp_server.core import consolidation as cons
+    from marm_mcp_server.core.consolidation import find_semantic_duplicate
+
+    mem = MARMMemory(str(tmp_path / "memory.db"))
+
+    with mem.get_connection() as conn:
+        _direct_insert_memory_with_embedding(
+            conn,
+            "session-a",
+            "machine learning deployment",
+            project="proj-a",
+            platform="claude-code",
+        )
+
+    fake_vec = np.ones(384, dtype=np.float32)
+    mem._load_encoder_lazily = lambda: True
+    mem._encode_sync = lambda _text: fake_vec
+
+    # Scoped to proj-b — no match
+    monkeypatch.setattr(cons, "MARM_PROJECT", "proj-b")
+    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    result_b = await find_semantic_duplicate(
+        mem, "machine learning deployment", "session-a", 0.5
+    )
+    assert result_b is None
+
+    # Scoped to proj-a — finds the row
+    monkeypatch.setattr(cons, "MARM_PROJECT", "proj-a")
+    monkeypatch.setattr(cons, "MARM_PLATFORM", "claude-code")
+    result_a = await find_semantic_duplicate(
+        mem, "machine learning deployment", "session-a", 0.5
+    )
+    assert result_a is not None
+
+
+# ---------------------------------------------------------------------------
+# 8. Notebook tagging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notebook_add_tags_project_and_platform(monkeypatch, tmp_path):
+    from marm_mcp_server.services import notebook as nb_module
+
+    mem = MARMMemory(str(tmp_path / "nb-test.db"))
+    mem._encoder_failed = True
+    monkeypatch.setattr(nb_module, "memory", mem)
+    monkeypatch.setattr(nb_module, "MARM_PROJECT", "notebook-proj")
+    monkeypatch.setattr(nb_module, "MARM_PLATFORM", "vscode")
+
+    result = await nb_module.notebook_dispatch(
+        action="add", name="test-rule", data="always test your code"
+    )
+    assert result["status"] == "success"
+
+    import sqlite3 as _sqlite3
+
+    with _sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
+        row = conn.execute(
+            "SELECT project, platform FROM notebook_entries WHERE name = 'test-rule'"
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "notebook-proj"
+    assert row[1] == "vscode"
+
+
+@pytest.mark.asyncio
+async def test_notebook_add_null_tags_when_detection_empty(monkeypatch, tmp_path):
+    from marm_mcp_server.services import notebook as nb_module
+
+    mem = MARMMemory(str(tmp_path / "nb-test.db"))
+    mem._encoder_failed = True
+    monkeypatch.setattr(nb_module, "memory", mem)
+    monkeypatch.setattr(nb_module, "MARM_PROJECT", "")
+    monkeypatch.setattr(nb_module, "MARM_PLATFORM", "")
+
+    result = await nb_module.notebook_dispatch(
+        action="add", name="untagged-rule", data="some rule"
+    )
+    assert result["status"] == "success"
+
+    import sqlite3 as _sqlite3
+
+    with _sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
+        row = conn.execute(
+            "SELECT project, platform FROM notebook_entries WHERE name = 'untagged-rule'"
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] is None
+    assert row[1] is None


### PR DESCRIPTION
Add project/platform metadata across memories, logs, and notebooks with scoped recall, scoring, consolidation, and API wiring. Update versioned release docs for v2.14.2 and add focused regression coverage for attribution behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nullable **project/platform attribution** to newly stored memories, logs, and notebook entries, with auto-detection and `MARM_PROJECT` / `MARM_PLATFORM` overrides.
  * Enhanced **smart recall** with optional `project`/`platform` filters, including correct scoping when `include_logs=True`.
  * Restricted **deduplication, consolidation, and compaction** to the same attribution scope.

* **Documentation**
  * Updated release notes, READMEs, install guides, and tool references to describe attribution fields, overrides, and scoped recall behavior.

* **Tests**
  * Added end-to-end tests covering tagging, scoped recall, log filtering, and consolidation/compaction boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->