### PR TITLE
Feature/stdio graph parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>July 6th, 2026: STDIO Graph Tool Parity (v2.17.x)</strong></summary>
+
+### STDIO Transport
+
+- Added the 5 bundled marm-graph tools (`marm_graph_index`, `marm_code_lookup`, `marm_graph_trace`, `marm_graph_architecture`, `marm_graph_impact`) to `marm_mcp_server.server_stdio`, bringing STDIO's discoverable tool count from 7 to 12 and matching the HTTP surface.
+- STDIO graph tools reuse the same `graph_supervisor` and `marm_graph.core.tool_router` path HTTP uses; no second graph process, no new install step, no port or API key added to STDIO.
+- Graph startup stays lazy (triggered by the first graph tool call) and degrades cleanly (`{"status": "error", "message": "graph backend unavailable"}`) if the graph engine is disabled or fails to start, without affecting the 7 core memory tools.
+- `graph_supervisor.stop()` now runs during STDIO shutdown so a started graph child process is not left running after the STDIO process exits.
+
+</details>
+
+<details>
 <summary><strong>July 6th, 2026: Unified Graph & Dashboard Package Layout (v2.17.0)</strong></summary>
 
 ### Packaging Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
-<summary><strong>July 6th, 2026: STDIO Graph Tool Parity (v2.17.x)</strong></summary>
+<summary><strong>July 6th, 2026: STDIO Graph Tool Parity (v2.17.1)</strong></summary>
 
 ### STDIO Transport
 

--- a/MCP-HANDBOOK.md
+++ b/MCP-HANDBOOK.md
@@ -279,7 +279,7 @@ MARM automatically categorizes content:
 | **📔 Notebook** | `marm_notebook` | Unified notebook management | `action="add"` saves entries, `action="use"` activates entries, `action="show"` lists saved entries, `action="status"` shows active entries, `action="clear"` clears active entries. `session_name` scopes active entries when needed |
 | **🔄 Workflow** | `marm_summary` | Generate cached, paste-ready session summaries with intelligent truncation | Create summaries for new conversations or context bridging |
 | **🧹 Maintenance** | `marm_compaction` | Agent-assisted memory compaction | `action="status"`, `"candidates"`, `"review"`, `"stage"`, `"apply"`, or `"discard"`. Used when MARM detects duplicate memory clusters and asks the agent to summarize them |
-| **🕸️ Code Graph** (bundled, HTTP only) | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects | `repo_path` to index, `project` to check status, omit both to list |
+| **🕸️ Code Graph** (bundled, HTTP + STDIO) | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects | `repo_path` to index, `project` to check status, omit both to list |
 | | `marm_code_lookup` | Find symbols, text patterns, or a symbol's source — use instead of grep/glob | `kind="auto"\|"symbol"\|"text"\|"snippet"` |
 | | `marm_graph_trace` | Trace call paths / data flow through the graph from a function | `direction="inbound"\|"outbound"\|"both"`, `mode="calls"\|"data_flow"\|"cross_service"` |
 | | `marm_graph_architecture` | High-level architecture overview: node/edge breakdown, modules, and schema | `project` (optional) |
@@ -287,7 +287,7 @@ MARM automatically categorizes content:
 
 **Internal automation:** lifecycle initialization, protocol delivery with periodic protocol-lite refresh, documentation refresh, current date context, summary-cache maintenance, serialized write queue handling, and system checks are no longer AI-facing tools. Documentation refresh uses `doc_index` hash tracking to avoid duplicate `marm_system` memories across restarts. Use the dashboard health panel for live server status, or `curl http://localhost:8001/health` for terminal checks.
 
-**Graph degraded mode:** the 5 code-graph tools start lazily on first use (first-run may download a ~269MB engine binary) and are always listed in `tools/list`, but they never affect the 7 core memory tools. If the graph engine fails to start (no network, disk full, schema drift) or `GRAPH_ENABLED=false` is set, graph tools return `{"status": "error", "message": "graph backend unavailable"}` while memory, logging, notebook, and compaction keep working normally.
+**Graph degraded mode:** the 5 code-graph tools start lazily on first use on both HTTP and STDIO (first-run may download a ~269MB engine binary) and are always listed in `tools/list`, but they never affect the 7 core memory tools. If the graph engine fails to start (no network, disk full, schema drift) or `GRAPH_ENABLED=false` is set, graph tools return `{"status": "error", "message": "graph backend unavailable"}` while memory, logging, notebook, and compaction keep working normally.
 
 **Code graph workflow:** first call `marm_graph_index(repo_path="...")` for the repository you want indexed. The response returns the project name the graph backend recognizes. After that, agents should use `marm_code_lookup` before broad file reads, `marm_graph_trace` when they need callers/callees or data-flow context, `marm_graph_architecture` for orientation, and `marm_graph_impact` before risky refactors. Re-index after meaningful code changes; the graph is local and does not replace normal memory logs.
 
@@ -417,7 +417,7 @@ The canonical FAQ lives in [marm-mcp-server/marm-docs/FAQ.md](marm-mcp-server/ma
 - Verify HTTP mode in the dashboard health panel, or with `curl http://localhost:8001/health`
 - Check server logs for initialization errors
 - Disconnect and reconnect AI client to refresh tool list
-- In HTTP mode, expect 12 tools: 7 core memory/logging/notebook/compaction tools plus 5 bundled code-graph tools. In STDIO mode, expect the 7 core tools only.
+- Both HTTP and STDIO expose 12 tools: 7 core memory/logging/notebook/compaction tools plus 5 bundled code-graph tools.
 
 #### Graph tools return `graph backend unavailable`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 MARM MCP is a local memory infrastructure layer for AI agents. It gives Claude, Codex, Gemini, Qwen, IDE agents, and other MCP clients one persistent place to store decisions, retrieve context, reuse notebooks, and keep long-running work from drifting.
 
-MARM is built around two focused surfaces: **7 core memory tools** for daily agent context and **5 HTTP code-graph tools** for repo intelligence. The server handles the heavy work behind those tools: protocol delivery, hybrid recall, serialized writes, rate-limit presets, write-time consolidation, agent-assisted compaction, and lazy graph startup. Agents get a compact memory workflow plus codebase lookup when they need it, without rereading the whole project or flooding the model with duplicate context.
+MARM is built around two focused surfaces: **7 core memory tools** for daily agent context and **5 code-graph tools** for repo intelligence (bundled over both HTTP and STDIO). The server handles the heavy work behind those tools: protocol delivery, hybrid recall, serialized writes, rate-limit presets, write-time consolidation, agent-assisted compaction, and lazy graph startup. Agents get a compact memory workflow plus codebase lookup when they need it, without rereading the whole project or flooding the model with duplicate context.
 
 ### How It Works
 
@@ -99,7 +99,7 @@ Then use marm_code_lookup when you need symbols, files, or source snippets.
 Use marm_graph_trace for call paths, marm_graph_architecture for an overview, and marm_graph_impact for change-risk checks.
 ```
 
-Graph tools are currently part of the HTTP MCP surface. STDIO remains focused on the 7 core memory tools for private local use.
+Graph tools are bundled on both HTTP and STDIO. STDIO stays a single local process with no port and no API key; the graph engine still starts lazily on first use.
 
 ## 🚀 Quick Start for MCP (HTTP & STDIO)
 
@@ -308,7 +308,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 | **Reasoning & Workflow** | `marm_summary` | Generate cached session summaries with intelligent truncation for LLM conversations |
 | **Notebook Management** | `marm_notebook` | Unified notebook tool: add, use, show, status, or clear entries with `action="add"\|"use"\|"show"\|"status"\|"clear"` |
 | **Memory Maintenance** | `marm_compaction` | Unified compaction workflow with `action="status"\|"candidates"\|"review"\|"stage"\|"apply"\|"discard"` for agent-assisted memory cleanup |
-| **Code Graph (bundled, HTTP only)** | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects |
+| **Code Graph (bundled, HTTP + STDIO)** | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects |
 | | `marm_code_lookup` | Find symbols, text patterns, or a symbol's source — use instead of grep/glob |
 | | `marm_graph_trace` | Trace call paths / data flow through the graph from a function |
 | | `marm_graph_architecture` | High-level architecture overview: node/edge breakdown, modules, and schema |
@@ -316,7 +316,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 ### A Deeper Look
 
-MARM keeps the core MCP surface lean with 7 tools by grouping domain operations behind explicit parameters like `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)`. Behind those tools, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks. Over HTTP, marm-graph's 5 code-structure tools are bundled by default, bringing the discoverable surface to 12; the code-graph engine starts lazily on first use and never blocks the 7 core tools if it fails to start (`GRAPH_ENABLED=false` disables it outright).
+MARM keeps the core MCP surface lean with 7 tools by grouping domain operations behind explicit parameters like `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)`. Behind those tools, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks. marm-graph's 5 code-structure tools are bundled by default on both HTTP and STDIO, bringing the discoverable surface to 12; the code-graph engine starts lazily on first use and never blocks the 7 core tools if it fails to start (`GRAPH_ENABLED=false` disables it outright).
 
 Under the hood, MARM uses SQLite WAL mode, connection pooling, serialized writes, HTTP swarm presets, safe local defaults, exact-query routing for syntax-heavy lookups, FTS→semantic reranking, bounded fallback search, chunk-aware long-memory recall, and summary/context/full recall depths to keep memory fast, stable, and token-efficient as projects grow.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -12,7 +12,7 @@ MARM Systems is a persistent memory layer for AI agents. The MCP server gives Cl
 
 | Component | Description | Best For |
 |-----------|-------------|----------|
-| **MARM MCP Server** | Persistent memory server with 12 HTTP MCP tools: 7 core memory tools plus 5 bundled code-graph tools | AI agents, IDEs, local workflows, shared team memory |
+| **MARM MCP Server** | Persistent memory server with 12 MCP tools (HTTP + STDIO): 7 core memory tools plus 5 bundled code-graph tools | AI agents, IDEs, local workflows, shared team memory |
 | **MARM Protocol** | Runtime guidance delivered automatically by the MCP server | Keeping agents aligned on what to store, recall, and trust |
 | **MARM Dashboard** | Local browser UI for viewing memory and server health | Inspection, cleanup, and quick status checks |
 
@@ -79,7 +79,7 @@ For HTTP mode, use the MARM Dashboard status panel or run `curl http://localhost
 
 #### Q: What MCP tools does MARM provide?
 
-MARM currently exposes **12 HTTP MCP tools**: 7 focused core memory tools plus 5 bundled code-graph tools. STDIO stays focused on the 7 core memory tools.
+MARM currently exposes **12 MCP tools on both HTTP and STDIO**: 7 focused core memory tools plus 5 bundled code-graph tools.
 
 | Category | Tools | Description |
 |----------|-------|-------------|
@@ -89,7 +89,7 @@ MARM currently exposes **12 HTTP MCP tools**: 7 focused core memory tools plus 5
 | **Delete** | `marm_delete` | Delete log sessions, log entries, or notebook entries |
 | **Summary** | `marm_summary` | Generate concise context summaries |
 | **Maintenance** | `marm_compaction` | Agent-assisted memory compaction with `action="status"`, `"candidates"`, `"review"`, `"stage"`, `"apply"`, or `"discard"` |
-| **Code Graph (HTTP only)** | `marm_graph_index`, `marm_code_lookup`, `marm_graph_trace`, `marm_graph_architecture`, `marm_graph_impact` | Index repositories, look up symbols/source, trace call paths, summarize architecture, and inspect change impact |
+| **Code Graph (HTTP + STDIO)** | `marm_graph_index`, `marm_code_lookup`, `marm_graph_trace`, `marm_graph_architecture`, `marm_graph_impact` | Index repositories, look up symbols/source, trace call paths, summarize architecture, and inspect change impact |
 
 #### Q: Do I still need to call `marm_start`?
 

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -42,7 +42,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
 
 MARM MCP is a local memory infrastructure layer for AI agents. It gives Claude, Codex, Gemini, Qwen, IDE agents, and other MCP clients one persistent place to store decisions, retrieve context, reuse notebooks, and keep long-running work from drifting.
 
-MARM is built around two focused surfaces: **7 core memory tools** for daily agent context and **5 HTTP code-graph tools** for repo intelligence. The server handles the heavy work behind those tools: protocol delivery, hybrid recall, serialized writes, rate-limit presets, write-time consolidation, agent-assisted compaction, and lazy graph startup. Agents get a compact memory workflow plus codebase lookup when they need it, without rereading the whole project or flooding the model with duplicate context.
+MARM is built around two focused surfaces: **7 core memory tools** for daily agent context and **5 code-graph tools** for repo intelligence (bundled over both HTTP and STDIO). The server handles the heavy work behind those tools: protocol delivery, hybrid recall, serialized writes, rate-limit presets, write-time consolidation, agent-assisted compaction, and lazy graph startup. Agents get a compact memory workflow plus codebase lookup when they need it, without rereading the whole project or flooding the model with duplicate context.
 
 ### How It Works
 
@@ -101,7 +101,7 @@ Then use marm_code_lookup when you need symbols, files, or source snippets.
 Use marm_graph_trace for call paths, marm_graph_architecture for an overview, and marm_graph_impact for change-risk checks.
 ```
 
-Graph tools are currently part of the HTTP MCP surface. STDIO remains focused on the 7 core memory tools for private local use.
+Graph tools are bundled on both HTTP and STDIO. STDIO stays a single local process with no port and no API key; the graph engine still starts lazily on first use.
 
 ## 🚀 Quick Start for MCP (HTTP & STDIO)
 
@@ -310,7 +310,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 | **Reasoning & Workflow** | `marm_summary` | Generate cached session summaries with intelligent truncation for LLM conversations |
 | **Notebook Management** | `marm_notebook` | Unified notebook tool: add, use, show, status, or clear entries with `action="add"\|"use"\|"show"\|"status"\|"clear"` |
 | **Memory Maintenance** | `marm_compaction` | Unified compaction workflow with `action="status"\|"candidates"\|"review"\|"stage"\|"apply"\|"discard"` for agent-assisted memory cleanup |
-| **Code Graph (bundled, HTTP only)** | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects |
+| **Code Graph (bundled, HTTP + STDIO)** | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects |
 | | `marm_code_lookup` | Find symbols, text patterns, or a symbol's source — use instead of grep/glob |
 | | `marm_graph_trace` | Trace call paths / data flow through the graph from a function |
 | | `marm_graph_architecture` | High-level architecture overview: node/edge breakdown, modules, and schema |
@@ -318,7 +318,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 ### A Deeper Look
 
-MARM keeps the core MCP surface lean with 7 tools by grouping domain operations behind explicit parameters like `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)`. Behind those tools, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks. Over HTTP, marm-graph's 5 code-structure tools are bundled by default, bringing the discoverable surface to 12; the code-graph engine starts lazily on first use and never blocks the 7 core tools if it fails to start (`GRAPH_ENABLED=false` disables it outright).
+MARM keeps the core MCP surface lean with 7 tools by grouping domain operations behind explicit parameters like `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)`. Behind those tools, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks. marm-graph's 5 code-structure tools are bundled by default on both HTTP and STDIO, bringing the discoverable surface to 12; the code-graph engine starts lazily on first use and never blocks the 7 core tools if it fails to start (`GRAPH_ENABLED=false` disables it outright).
 
 Under the hood, MARM uses SQLite WAL mode, connection pooling, serialized writes, HTTP swarm presets, safe local defaults, exact-query routing for syntax-heavy lookups, FTS→semantic reranking, bounded fallback search, chunk-aware long-memory recall, and summary/context/full recall depths to keep memory fast, stable, and token-efficient as projects grow.
 

--- a/marm-mcp-server/marm-docs/FAQ.md
+++ b/marm-mcp-server/marm-docs/FAQ.md
@@ -12,7 +12,7 @@ MARM Systems is a persistent memory layer for AI agents. The MCP server gives Cl
 
 | Component | Description | Best For |
 |-----------|-------------|----------|
-| **MARM MCP Server** | Persistent memory server with 12 HTTP MCP tools: 7 core memory tools plus 5 bundled code-graph tools | AI agents, IDEs, local workflows, shared team memory |
+| **MARM MCP Server** | Persistent memory server with 12 MCP tools (HTTP + STDIO): 7 core memory tools plus 5 bundled code-graph tools | AI agents, IDEs, local workflows, shared team memory |
 | **MARM Protocol** | Runtime guidance delivered automatically by the MCP server | Keeping agents aligned on what to store, recall, and trust |
 | **MARM Dashboard** | Local browser UI for viewing memory and server health | Inspection, cleanup, and quick status checks |
 
@@ -79,7 +79,7 @@ For HTTP mode, use the MARM Dashboard status panel or run `curl http://localhost
 
 #### Q: What MCP tools does MARM provide?
 
-MARM currently exposes **12 HTTP MCP tools**: 7 focused core memory tools plus 5 bundled code-graph tools. STDIO stays focused on the 7 core memory tools.
+MARM currently exposes **12 MCP tools on both HTTP and STDIO**: 7 focused core memory tools plus 5 bundled code-graph tools.
 
 | Category | Tools | Description |
 |----------|-------|-------------|
@@ -89,7 +89,7 @@ MARM currently exposes **12 HTTP MCP tools**: 7 focused core memory tools plus 5
 | **Delete** | `marm_delete` | Delete log sessions, log entries, or notebook entries |
 | **Summary** | `marm_summary` | Generate concise context summaries |
 | **Maintenance** | `marm_compaction` | Agent-assisted memory compaction with `action="status"`, `"candidates"`, `"review"`, `"stage"`, `"apply"`, or `"discard"` |
-| **Code Graph (HTTP only)** | `marm_graph_index`, `marm_code_lookup`, `marm_graph_trace`, `marm_graph_architecture`, `marm_graph_impact` | Index repositories, look up symbols/source, trace call paths, summarize architecture, and inspect change impact |
+| **Code Graph (HTTP + STDIO)** | `marm_graph_index`, `marm_code_lookup`, `marm_graph_trace`, `marm_graph_architecture`, `marm_graph_impact` | Index repositories, look up symbols/source, trace call paths, summarize architecture, and inspect change impact |
 
 #### Q: Do I still need to call `marm_start`?
 

--- a/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
+++ b/marm-mcp-server/marm-docs/MCP-HANDBOOK.md
@@ -279,7 +279,7 @@ MARM automatically categorizes content:
 | **📔 Notebook** | `marm_notebook` | Unified notebook management | `action="add"` saves entries, `action="use"` activates entries, `action="show"` lists saved entries, `action="status"` shows active entries, `action="clear"` clears active entries. `session_name` scopes active entries when needed |
 | **🔄 Workflow** | `marm_summary` | Generate cached, paste-ready session summaries with intelligent truncation | Create summaries for new conversations or context bridging |
 | **🧹 Maintenance** | `marm_compaction` | Agent-assisted memory compaction | `action="status"`, `"candidates"`, `"review"`, `"stage"`, `"apply"`, or `"discard"`. Used when MARM detects duplicate memory clusters and asks the agent to summarize them |
-| **🕸️ Code Graph** (bundled, HTTP only) | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects | `repo_path` to index, `project` to check status, omit both to list |
+| **🕸️ Code Graph** (bundled, HTTP + STDIO) | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects | `repo_path` to index, `project` to check status, omit both to list |
 | | `marm_code_lookup` | Find symbols, text patterns, or a symbol's source — use instead of grep/glob | `kind="auto"\|"symbol"\|"text"\|"snippet"` |
 | | `marm_graph_trace` | Trace call paths / data flow through the graph from a function | `direction="inbound"\|"outbound"\|"both"`, `mode="calls"\|"data_flow"\|"cross_service"` |
 | | `marm_graph_architecture` | High-level architecture overview: node/edge breakdown, modules, and schema | `project` (optional) |
@@ -287,7 +287,7 @@ MARM automatically categorizes content:
 
 **Internal automation:** lifecycle initialization, protocol delivery with periodic protocol-lite refresh, documentation refresh, current date context, summary-cache maintenance, serialized write queue handling, and system checks are no longer AI-facing tools. Documentation refresh uses `doc_index` hash tracking to avoid duplicate `marm_system` memories across restarts. Use the dashboard health panel for live server status, or `curl http://localhost:8001/health` for terminal checks.
 
-**Graph degraded mode:** the 5 code-graph tools start lazily on first use (first-run may download a ~269MB engine binary) and are always listed in `tools/list`, but they never affect the 7 core memory tools. If the graph engine fails to start (no network, disk full, schema drift) or `GRAPH_ENABLED=false` is set, graph tools return `{"status": "error", "message": "graph backend unavailable"}` while memory, logging, notebook, and compaction keep working normally.
+**Graph degraded mode:** the 5 code-graph tools start lazily on first use on both HTTP and STDIO (first-run may download a ~269MB engine binary) and are always listed in `tools/list`, but they never affect the 7 core memory tools. If the graph engine fails to start (no network, disk full, schema drift) or `GRAPH_ENABLED=false` is set, graph tools return `{"status": "error", "message": "graph backend unavailable"}` while memory, logging, notebook, and compaction keep working normally.
 
 **Code graph workflow:** first call `marm_graph_index(repo_path="...")` for the repository you want indexed. The response returns the project name the graph backend recognizes. After that, agents should use `marm_code_lookup` before broad file reads, `marm_graph_trace` when they need callers/callees or data-flow context, `marm_graph_architecture` for orientation, and `marm_graph_impact` before risky refactors. Re-index after meaningful code changes; the graph is local and does not replace normal memory logs.
 
@@ -417,7 +417,7 @@ The canonical FAQ lives in [marm-mcp-server/marm-docs/FAQ.md](marm-mcp-server/ma
 - Verify HTTP mode in the dashboard health panel, or with `curl http://localhost:8001/health`
 - Check server logs for initialization errors
 - Disconnect and reconnect AI client to refresh tool list
-- In HTTP mode, expect 12 tools: 7 core memory/logging/notebook/compaction tools plus 5 bundled code-graph tools. In STDIO mode, expect the 7 core tools only.
+- Both HTTP and STDIO expose 12 tools: 7 core memory/logging/notebook/compaction tools plus 5 bundled code-graph tools.
 
 #### Graph tools return `graph backend unavailable`
 

--- a/marm-mcp-server/marm-docs/README.md
+++ b/marm-mcp-server/marm-docs/README.md
@@ -17,7 +17,7 @@
 
 MARM MCP is a local memory infrastructure layer for AI agents. It gives Claude, Codex, Gemini, Qwen, IDE agents, and other MCP clients one persistent place to store decisions, retrieve context, reuse notebooks, and keep long-running work from drifting.
 
-MARM is built around two focused surfaces: **7 core memory tools** for daily agent context and **5 HTTP code-graph tools** for repo intelligence. The server handles the heavy work behind those tools: protocol delivery, hybrid recall, serialized writes, rate-limit presets, write-time consolidation, agent-assisted compaction, and lazy graph startup. Agents get a compact memory workflow plus codebase lookup when they need it, without rereading the whole project or flooding the model with duplicate context.
+MARM is built around two focused surfaces: **7 core memory tools** for daily agent context and **5 code-graph tools** for repo intelligence (bundled over both HTTP and STDIO). The server handles the heavy work behind those tools: protocol delivery, hybrid recall, serialized writes, rate-limit presets, write-time consolidation, agent-assisted compaction, and lazy graph startup. Agents get a compact memory workflow plus codebase lookup when they need it, without rereading the whole project or flooding the model with duplicate context.
 
 ### How It Works
 
@@ -70,7 +70,7 @@ Then use marm_code_lookup when you need symbols, files, or source snippets.
 Use marm_graph_trace for call paths, marm_graph_architecture for an overview, and marm_graph_impact for change-risk checks.
 ```
 
-Graph tools are currently part of the HTTP MCP surface. STDIO remains focused on the 7 core memory tools for private local use.
+Graph tools are bundled on both HTTP and STDIO. STDIO stays a single local process with no port and no API key; the graph engine still starts lazily on first use.
 
 ## 🚀 Quick Start for MCP (HTTP & STDIO)
 
@@ -263,7 +263,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 | **Reasoning & Workflow** | `marm_summary` | Generate cached session summaries with intelligent truncation for LLM conversations |
 | **Notebook Management** | `marm_notebook` | Unified notebook tool: add, use, show, status, or clear entries with `action="add"\|"use"\|"show"\|"status"\|"clear"` |
 | **Memory Maintenance** | `marm_compaction` | Unified compaction workflow with `action="status"\|"candidates"\|"review"\|"stage"\|"apply"\|"discard"` for agent-assisted memory cleanup |
-| **Code Graph (bundled, HTTP only)** | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects |
+| **Code Graph (bundled, HTTP + STDIO)** | `marm_graph_index` | Index a repo into the code-structure graph, or check status / list indexed projects |
 | | `marm_code_lookup` | Find symbols, text patterns, or a symbol's source — use instead of grep/glob |
 | | `marm_graph_trace` | Trace call paths / data flow through the graph from a function |
 | | `marm_graph_architecture` | High-level architecture overview: node/edge breakdown, modules, and schema |
@@ -271,7 +271,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 ### A Deeper Look
 
-MARM keeps the core MCP surface lean with 7 tools by grouping domain operations behind explicit parameters like `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)`. Behind those tools, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks. Over HTTP, marm-graph's 5 code-structure tools are bundled by default, bringing the discoverable surface to 12; the code-graph engine starts lazily on first use and never blocks the 7 core tools if it fails to start (`GRAPH_ENABLED=false` disables it outright).
+MARM keeps the core MCP surface lean with 7 tools by grouping domain operations behind explicit parameters like `marm_notebook(action=...)`, `marm_delete(type=...)`, and `marm_compaction(action=...)`. Behind those tools, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks. marm-graph's 5 code-structure tools are bundled by default on both HTTP and STDIO, bringing the discoverable surface to 12; the code-graph engine starts lazily on first use and never blocks the 7 core tools if it fails to start (`GRAPH_ENABLED=false` disables it outright).
 
 Under the hood, MARM uses SQLite WAL mode, connection pooling, serialized writes, HTTP swarm presets, safe local defaults, exact-query routing for syntax-heavy lookups, FTS→semantic reranking, bounded fallback search, chunk-aware long-memory recall, and summary/context/full recall depths to keep memory fast, stable, and token-efficient as projects grow.
 

--- a/marm-mcp-server/marm_mcp_server/core/graph_supervisor.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_supervisor.py
@@ -99,11 +99,13 @@ class GraphSupervisor:
         the backend was up.
         """
         with self._lock:
-            if self._client is not None:
-                self._client.close()
-            self._client = None
-            self._available = False
-            self._ready.clear()
+            try:
+                if self._client is not None:
+                    self._client.close()
+            finally:
+                self._client = None
+                self._available = False
+                self._ready.clear()
 
 
 graph_supervisor = GraphSupervisor()

--- a/marm-mcp-server/marm_mcp_server/core/graph_supervisor.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_supervisor.py
@@ -90,12 +90,20 @@ class GraphSupervisor:
         return self._client
 
     def stop(self) -> None:
-        """Terminate the child process, if one was ever started."""
-        if self._client is not None:
-            self._client.close()
-        self._client = None
-        self._available = False
-        self._ready.clear()
+        """Terminate the child process, if one was ever started.
+
+        Must share _lock with _ensure_started(): without it, a stop() racing
+        an in-flight lazy startup could interleave with that critical section
+        and leave _ready set + _available True but _client None -- a caller's
+        get_client() would then return None while is_available() just said
+        the backend was up.
+        """
+        with self._lock:
+            if self._client is not None:
+                self._client.close()
+            self._client = None
+            self._available = False
+            self._ready.clear()
 
 
 graph_supervisor = GraphSupervisor()

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -251,7 +251,7 @@ async def lifespan(app: FastAPI):
     if _compaction_scheduler and _compaction_scheduler.running:
         _compaction_scheduler.shutdown(wait=False)
     await memory.stop_write_queue()
-    graph_supervisor.stop()
+    await asyncio.to_thread(graph_supervisor.stop)
     track_usage("server_shutdown")
 
 

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -27,7 +27,7 @@ import pathlib  # noqa: E402
 import re  # noqa: E402
 import uuid  # noqa: E402
 from datetime import datetime, timezone  # noqa: E402
-from typing import Optional  # noqa: E402
+from typing import Literal, Optional  # noqa: E402
 
 from anyio import BrokenResourceError, ClosedResourceError, EndOfStream  # noqa: E402
 
@@ -199,7 +199,12 @@ from marm_graph.core.models import (  # noqa: E402
 
 mcp = FastMCP("MARM MCP Server")
 
-_GRAPH_UNAVAILABLE = {"status": "error", "message": "graph backend unavailable"}
+
+def _graph_unavailable() -> dict:
+    """Fresh dict per call -- _log_tool_call mutates result in place (protocol
+    injection, compaction blocks), so a shared constant here would leak state
+    (e.g. marm_protocol) into every subsequent unavailable response."""
+    return {"status": "error", "message": "graph backend unavailable"}
 
 
 async def _graph_available() -> bool:
@@ -699,8 +704,8 @@ async def marm_compaction(
 async def marm_graph_index(
     repo_path: Optional[str] = None,
     project: Optional[str] = None,
-    mode: str = "moderate",
-    action: str = "auto",
+    mode: Literal["full", "moderate", "fast"] = "moderate",
+    action: Literal["auto", "index", "status", "list"] = "auto",
 ) -> dict:
     """
     🕸️ Index a code repository into the graph, or check status / list known projects.
@@ -719,7 +724,7 @@ async def marm_graph_index(
     graph backend is disabled or failed to start
     """
     if not await _graph_available():
-        return _GRAPH_UNAVAILABLE
+        return _graph_unavailable()
     req = GraphIndexRequest(
         repo_path=repo_path, project=project, mode=mode, action=action
     )
@@ -733,7 +738,7 @@ async def marm_graph_index(
 async def marm_code_lookup(
     query: str,
     project: Optional[str] = None,
-    kind: str = "auto",
+    kind: Literal["auto", "symbol", "text", "snippet"] = "auto",
     regex: bool = False,
     file_pattern: Optional[str] = None,
     limit: int = 20,
@@ -757,7 +762,7 @@ async def marm_code_lookup(
     backend is disabled or failed to start
     """
     if not await _graph_available():
-        return _GRAPH_UNAVAILABLE
+        return _graph_unavailable()
     req = CodeLookupRequest(
         query=query,
         project=project,
@@ -776,9 +781,9 @@ async def marm_code_lookup(
 async def marm_graph_trace(
     function_name: str,
     project: Optional[str] = None,
-    direction: str = "both",
+    direction: Literal["inbound", "outbound", "both"] = "both",
     depth: int = 3,
-    mode: str = "calls",
+    mode: Literal["calls", "data_flow", "cross_service"] = "calls",
     risk_labels: bool = True,
 ) -> dict:
     """
@@ -800,7 +805,7 @@ async def marm_graph_trace(
     backend is disabled or failed to start
     """
     if not await _graph_available():
-        return _GRAPH_UNAVAILABLE
+        return _graph_unavailable()
     req = GraphTraceRequest(
         function_name=function_name,
         project=project,
@@ -832,7 +837,7 @@ async def marm_graph_architecture(
     graph backend is disabled or failed to start
     """
     if not await _graph_available():
-        return _GRAPH_UNAVAILABLE
+        return _graph_unavailable()
     req = GraphArchitectureRequest(project=project)
     return await asyncio.to_thread(
         graph_router.do_architecture, graph_supervisor.get_client(), req
@@ -863,7 +868,7 @@ async def marm_graph_impact(
     backend is disabled or failed to start
     """
     if not await _graph_available():
-        return _GRAPH_UNAVAILABLE
+        return _graph_unavailable()
     req = GraphImpactRequest(
         project=project, since=since, base_branch=base_branch, depth=depth
     )

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -187,8 +187,23 @@ from marm_mcp_server.config.settings import (  # noqa: E402
     MARM_PROJECT,
     MARM_PLATFORM,
 )
+from marm_mcp_server.core.graph_supervisor import graph_supervisor  # noqa: E402
+from marm_graph.core import tool_router as graph_router  # noqa: E402
+from marm_graph.core.models import (  # noqa: E402
+    CodeLookupRequest,
+    GraphArchitectureRequest,
+    GraphImpactRequest,
+    GraphIndexRequest,
+    GraphTraceRequest,
+)
 
 mcp = FastMCP("MARM MCP Server")
+
+_GRAPH_UNAVAILABLE = {"status": "error", "message": "graph backend unavailable"}
+
+
+async def _graph_available() -> bool:
+    return await asyncio.to_thread(graph_supervisor.is_available)
 
 
 @mcp.tool()
@@ -679,6 +694,184 @@ async def marm_compaction(
         return {"status": "error", "message": f"Compaction operation failed: {e!s}"}
 
 
+@mcp.tool()
+@_log_tool_call
+async def marm_graph_index(
+    repo_path: Optional[str] = None,
+    project: Optional[str] = None,
+    mode: str = "moderate",
+    action: str = "auto",
+) -> dict:
+    """
+    🕸️ Index a code repository into the graph, or check status / list known projects.
+
+    Pass `repo_path` to index a repo (returns the project name to use in every
+    other tool). Omit it to list indexed projects, or pass `project` to check
+    index status. Call this first — all other graph tools need an indexed project.
+
+    Parameters:
+    - repo_path: path to the repository to index; omit to list/status only
+    - project: existing project name for a status check; omit to auto-resolve
+    - mode: index depth — full | moderate | fast (default moderate)
+    - action: auto | index | status | list (default auto; infers from repo_path presence)
+
+    Returns: graph index/status/list response, or a graph-unavailable error if the
+    graph backend is disabled or failed to start
+    """
+    if not await _graph_available():
+        return _GRAPH_UNAVAILABLE
+    req = GraphIndexRequest(
+        repo_path=repo_path, project=project, mode=mode, action=action
+    )
+    return await asyncio.to_thread(
+        graph_router.do_index, graph_supervisor.get_client(), req
+    )
+
+
+@mcp.tool()
+@_log_tool_call
+async def marm_code_lookup(
+    query: str,
+    project: Optional[str] = None,
+    kind: str = "auto",
+    regex: bool = False,
+    file_pattern: Optional[str] = None,
+    limit: int = 20,
+) -> dict:
+    """
+    🔎 Find code: symbols/definitions, text patterns, or a symbol's source.
+
+    Use INSTEAD OF grep/glob. `kind=auto` picks: a qualified_name reads source;
+    otherwise it searches the graph by name/keyword. Set `kind=text` to grep code,
+    `kind=snippet` to read a symbol's source, `kind=symbol` to force graph search.
+
+    Parameters:
+    - query: symbol name, natural-language phrase, code/text pattern, or a qualified_name
+    - project: project name; omit to auto-resolve
+    - kind: auto | symbol | text | snippet (default auto)
+    - regex: for text search, treat query as a regex (default False)
+    - file_pattern: glob to scope search, e.g. "*.py" (optional)
+    - limit: max results, 1-200 (default 20)
+
+    Returns: graph lookup response, or a graph-unavailable error if the graph
+    backend is disabled or failed to start
+    """
+    if not await _graph_available():
+        return _GRAPH_UNAVAILABLE
+    req = CodeLookupRequest(
+        query=query,
+        project=project,
+        kind=kind,
+        regex=regex,
+        file_pattern=file_pattern,
+        limit=limit,
+    )
+    return await asyncio.to_thread(
+        graph_router.do_lookup, graph_supervisor.get_client(), req
+    )
+
+
+@mcp.tool()
+@_log_tool_call
+async def marm_graph_trace(
+    function_name: str,
+    project: Optional[str] = None,
+    direction: str = "both",
+    depth: int = 3,
+    mode: str = "calls",
+    risk_labels: bool = True,
+) -> dict:
+    """
+    🧭 Trace call paths / data flow through the graph from a function.
+
+    `direction=inbound` finds callers, `outbound` finds callees, `both` for all.
+    `mode=data_flow` follows value propagation; `cross_service` crosses HTTP/async
+    boundaries. Use for impact analysis, dependency tracing, "who calls this".
+
+    Parameters:
+    - function_name: function or method to trace from
+    - project: project name; omit to auto-resolve
+    - direction: inbound | outbound | both (default both)
+    - depth: max hops, 1-5 (default 3)
+    - mode: calls | data_flow | cross_service (default calls)
+    - risk_labels: add CRITICAL/HIGH/MEDIUM/LOW risk tiers by hop distance (default True)
+
+    Returns: graph trace response, or a graph-unavailable error if the graph
+    backend is disabled or failed to start
+    """
+    if not await _graph_available():
+        return _GRAPH_UNAVAILABLE
+    req = GraphTraceRequest(
+        function_name=function_name,
+        project=project,
+        direction=direction,
+        depth=depth,
+        mode=mode,
+        risk_labels=risk_labels,
+    )
+    return await asyncio.to_thread(
+        graph_router.do_trace, graph_supervisor.get_client(), req
+    )
+
+
+@mcp.tool()
+@_log_tool_call
+async def marm_graph_architecture(
+    project: Optional[str] = None,
+) -> dict:
+    """
+    🏛️ High-level architecture overview: node/edge breakdown, modules, and schema.
+
+    One-shot orientation for a project — the de-facto module clusters, package
+    structure, and the graph schema (node labels + properties) folded in.
+
+    Parameters:
+    - project: project name; omit to auto-resolve
+
+    Returns: graph architecture response, or a graph-unavailable error if the
+    graph backend is disabled or failed to start
+    """
+    if not await _graph_available():
+        return _GRAPH_UNAVAILABLE
+    req = GraphArchitectureRequest(project=project)
+    return await asyncio.to_thread(
+        graph_router.do_architecture, graph_supervisor.get_client(), req
+    )
+
+
+@mcp.tool()
+@_log_tool_call
+async def marm_graph_impact(
+    project: Optional[str] = None,
+    since: Optional[str] = None,
+    base_branch: str = "main",
+    depth: int = 2,
+) -> dict:
+    """
+    💥 Blast radius of code changes: git diff → affected symbols + risk.
+
+    Pass `since` (a git ref/date) or a `base_branch` to compare against. Returns
+    which symbols a change touches and how far the impact propagates.
+
+    Parameters:
+    - project: project name; omit to auto-resolve
+    - since: git ref or date to compare from, e.g. HEAD~5, v0.5.0 (optional)
+    - base_branch: base branch to diff against (default "main")
+    - depth: impact propagation depth, 1-5 (default 2)
+
+    Returns: graph impact response, or a graph-unavailable error if the graph
+    backend is disabled or failed to start
+    """
+    if not await _graph_available():
+        return _GRAPH_UNAVAILABLE
+    req = GraphImpactRequest(
+        project=project, since=since, base_branch=base_branch, depth=depth
+    )
+    return await asyncio.to_thread(
+        graph_router.do_impact, graph_supervisor.get_client(), req
+    )
+
+
 def _is_graceful_teardown(exc: BaseException) -> bool:
     """Return True only if exc is safe to swallow as normal STDIO EOF teardown.
 
@@ -701,6 +894,14 @@ def _is_graceful_teardown(exc: BaseException) -> bool:
     return True
 
 
+def _stop_graph_supervisor_safely() -> None:
+    """Best-effort graph child-process shutdown; must not mask normal STDIO teardown."""
+    try:
+        graph_supervisor.stop()
+    except Exception as e:
+        _stdio_log.warning("graph shutdown failed: %s", e)
+
+
 def main() -> None:
     _stdio_log.info(
         "startup version=%s db=%s semantic_search=%s",
@@ -717,6 +918,7 @@ def main() -> None:
             return
         raise
     finally:
+        _stop_graph_supervisor_safely()
         _stdio_log.info("shutdown")
 
 

--- a/marm-mcp-server/requirements-glama.txt
+++ b/marm-mcp-server/requirements-glama.txt
@@ -9,3 +9,4 @@ psutil>=6.1.0,<8.0.0
 structlog>=24.4.0,<27.0.0
 httpx>=0.27.0,<1.0.0
 packaging>=24.0,<26.0
+codebase-memory-mcp==0.8.1

--- a/marm-mcp-server/requirements_stdio.txt
+++ b/marm-mcp-server/requirements_stdio.txt
@@ -8,3 +8,4 @@ psutil>=6.1.0,<8.0.0
 structlog>=24.4.0,<27.0.0
 packaging>=24.0,<27.0
 torch>=1.13.0
+codebase-memory-mcp==0.8.1

--- a/marm-mcp-server/tests/test_graph_cbm_client.py
+++ b/marm-mcp-server/tests/test_graph_cbm_client.py
@@ -132,9 +132,11 @@ def test_call_tool_missing_arg_raises_with_hint(client):
 def test_timeout_does_not_kill_child(binary, monkeypatch):
     """A slow-but-alive child must not be killed on timeout (finding 3):
     killing it mid-call would destroy in-flight work (e.g. a long index run)
-    and force a blind retry from zero. Force a timeout with an unreasonably
-    short call_timeout, then confirm the same process is still running and
-    still answers correctly once given a normal timeout.
+    and force a blind retry from zero. Force a deterministic timeout by
+    monkeypatching _send_recv (not a real short call_timeout racing against
+    actual IPC latency, which would make this test flaky), then confirm the
+    same process is still running and still answers correctly once given a
+    normal timeout.
     """
     c = CbmClient(command=[binary], startup_timeout=90, call_timeout=300)
     c.start()

--- a/marm-mcp-server/tests/test_graph_supervisor.py
+++ b/marm-mcp-server/tests/test_graph_supervisor.py
@@ -46,11 +46,12 @@ _ALL_UPSTREAM_TOOLS = [
 class _FakeClient:
     """Stands in for CbmClient: same start()/list_tools()/close() surface."""
 
-    def __init__(self, tools=None, start_error=None):
+    def __init__(self, tools=None, start_error=None, close_error=None):
         self._tools = (
             tools if tools is not None else [{"name": n} for n in _ALL_UPSTREAM_TOOLS]
         )
         self._start_error = start_error
+        self._close_error = close_error
         self.server_version = "0.8.1-fake"
         self.started = False
         self.closed = False
@@ -65,6 +66,8 @@ class _FakeClient:
 
     def close(self):
         self.closed = True
+        if self._close_error:
+            raise self._close_error
 
 
 def test_graph_disabled_short_circuits_before_any_client_construction(monkeypatch):
@@ -249,6 +252,32 @@ def test_stop_closes_client_and_resets_state(monkeypatch):
     assert fake.closed is True
     assert supervisor._client is None
     assert supervisor._available is False
+
+
+def test_stop_resets_state_even_if_close_raises(monkeypatch):
+    """Regression: stop() used to mutate _client/_available/_ready only after
+    close() returned. A raising close() (e.g. the child already died) would
+    then skip that cleanup entirely, leaving is_available() claim True with
+    a dead/closing client still cached -- get_client() would hand callers a
+    client that's no longer usable. The reset must happen in a finally, so a
+    close() failure still leaves the supervisor in a clean not-started state.
+    """
+    gs = _fresh_gs()
+    monkeypatch.setattr(gs.mcp_settings, "GRAPH_ENABLED", True)
+    fake = _FakeClient(close_error=RuntimeError("child already dead"))
+    monkeypatch.setattr(gs, "CbmClient", lambda **kwargs: fake)
+
+    supervisor = gs.GraphSupervisor()
+    supervisor.is_available()
+    assert fake.started is True
+
+    with pytest.raises(RuntimeError, match="child already dead"):
+        supervisor.stop()
+
+    assert fake.closed is True  # close() was attempted
+    assert supervisor._client is None
+    assert supervisor._available is False
+    assert not supervisor._ready.is_set()
 
 
 def test_stop_during_inflight_startup_waits_and_leaves_consistent_state(

--- a/marm-mcp-server/tests/test_graph_supervisor.py
+++ b/marm-mcp-server/tests/test_graph_supervisor.py
@@ -251,6 +251,55 @@ def test_stop_closes_client_and_resets_state(monkeypatch):
     assert supervisor._available is False
 
 
+def test_stop_during_inflight_startup_waits_and_leaves_consistent_state(
+    monkeypatch,
+):
+    """Regression: stop() used to mutate _client/_available/_ready without
+    the lock _ensure_started() uses. A stop() racing an in-flight startup
+    could interleave with that critical section and leave _available True
+    with _client None -- a caller's get_client() would then return None
+    while is_available() just said the backend was up. stop() must block on
+    the same lock until the in-flight startup resolves, then tear down
+    whatever it produced.
+    """
+    gs = _fresh_gs()
+    monkeypatch.setattr(gs.mcp_settings, "GRAPH_ENABLED", True)
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _SlowFakeClient(_FakeClient):
+        def start(self):
+            entered.set()
+            assert release.wait(timeout=5), "test deadlocked waiting for release"
+            super().start()
+
+    fake = _SlowFakeClient()
+    monkeypatch.setattr(gs, "CbmClient", lambda **kwargs: fake)
+
+    supervisor = gs.GraphSupervisor()
+
+    starter = threading.Thread(target=supervisor.is_available)
+    starter.start()
+    assert entered.wait(timeout=5), "startup never reached the blocking call"
+
+    stopper = threading.Thread(target=supervisor.stop)
+    stopper.start()
+
+    # stop() must block on the same lock as _ensure_started(), not interleave
+    stopper.join(timeout=0.2)
+    assert stopper.is_alive(), "stop() proceeded before startup resolved"
+
+    release.set()
+    starter.join(timeout=5)
+    stopper.join(timeout=5)
+
+    assert fake.started is True  # the in-flight startup actually completed
+    assert fake.closed is True  # ...then stop() tore it down
+    assert supervisor._client is None
+    assert supervisor._available is False
+
+
 def test_stop_on_never_started_supervisor_is_a_no_op(monkeypatch):
     """Shutdown must be safe even if no graph tool was ever called."""
     gs = _fresh_gs()

--- a/marm-mcp-server/tests/test_stdio_transport.py
+++ b/marm-mcp-server/tests/test_stdio_transport.py
@@ -312,6 +312,29 @@ def test_stdio_graph_tool_returns_unavailable_when_backend_down(monkeypatch, tmp
     assert result == {"status": "error", "message": "graph backend unavailable"}
 
 
+def test_stdio_graph_unavailable_response_is_not_shared_mutable_state(
+    monkeypatch, tmp_path
+):
+    """Regression: the unavailable response used to be one shared module-level
+    dict returned by every call. _log_tool_call mutates its result in place
+    (injecting marm_protocol on the first delivered call), so if the first
+    STDIO call ever made were an unavailable graph call, that injected key
+    would leak into every subsequent unavailable response forever. Force the
+    real first-call path (_protocol_delivered = False, unlike the other tests
+    in this module) and call twice to prove no state survives between calls.
+    """
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+    stdio._protocol_delivered = False
+    monkeypatch.setattr(stdio.graph_supervisor, "is_available", lambda: False)
+
+    first = asyncio.run(stdio.marm_graph_index(repo_path="/tmp/some-repo"))
+    assert "marm_protocol" in first  # confirms injection actually happened
+
+    second = asyncio.run(stdio.marm_graph_index(repo_path="/tmp/some-repo"))
+
+    assert second == {"status": "error", "message": "graph backend unavailable"}
+
+
 def test_stdio_core_tool_unaffected_by_graph_unavailable(monkeypatch, tmp_path):
     """GRAPH_ENABLED=false (or a failed backend) must never break core STDIO tools."""
     stdio = _isolated_stdio(monkeypatch, tmp_path)

--- a/marm-mcp-server/tests/test_stdio_transport.py
+++ b/marm-mcp-server/tests/test_stdio_transport.py
@@ -142,7 +142,12 @@ def test_stdio_handles_mcp_initialize_and_exposes_tools(tmp_path):
     assert "marm_stage_compaction_summaries" not in tool_names
     assert "marm_get_staged_summaries" not in tool_names
     assert "marm_apply_compaction" not in tool_names
-    assert len(tools) == 7
+    assert "marm_graph_index" in tool_names
+    assert "marm_code_lookup" in tool_names
+    assert "marm_graph_trace" in tool_names
+    assert "marm_graph_architecture" in tool_names
+    assert "marm_graph_impact" in tool_names
+    assert len(tools) == 12
 
 
 def test_stdio_delete_notebook_removes_entry_from_active_state(monkeypatch, tmp_path):
@@ -296,6 +301,71 @@ def test_stdio_inprocess_client_wraps_notebook_delete_and_log_results(
     assert json.loads(delete_result.content[0].text)["deleted"] is True
     assert json.loads(session_result.content[0].text)["status"] == "session_switched"
     assert json.loads(entry_result.content[0].text)["status"] == "success"
+
+
+def test_stdio_graph_tool_returns_unavailable_when_backend_down(monkeypatch, tmp_path):
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+    monkeypatch.setattr(stdio.graph_supervisor, "is_available", lambda: False)
+
+    result = asyncio.run(stdio.marm_graph_index(repo_path="/tmp/some-repo"))
+
+    assert result == {"status": "error", "message": "graph backend unavailable"}
+
+
+def test_stdio_core_tool_unaffected_by_graph_unavailable(monkeypatch, tmp_path):
+    """GRAPH_ENABLED=false (or a failed backend) must never break core STDIO tools."""
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+    monkeypatch.setattr(stdio.graph_supervisor, "is_available", lambda: False)
+
+    result = asyncio.run(stdio.marm_notebook(action="status"))
+
+    assert result["status"] == "success"
+
+
+def test_stdio_inprocess_client_wraps_graph_index_happy_path(monkeypatch, tmp_path):
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+    monkeypatch.setattr(stdio.graph_supervisor, "is_available", lambda: True)
+    monkeypatch.setattr(stdio.graph_supervisor, "get_client", lambda: "fake-client")
+
+    captured = {}
+
+    def _fake_do_index(client, req):
+        captured["client"] = client
+        captured["req"] = req
+        return {"status": "success", "project": "marm-systems"}
+
+    monkeypatch.setattr(stdio.graph_router, "do_index", _fake_do_index)
+
+    async def run():
+        async with create_connected_server_and_client_session(stdio.mcp) as client:
+            return await client.call_tool(
+                "marm_graph_index", {"repo_path": "/tmp/some-repo"}
+            )
+
+    result = asyncio.run(run())
+
+    assert result.content
+    assert result.content[0].type == "text"
+    payload = json.loads(result.content[0].text)
+    assert payload["status"] == "success"
+    assert payload["project"] == "marm-systems"
+
+    # Proves the wrapper reused graph_supervisor's client and built the same
+    # Pydantic request model the HTTP endpoint uses, rather than duplicating
+    # HTTP endpoint logic by hand.
+    assert captured["client"] == "fake-client"
+    assert captured["req"].repo_path == "/tmp/some-repo"
+
+
+def test_stop_graph_supervisor_safely_swallows_errors(monkeypatch):
+    import marm_mcp_server.server_stdio as stdio
+
+    def _boom():
+        raise RuntimeError("child process gone")
+
+    monkeypatch.setattr(stdio.graph_supervisor, "stop", _boom)
+
+    stdio._stop_graph_supervisor_safely()  # must not raise
 
 
 def _base_rpc_stdin():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five code-graph tools to the local STDIO experience, matching the 12-tool set available over HTTP.
  * Code-graph tools now start lazily on first use for both HTTP and STDIO.

* **Bug Fixes**
  * Improved graph shutdown to prevent lingering processes and keep availability/state consistent during termination.
  * Graph tooling cleanly reports degraded/unavailable mode without impacting the 7 core memory tools.

* **Documentation**
  * Updated the README, FAQs, and tool references to reflect HTTP + STDIO availability and the correct 12-tool count.  

* **Tests**
  * Added coverage for graph unavailability behavior, shutdown safety, and tool exposure counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->