### PR TITLE
Dedup log-entry logic between HTTP and STDIO transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>Unreleased: Log-Entry Cross-Transport Dedup (v2.21.3)</strong></summary>
+
+### Shared Log-Entry Logic
+
+- `endpoints/logging.py` (HTTP) and `services/stdio_entry_tools.py` (STDIO) each carried their own near-identical copy of `marm_log_entry`/`marm_log_show`/`marm_delete`'s session-switch detection, SQL, and dual-write-to-semantic-memory logic. Extracted into a shared `services/log_entry.py`; both transports now call the same functions through thin, transport-specific wrappers.
+- Fixed an information-disclosure gap: STDIO's error responses used to return raw exception text (e.g. SQLite paths/schema) to the client on failure. Now returns the same fixed generic messages HTTP already used, logging the real exception server-side instead.
+- Fixed a latent bug: HTTP's whole-session `marm_delete` deleted from `session_summary_cache` without a `try/except` guard, unlike every other cache-invalidation touch in both files (including STDIO's equivalent). Unified on the guarded behavior for both transports.
+
+</details>
+
+<details>
 <summary><strong>Unreleased: HTTP and STDIO Server Module Refactors (v2.21.2)</strong></summary>
 
 ### Server Module Boundaries

--- a/marm-mcp-server/marm_mcp_server/endpoints/logging.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/logging.py
@@ -1,21 +1,16 @@
 """Logging endpoints for MARM MCP Server."""
 
 from fastapi import HTTPException, APIRouter, Query
-import sqlite3
-import re
-import uuid
-from datetime import datetime, timezone
 from typing import Optional
 
 from ..core.models import LogEntryRequest, DeleteRequest
-from ..core.memory import memory
-from ..core.events import events
-from ..config.settings import MARM_PROJECT, MARM_PLATFORM
+from ..services.log_entry import (
+    create_log_entry,
+    delete_log_or_notebook_entry,
+    list_log_entries,
+)
 
 router = APIRouter(prefix="", tags=["Logging"])
-
-SESSION_PREFIXES = ("Session: ", "Topic: ")
-SESSION_INACTIVITY_NOTICE_SECONDS = 3600
 
 
 @router.post("/marm_log_entry", operation_id="marm_log_entry")
@@ -28,186 +23,7 @@ async def marm_log_entry(request: LogEntryRequest):
     Entries are also stored as semantic memories so marm_smart_recall can find them.
     Equivalent to /log entry: [YYYY-MM-DD-topic-summary] command
     """
-    try:
-        formatted_entry = request.entry.strip()
-
-        # Session-switch detection
-        for prefix in SESSION_PREFIXES:
-            if formatted_entry.startswith(prefix):
-                base_name = formatted_entry[len(prefix) :].strip()
-                if not base_name:
-                    return {
-                        "status": "error",
-                        "message": "Session name cannot be empty.",
-                    }
-                date_tag = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-                new_session = f"{base_name}-{date_tag}"
-                marker_id = str(uuid.uuid4())
-                with memory.get_connection() as conn:
-                    conn.execute("UPDATE sessions SET marm_active = FALSE")
-                    conn.execute(
-                        """
-                        INSERT INTO sessions (session_name, last_accessed, marm_active)
-                        VALUES (?, ?, TRUE)
-                        ON CONFLICT(session_name) DO UPDATE SET
-                            last_accessed = excluded.last_accessed,
-                            marm_active = TRUE
-                        """,
-                        (new_session, datetime.now(timezone.utc).isoformat()),
-                    )
-                    conn.execute(
-                        """
-                        INSERT INTO log_entries
-                            (id, session_name, entry_date, topic, summary, full_entry, project, platform)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            marker_id,
-                            new_session,
-                            date_tag,
-                            "session_start",
-                            base_name,
-                            formatted_entry,
-                            MARM_PROJECT or None,
-                            MARM_PLATFORM or None,
-                        ),
-                    )
-                    try:
-                        conn.execute(
-                            "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
-                            (datetime.now(timezone.utc).isoformat(), new_session),
-                        )
-                    except Exception:
-                        pass
-                    conn.commit()
-                memory.active_log_session = new_session
-                await events.emit("session_created", {"session": new_session})
-                return {
-                    "status": "session_switched",
-                    "message": f"📂 Session switched to '{new_session}'",
-                    "session_name": new_session,
-                }
-
-        # Resolve session — explicit > active > dated fallback
-        if request.session_name:
-            session = request.session_name
-        elif memory.active_log_session != "main":
-            session = memory.active_log_session
-        else:
-            date_tag = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            session = f"session-{date_tag}"
-            with memory.get_connection() as conn:
-                conn.execute("UPDATE sessions SET marm_active = FALSE")
-                conn.execute(
-                    """
-                    INSERT INTO sessions (session_name, last_accessed, marm_active)
-                    VALUES (?, ?, TRUE)
-                    ON CONFLICT(session_name) DO UPDATE SET
-                        last_accessed = excluded.last_accessed,
-                        marm_active = TRUE
-                    """,
-                    (session, datetime.now(timezone.utc).isoformat()),
-                )
-                conn.commit()
-            memory.active_log_session = session
-
-        # Chunk boundary check
-        with memory.get_connection() as conn:
-            row = conn.execute(
-                "SELECT last_accessed FROM sessions WHERE session_name = ?", (session,)
-            ).fetchone()
-        if row and row[0]:
-            try:
-                last_dt = datetime.fromisoformat(row[0])
-                if last_dt.tzinfo is None:
-                    last_dt = last_dt.replace(tzinfo=timezone.utc)
-                gap = (datetime.now(timezone.utc) - last_dt).total_seconds()
-                if gap > SESSION_INACTIVITY_NOTICE_SECONDS:
-                    print(
-                        f"[MARM] Chunk boundary detected for '{session}' — {gap:.0f}s since last write"
-                    )
-            except Exception:
-                pass
-
-        entry_pattern = r"^(\d{4}-\d{2}-\d{2})-(.*?)-(.*?)$"
-        match = re.match(entry_pattern, formatted_entry)
-
-        if match:
-            entry_date, topic, summary = match.groups()
-        else:
-            entry_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            topic = "general"
-            summary = formatted_entry
-
-        entry_id = str(uuid.uuid4())
-        now_iso = datetime.now(timezone.utc).isoformat()
-        with memory.get_connection() as conn:
-            conn.execute(
-                """
-                INSERT INTO log_entries (id, session_name, entry_date, topic, summary, full_entry, project, platform)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    entry_id,
-                    session,
-                    entry_date,
-                    topic,
-                    summary,
-                    formatted_entry,
-                    MARM_PROJECT or None,
-                    MARM_PLATFORM or None,
-                ),
-            )
-            conn.execute(
-                """
-                INSERT INTO sessions (session_name, last_accessed)
-                VALUES (?, ?)
-                ON CONFLICT(session_name) DO UPDATE SET last_accessed = excluded.last_accessed
-                """,
-                (session, now_iso),
-            )
-            try:
-                conn.execute(
-                    "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
-                    (now_iso, session),
-                )
-            except Exception:
-                pass
-            conn.commit()
-
-        # Dual-write into semantic memory so marm_smart_recall can find it;
-        # a store failure must never fail the log write itself.
-        memory_id = None
-        try:
-            memory_id = await memory.store_memory_queued(
-                formatted_entry,
-                session,
-                metadata={"source": "log_entry", "log_entry_id": entry_id},
-            )
-        except Exception as store_error:
-            print(f"Semantic store failed for log entry {entry_id}: {store_error}")
-
-        await events.emit(
-            "log_entry_created",
-            {"entry_id": entry_id, "session": session, "content": formatted_entry},
-        )
-
-        return {
-            "status": "success",
-            "message": f"📝 Log entry added: {formatted_entry}",
-            "entry_id": entry_id,
-            "memory_id": memory_id,
-            "formatted_entry": formatted_entry,
-        }
-    except sqlite3.Error as e:
-        print(f"Database error in marm_log_entry: {e}")
-        return {
-            "status": "error",
-            "message": "Database error while creating log entry.",
-        }
-    except Exception as e:
-        print(f"Unexpected error in marm_log_entry: {e}")
-        return {"status": "error", "message": "Log entry creation failed."}
+    return await create_log_entry(request.entry, request.session_name)
 
 
 @router.get("/marm_log_show", operation_id="marm_log_show")
@@ -221,54 +37,7 @@ async def marm_log_show(
 
     Equivalent to /log show: [session] command
     """
-    try:
-        with memory.get_connection() as conn:
-            if session_name:
-                cursor = conn.execute(
-                    """
-                    SELECT id, entry_date, topic, summary, full_entry
-                    FROM log_entries WHERE session_name = ?
-                    ORDER BY entry_date DESC
-                """,
-                    (session_name,),
-                )
-                entries = [
-                    {
-                        "id": r[0],
-                        "entry_date": r[1],
-                        "topic": r[2],
-                        "summary": r[3],
-                        "full_entry": r[4],
-                    }
-                    for r in cursor.fetchall()
-                ]
-
-                return {
-                    "status": "success",
-                    "session_name": session_name,
-                    "entries": entries,
-                    "total_entries": len(entries),
-                }
-            else:
-                cursor = conn.execute(
-                    "SELECT session_name, COUNT(*) FROM log_entries GROUP BY session_name"
-                )
-                sessions = [
-                    {"session_name": r[0], "entry_count": r[1]}
-                    for r in cursor.fetchall()
-                ]
-
-                return {
-                    "status": "success",
-                    "sessions": sessions,
-                    "total_sessions": len(sessions),
-                }
-    except sqlite3.Error as e:
-        print(f"Database error in marm_log_show: {e}")
-        return {"status": "error", "message": "Database error while showing logs."}
-    except Exception as e:
-        print(f"Unexpected error in marm_log_show: {e}")
-        return {"status": "error", "message": "Log show failed."}
+    return await list_log_entries(session_name)
 
 
 @router.post("/marm_delete", operation_id="marm_delete")
@@ -280,92 +49,11 @@ async def marm_delete(request: DeleteRequest):
     type="log" (no session_name): delete entire session and all its entries
     type="notebook": delete notebook entry by name
     """
-    try:
-        with memory.get_connection() as conn:
-            if request.type == "log":
-                memories_deleted = 0
-                if request.session_name:
-                    # Dual-written semantic memories must not outlive their log entries
-                    rows = conn.execute(
-                        "SELECT id FROM log_entries WHERE session_name = ? AND (id = ? OR topic = ?)",
-                        (request.session_name, request.target, request.target),
-                    ).fetchall()
-                    entry_ids = [r[0] for r in rows]
-                    cursor = conn.execute(
-                        "DELETE FROM log_entries WHERE session_name = ? AND (id = ? OR topic = ?)",
-                        (request.session_name, request.target, request.target),
-                    )
-                    deleted = cursor.rowcount
-                    if entry_ids:
-                        placeholders = ",".join("?" * len(entry_ids))
-                        memories_deleted = conn.execute(
-                            "DELETE FROM memories WHERE json_extract(metadata, '$.source') = 'log_entry' "
-                            f"AND json_extract(metadata, '$.log_entry_id') IN ({placeholders})",
-                            entry_ids,
-                        ).rowcount
-                    if deleted:
-                        try:
-                            conn.execute(
-                                "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
-                                (
-                                    datetime.now(timezone.utc).isoformat(),
-                                    request.session_name,
-                                ),
-                            )
-                        except Exception:
-                            pass
-                else:
-                    conn.execute(
-                        "DELETE FROM sessions WHERE session_name = ?", (request.target,)
-                    )
-                    cursor = conn.execute(
-                        "DELETE FROM log_entries WHERE session_name = ?",
-                        (request.target,),
-                    )
-                    deleted = cursor.rowcount
-                    conn.execute(
-                        "DELETE FROM session_summary_cache WHERE session_name = ?",
-                        (request.target,),
-                    )
-                    memories_deleted = conn.execute(
-                        "DELETE FROM memories WHERE session_name = ? "
-                        "AND json_extract(metadata, '$.source') = 'log_entry'",
-                        (request.target,),
-                    ).rowcount
-                    if memory.active_log_session == request.target:
-                        memory.active_log_session = "main"
-                conn.commit()
-                return {
-                    "status": "success",
-                    "message": f"🗑️ Deleted {deleted} items",
-                    "deleted_count": deleted,
-                    "memories_deleted": memories_deleted,
-                }
-            elif request.type == "notebook":
-                cursor = conn.execute(
-                    "DELETE FROM notebook_entries WHERE name = ?", (request.target,)
-                )
-                deleted = cursor.rowcount
-                conn.commit()
-                if deleted > 0:
-                    memory.remove_active_notebook_entry(request.target)
-                return {
-                    "status": "success" if deleted > 0 else "not_found",
-                    "message": f"🗑️ Deleted notebook entry '{request.target}'"
-                    if deleted > 0
-                    else f"Entry '{request.target}' not found",
-                    "deleted": deleted > 0,
-                }
-            else:
-                raise HTTPException(
-                    status_code=422,
-                    detail=f"Invalid type '{request.type}'. Must be 'log' or 'notebook'.",
-                )
-    except HTTPException:
-        raise
-    except sqlite3.Error as e:
-        print(f"Database error in marm_delete: {e}")
-        return {"status": "error", "message": "Database error while deleting."}
-    except Exception as e:
-        print(f"Unexpected error in marm_delete: {e}")
-        return {"status": "error", "message": "Delete failed."}
+    if request.type not in ("log", "notebook"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid type '{request.type}'. Must be 'log' or 'notebook'.",
+        )
+    return await delete_log_or_notebook_entry(
+        request.type, request.target, request.session_name
+    )

--- a/marm-mcp-server/marm_mcp_server/services/log_entry.py
+++ b/marm-mcp-server/marm_mcp_server/services/log_entry.py
@@ -1,0 +1,367 @@
+"""Shared log-entry/notebook data operations used by both transports.
+
+endpoints/logging.py (HTTP) and services/stdio_entry_tools.py (STDIO) call
+into these three functions instead of each carrying their own copy of the
+session-switch detection, SQL, and dual-write-to-semantic-memory logic.
+Each transport wrapper supplies its own log_info/log_warning callables so
+HTTP keeps its print()-to-stdout convention and STDIO keeps its
+_stdio_log-to-stderr-and-file convention -- this module has no opinion on
+logging destination, only on what to log.
+"""
+
+import re
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+from ..config.settings import MARM_PLATFORM, MARM_PROJECT
+from ..core.events import events
+from ..core.memory import memory
+
+_SESSION_PREFIXES = ("Session: ", "Topic: ")
+_SESSION_INACTIVITY_NOTICE_SECONDS = 3600
+
+
+async def create_log_entry(
+    entry: str,
+    session_name: Optional[str],
+    *,
+    log_info: Callable[[str], None] = print,
+    log_warning: Callable[[str], None] = print,
+) -> dict:
+    try:
+        formatted_entry = entry.strip()
+
+        # Session-switch detection
+        for prefix in _SESSION_PREFIXES:
+            if formatted_entry.startswith(prefix):
+                base_name = formatted_entry[len(prefix) :].strip()
+                if not base_name:
+                    return {
+                        "status": "error",
+                        "message": "Session name cannot be empty.",
+                    }
+                date_tag = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+                new_session = f"{base_name}-{date_tag}"
+                marker_id = str(uuid.uuid4())
+                with memory.get_connection() as conn:
+                    conn.execute("UPDATE sessions SET marm_active = FALSE")
+                    conn.execute(
+                        """
+                        INSERT INTO sessions (session_name, last_accessed, marm_active)
+                        VALUES (?, ?, TRUE)
+                        ON CONFLICT(session_name) DO UPDATE SET
+                            last_accessed = excluded.last_accessed,
+                            marm_active = TRUE
+                        """,
+                        (new_session, datetime.now(timezone.utc).isoformat()),
+                    )
+                    conn.execute(
+                        """
+                        INSERT INTO log_entries
+                            (id, session_name, entry_date, topic, summary, full_entry, project, platform)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            marker_id,
+                            new_session,
+                            date_tag,
+                            "session_start",
+                            base_name,
+                            formatted_entry,
+                            MARM_PROJECT or None,
+                            MARM_PLATFORM or None,
+                        ),
+                    )
+                    try:
+                        conn.execute(
+                            "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
+                            (datetime.now(timezone.utc).isoformat(), new_session),
+                        )
+                    except Exception:
+                        pass
+                    conn.commit()
+                memory.active_log_session = new_session
+                await events.emit("session_created", {"session": new_session})
+                return {
+                    "status": "session_switched",
+                    "message": f"📂 Session switched to '{new_session}'",
+                    "session_name": new_session,
+                }
+
+        # Resolve session — explicit > active > dated fallback
+        if session_name:
+            session = session_name
+        elif memory.active_log_session != "main":
+            session = memory.active_log_session
+        else:
+            date_tag = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            session = f"session-{date_tag}"
+            with memory.get_connection() as conn:
+                conn.execute("UPDATE sessions SET marm_active = FALSE")
+                conn.execute(
+                    """
+                    INSERT INTO sessions (session_name, last_accessed, marm_active)
+                    VALUES (?, ?, TRUE)
+                    ON CONFLICT(session_name) DO UPDATE SET
+                        last_accessed = excluded.last_accessed,
+                        marm_active = TRUE
+                    """,
+                    (session, datetime.now(timezone.utc).isoformat()),
+                )
+                conn.commit()
+            memory.active_log_session = session
+
+        # Chunk boundary check
+        with memory.get_connection() as conn:
+            row = conn.execute(
+                "SELECT last_accessed FROM sessions WHERE session_name = ?", (session,)
+            ).fetchone()
+        if row and row[0]:
+            try:
+                last_dt = datetime.fromisoformat(row[0])
+                if last_dt.tzinfo is None:
+                    last_dt = last_dt.replace(tzinfo=timezone.utc)
+                gap = (datetime.now(timezone.utc) - last_dt).total_seconds()
+                if gap > _SESSION_INACTIVITY_NOTICE_SECONDS:
+                    log_info(
+                        f"[MARM] Chunk boundary detected for '{session}' — {gap:.0f}s since last write"
+                    )
+            except Exception:
+                pass
+
+        entry_pattern = r"^(\d{4}-\d{2}-\d{2})-(.*?)-(.*?)$"
+        match = re.match(entry_pattern, formatted_entry)
+
+        if match:
+            entry_date, topic, summary = match.groups()
+        else:
+            entry_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            topic = "general"
+            summary = formatted_entry
+
+        entry_id = str(uuid.uuid4())
+        now_iso = datetime.now(timezone.utc).isoformat()
+        with memory.get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO log_entries (id, session_name, entry_date, topic, summary, full_entry, project, platform)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry_id,
+                    session,
+                    entry_date,
+                    topic,
+                    summary,
+                    formatted_entry,
+                    MARM_PROJECT or None,
+                    MARM_PLATFORM or None,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO sessions (session_name, last_accessed)
+                VALUES (?, ?)
+                ON CONFLICT(session_name) DO UPDATE SET last_accessed = excluded.last_accessed
+                """,
+                (session, now_iso),
+            )
+            try:
+                conn.execute(
+                    "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
+                    (now_iso, session),
+                )
+            except Exception:
+                pass
+            conn.commit()
+
+        # Dual-write into semantic memory so marm_smart_recall can find it;
+        # a store failure must never fail the log write itself.
+        memory_id = None
+        try:
+            memory_id = await memory.store_memory_queued(
+                formatted_entry,
+                session,
+                metadata={"source": "log_entry", "log_entry_id": entry_id},
+            )
+        except Exception as store_error:
+            log_warning(
+                f"Semantic store failed for log entry {entry_id}: {store_error}"
+            )
+
+        await events.emit(
+            "log_entry_created",
+            {"entry_id": entry_id, "session": session, "content": formatted_entry},
+        )
+
+        return {
+            "status": "success",
+            "message": f"📝 Log entry added: {formatted_entry}",
+            "entry_id": entry_id,
+            "memory_id": memory_id,
+            "formatted_entry": formatted_entry,
+        }
+    except sqlite3.Error as e:
+        # Never return str(e) to the client -- can leak SQLite paths/schema
+        # (same CWE-209 class as the marm_concept_recall fix). Log
+        # server-side via the caller's injected logger instead.
+        log_warning(f"Database error creating log entry: {e}")
+        return {
+            "status": "error",
+            "message": "Database error while creating log entry.",
+        }
+    except Exception as e:
+        log_warning(f"Unexpected error creating log entry: {e}")
+        return {"status": "error", "message": "Log entry creation failed."}
+
+
+async def list_log_entries(
+    session_name: Optional[str],
+    *,
+    log_warning: Callable[[str], None] = print,
+) -> dict:
+    try:
+        with memory.get_connection() as conn:
+            if session_name:
+                cursor = conn.execute(
+                    """
+                    SELECT id, entry_date, topic, summary, full_entry
+                    FROM log_entries WHERE session_name = ?
+                    ORDER BY entry_date DESC
+                    """,
+                    (session_name,),
+                )
+                entries = [
+                    {
+                        "id": r[0],
+                        "entry_date": r[1],
+                        "topic": r[2],
+                        "summary": r[3],
+                        "full_entry": r[4],
+                    }
+                    for r in cursor.fetchall()
+                ]
+                return {
+                    "status": "success",
+                    "session_name": session_name,
+                    "entries": entries,
+                    "total_entries": len(entries),
+                }
+            else:
+                cursor = conn.execute(
+                    "SELECT session_name, COUNT(*) FROM log_entries GROUP BY session_name"
+                )
+                sessions = [
+                    {"session_name": r[0], "entry_count": r[1]}
+                    for r in cursor.fetchall()
+                ]
+                return {
+                    "status": "success",
+                    "sessions": sessions,
+                    "total_sessions": len(sessions),
+                }
+    except sqlite3.Error as e:
+        log_warning(f"Database error showing logs: {e}")
+        return {"status": "error", "message": "Database error while showing logs."}
+    except Exception as e:
+        log_warning(f"Unexpected error showing logs: {e}")
+        return {"status": "error", "message": "Log show failed."}
+
+
+async def delete_log_or_notebook_entry(
+    type: str,
+    target: str,
+    session_name: Optional[str],
+    *,
+    log_warning: Callable[[str], None] = print,
+) -> dict:
+    """type must already be validated as "log" or "notebook" by the caller
+    -- transport-specific invalid-type handling (HTTP 422 vs. STDIO error
+    dict) stays at the transport layer so this module has no FastAPI
+    dependency."""
+    try:
+        with memory.get_connection() as conn:
+            if type == "log":
+                memories_deleted = 0
+                if session_name:
+                    # Dual-written semantic memories must not outlive their log entries
+                    rows = conn.execute(
+                        "SELECT id FROM log_entries WHERE session_name = ? AND (id = ? OR topic = ?)",
+                        (session_name, target, target),
+                    ).fetchall()
+                    entry_ids = [r[0] for r in rows]
+                    cursor = conn.execute(
+                        "DELETE FROM log_entries WHERE session_name = ? AND (id = ? OR topic = ?)",
+                        (session_name, target, target),
+                    )
+                    deleted = cursor.rowcount
+                    if entry_ids:
+                        placeholders = ",".join("?" * len(entry_ids))
+                        memories_deleted = conn.execute(
+                            "DELETE FROM memories WHERE json_extract(metadata, '$.source') = 'log_entry' "
+                            f"AND json_extract(metadata, '$.log_entry_id') IN ({placeholders})",
+                            entry_ids,
+                        ).rowcount
+                    if deleted:
+                        try:
+                            conn.execute(
+                                "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
+                                (datetime.now(timezone.utc).isoformat(), session_name),
+                            )
+                        except Exception:
+                            pass
+                else:
+                    conn.execute(
+                        "DELETE FROM sessions WHERE session_name = ?", (target,)
+                    )
+                    cursor = conn.execute(
+                        "DELETE FROM log_entries WHERE session_name = ?", (target,)
+                    )
+                    deleted = cursor.rowcount
+                    # Guarded like every other session_summary_cache touch in
+                    # this module -- a missing/locked cache row must not
+                    # abort the rest of the whole-session delete.
+                    try:
+                        conn.execute(
+                            "DELETE FROM session_summary_cache WHERE session_name = ?",
+                            (target,),
+                        )
+                    except Exception:
+                        pass
+                    memories_deleted = conn.execute(
+                        "DELETE FROM memories WHERE session_name = ? "
+                        "AND json_extract(metadata, '$.source') = 'log_entry'",
+                        (target,),
+                    ).rowcount
+                    if memory.active_log_session == target:
+                        memory.active_log_session = "main"
+                conn.commit()
+                return {
+                    "status": "success",
+                    "message": f"🗑️ Deleted {deleted} items",
+                    "deleted_count": deleted,
+                    "memories_deleted": memories_deleted,
+                }
+            else:  # type == "notebook"
+                cursor = conn.execute(
+                    "DELETE FROM notebook_entries WHERE name = ?", (target,)
+                )
+                deleted = cursor.rowcount
+                conn.commit()
+                if deleted > 0:
+                    memory.remove_active_notebook_entry(target)
+                return {
+                    "status": "success" if deleted > 0 else "not_found",
+                    "message": f"🗑️ Deleted notebook entry '{target}'"
+                    if deleted > 0
+                    else f"Entry '{target}' not found",
+                    "deleted": deleted > 0,
+                }
+    except sqlite3.Error as e:
+        log_warning(f"Database error deleting: {e}")
+        return {"status": "error", "message": "Database error while deleting."}
+    except Exception as e:
+        log_warning(f"Unexpected error deleting: {e}")
+        return {"status": "error", "message": "Delete failed."}

--- a/marm-mcp-server/marm_mcp_server/services/log_entry.py
+++ b/marm-mcp-server/marm_mcp_server/services/log_entry.py
@@ -83,7 +83,16 @@ async def create_log_entry(
                         pass
                     conn.commit()
                 memory.active_log_session = new_session
-                await events.emit("session_created", {"session": new_session})
+                # The session row and marker entry above are already durably
+                # committed -- an event-publish failure must not turn that
+                # into a client-visible error (same principle as the
+                # semantic-store try/except below: a retry on a false
+                # "error" response would create a duplicate session_start
+                # marker).
+                try:
+                    await events.emit("session_created", {"session": new_session})
+                except Exception as event_error:
+                    log_warning(f"session_created event failed: {event_error}")
                 return {
                     "status": "session_switched",
                     "message": f"📂 Session switched to '{new_session}'",
@@ -191,10 +200,21 @@ async def create_log_entry(
                 f"Semantic store failed for log entry {entry_id}: {store_error}"
             )
 
-        await events.emit(
-            "log_entry_created",
-            {"entry_id": entry_id, "session": session, "content": formatted_entry},
-        )
+        # Same reasoning as the session_created emit above -- the log_entries
+        # row (and the semantic memory, if the dual-write above succeeded)
+        # are already committed, so an event-publish failure here must not
+        # turn an already-durable write into a client-visible error.
+        try:
+            await events.emit(
+                "log_entry_created",
+                {
+                    "entry_id": entry_id,
+                    "session": session,
+                    "content": formatted_entry,
+                },
+            )
+        except Exception as event_error:
+            log_warning(f"log_entry_created event failed: {event_error}")
 
         return {
             "status": "success",
@@ -335,9 +355,13 @@ async def delete_log_or_notebook_entry(
                         "AND json_extract(metadata, '$.source') = 'log_entry'",
                         (target,),
                     ).rowcount
-                    if memory.active_log_session == target:
-                        memory.active_log_session = "main"
                 conn.commit()
+                # Flip the runtime pointer only after the delete durably
+                # commits -- otherwise a failed commit leaves the process
+                # thinking the active session is "main" while the target
+                # session's rows are still intact in the DB.
+                if not session_name and memory.active_log_session == target:
+                    memory.active_log_session = "main"
                 return {
                     "status": "success",
                     "message": f"🗑️ Deleted {deleted} items",

--- a/marm-mcp-server/marm_mcp_server/services/stdio_entry_tools.py
+++ b/marm-mcp-server/marm_mcp_server/services/stdio_entry_tools.py
@@ -1,328 +1,35 @@
-"""STDIO log-entry/notebook data operations with real inline SQL (not
-thin service-call wrappers)."""
+"""STDIO log-entry/notebook tool wrappers.
 
-import re
-import uuid
-from datetime import datetime, timezone
+Thin transport-specific glue over services/log_entry.py's shared
+business logic -- supplies STDIO's own logger (stderr +
+~/.marm/logs/marm-stdio.log via _stdio_log) and STDIO's own
+invalid-type error shape for marm_delete (a dict, not an HTTPException).
+"""
+
 from typing import Optional
 
-from ..config.settings import MARM_PLATFORM, MARM_PROJECT
-from ..core.events import events
-from ..core.memory import memory
 from ..core.stdio_logging import _stdio_log
-
-
-_SESSION_PREFIXES = ("Session: ", "Topic: ")
-_SESSION_INACTIVITY_NOTICE_SECONDS = 3600
+from .log_entry import create_log_entry, delete_log_or_notebook_entry, list_log_entries
 
 
 async def create_log_entry_stdio(entry: str, session_name: Optional[str]) -> dict:
-    try:
-        formatted_entry = entry.strip()
-
-        # Session-switch detection
-        for prefix in _SESSION_PREFIXES:
-            if formatted_entry.startswith(prefix):
-                base_name = formatted_entry[len(prefix) :].strip()
-                if not base_name:
-                    return {
-                        "status": "error",
-                        "message": "Session name cannot be empty.",
-                    }
-                date_tag = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-                new_session = f"{base_name}-{date_tag}"
-                marker_id = str(uuid.uuid4())
-                with memory.get_connection() as conn:
-                    conn.execute("UPDATE sessions SET marm_active = FALSE")
-                    conn.execute(
-                        """
-                        INSERT INTO sessions (session_name, last_accessed, marm_active)
-                        VALUES (?, ?, TRUE)
-                        ON CONFLICT(session_name) DO UPDATE SET
-                            last_accessed = excluded.last_accessed,
-                            marm_active = TRUE
-                        """,
-                        (new_session, datetime.now(timezone.utc).isoformat()),
-                    )
-                    conn.execute(
-                        """
-                        INSERT INTO log_entries
-                            (id, session_name, entry_date, topic, summary, full_entry, project, platform)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            marker_id,
-                            new_session,
-                            date_tag,
-                            "session_start",
-                            base_name,
-                            formatted_entry,
-                            MARM_PROJECT or None,
-                            MARM_PLATFORM or None,
-                        ),
-                    )
-                    try:
-                        conn.execute(
-                            "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
-                            (datetime.now(timezone.utc).isoformat(), new_session),
-                        )
-                    except Exception:
-                        pass
-                    conn.commit()
-                memory.active_log_session = new_session
-                await events.emit("session_created", {"session": new_session})
-                return {
-                    "status": "session_switched",
-                    "message": f"📂 Session switched to '{new_session}'",
-                    "session_name": new_session,
-                }
-
-        # Resolve session — explicit > active > dated fallback
-        if session_name:
-            session = session_name
-        elif memory.active_log_session != "main":
-            session = memory.active_log_session
-        else:
-            date_tag = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            session = f"session-{date_tag}"
-            with memory.get_connection() as conn:
-                conn.execute("UPDATE sessions SET marm_active = FALSE")
-                conn.execute(
-                    """
-                    INSERT INTO sessions (session_name, last_accessed, marm_active)
-                    VALUES (?, ?, TRUE)
-                    ON CONFLICT(session_name) DO UPDATE SET
-                        last_accessed = excluded.last_accessed,
-                        marm_active = TRUE
-                    """,
-                    (session, datetime.now(timezone.utc).isoformat()),
-                )
-                conn.commit()
-            memory.active_log_session = session
-
-        # Chunk boundary check
-        with memory.get_connection() as conn:
-            row = conn.execute(
-                "SELECT last_accessed FROM sessions WHERE session_name = ?", (session,)
-            ).fetchone()
-        if row and row[0]:
-            try:
-                last_dt = datetime.fromisoformat(row[0])
-                if last_dt.tzinfo is None:
-                    last_dt = last_dt.replace(tzinfo=timezone.utc)
-                gap = (datetime.now(timezone.utc) - last_dt).total_seconds()
-                if gap > _SESSION_INACTIVITY_NOTICE_SECONDS:
-                    _stdio_log.info(
-                        "Chunk boundary detected for '%s' — %.0fs since last write",
-                        session,
-                        gap,
-                    )
-            except Exception:
-                pass
-
-        entry_pattern = r"^(\d{4}-\d{2}-\d{2})-(.*?)-(.*?)$"
-        match = re.match(entry_pattern, formatted_entry)
-
-        if match:
-            entry_date, topic, summary = match.groups()
-        else:
-            entry_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            topic = "general"
-            summary = formatted_entry
-
-        entry_id = str(uuid.uuid4())
-        now_iso = datetime.now(timezone.utc).isoformat()
-        with memory.get_connection() as conn:
-            conn.execute(
-                """
-                INSERT INTO log_entries (id, session_name, entry_date, topic, summary, full_entry, project, platform)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    entry_id,
-                    session,
-                    entry_date,
-                    topic,
-                    summary,
-                    formatted_entry,
-                    MARM_PROJECT or None,
-                    MARM_PLATFORM or None,
-                ),
-            )
-            conn.execute(
-                """
-                INSERT INTO sessions (session_name, last_accessed)
-                VALUES (?, ?)
-                ON CONFLICT(session_name) DO UPDATE SET last_accessed = excluded.last_accessed
-                """,
-                (session, now_iso),
-            )
-            try:
-                conn.execute(
-                    "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
-                    (now_iso, session),
-                )
-            except Exception:
-                pass
-            conn.commit()
-
-        # Dual-write into semantic memory so marm_smart_recall can find it;
-        # a store failure must never fail the log write itself.
-        memory_id = None
-        try:
-            memory_id = await memory.store_memory_queued(
-                formatted_entry,
-                session,
-                metadata={"source": "log_entry", "log_entry_id": entry_id},
-            )
-        except Exception as store_error:
-            _stdio_log.warning(
-                "semantic store failed for log entry %s: %s", entry_id, store_error
-            )
-
-        await events.emit(
-            "log_entry_created",
-            {"entry_id": entry_id, "session": session, "content": formatted_entry},
-        )
-
-        return {
-            "status": "success",
-            "message": f"📝 Log entry added: {formatted_entry}",
-            "entry_id": entry_id,
-            "memory_id": memory_id,
-            "formatted_entry": formatted_entry,
-        }
-    except Exception as e:
-        return {"status": "error", "message": f"Error creating log entry: {e!s}"}
+    return await create_log_entry(
+        entry, session_name, log_info=_stdio_log.info, log_warning=_stdio_log.warning
+    )
 
 
 async def list_log_entries_stdio(session_name: Optional[str]) -> dict:
-    try:
-        with memory.get_connection() as conn:
-            if session_name:
-                cursor = conn.execute(
-                    """
-                    SELECT id, entry_date, topic, summary, full_entry
-                    FROM log_entries WHERE session_name = ?
-                    ORDER BY entry_date DESC
-                    """,
-                    (session_name,),
-                )
-                entries = [
-                    {
-                        "id": r[0],
-                        "entry_date": r[1],
-                        "topic": r[2],
-                        "summary": r[3],
-                        "full_entry": r[4],
-                    }
-                    for r in cursor.fetchall()
-                ]
-                return {
-                    "status": "success",
-                    "session_name": session_name,
-                    "entries": entries,
-                    "total_entries": len(entries),
-                }
-            else:
-                cursor = conn.execute(
-                    "SELECT session_name, COUNT(*) FROM log_entries GROUP BY session_name"
-                )
-                sessions = [
-                    {"session_name": r[0], "entry_count": r[1]}
-                    for r in cursor.fetchall()
-                ]
-                return {
-                    "status": "success",
-                    "sessions": sessions,
-                    "total_sessions": len(sessions),
-                }
-    except Exception as e:
-        return {"status": "error", "message": f"Error retrieving log entries: {e!s}"}
+    return await list_log_entries(session_name, log_warning=_stdio_log.warning)
 
 
 async def delete_entry_stdio(
     type: str, target: str, session_name: Optional[str]
 ) -> dict:
-    try:
-        with memory.get_connection() as conn:
-            if type == "log":
-                memories_deleted = 0
-                if session_name:
-                    # Dual-written semantic memories must not outlive their log entries
-                    rows = conn.execute(
-                        "SELECT id FROM log_entries WHERE session_name = ? AND (id = ? OR topic = ?)",
-                        (session_name, target, target),
-                    ).fetchall()
-                    entry_ids = [r[0] for r in rows]
-                    cursor = conn.execute(
-                        "DELETE FROM log_entries WHERE session_name = ? AND (id = ? OR topic = ?)",
-                        (session_name, target, target),
-                    )
-                    deleted = cursor.rowcount
-                    if entry_ids:
-                        placeholders = ",".join("?" * len(entry_ids))
-                        memories_deleted = conn.execute(
-                            "DELETE FROM memories WHERE json_extract(metadata, '$.source') = 'log_entry' "
-                            f"AND json_extract(metadata, '$.log_entry_id') IN ({placeholders})",
-                            entry_ids,
-                        ).rowcount
-                    if deleted:
-                        try:
-                            conn.execute(
-                                "UPDATE session_summary_cache SET dirty = TRUE, updated_at = ? WHERE session_name = ?",
-                                (datetime.now(timezone.utc).isoformat(), session_name),
-                            )
-                        except Exception:
-                            pass
-                else:
-                    conn.execute(
-                        "DELETE FROM sessions WHERE session_name = ?", (target,)
-                    )
-                    cursor = conn.execute(
-                        "DELETE FROM log_entries WHERE session_name = ?", (target,)
-                    )
-                    deleted = cursor.rowcount
-                    try:
-                        conn.execute(
-                            "DELETE FROM session_summary_cache WHERE session_name = ?",
-                            (target,),
-                        )
-                    except Exception:
-                        pass
-                    memories_deleted = conn.execute(
-                        "DELETE FROM memories WHERE session_name = ? "
-                        "AND json_extract(metadata, '$.source') = 'log_entry'",
-                        (target,),
-                    ).rowcount
-                    if memory.active_log_session == target:
-                        memory.active_log_session = "main"
-                conn.commit()
-                return {
-                    "status": "success",
-                    "message": f"🗑️ Deleted {deleted} items",
-                    "deleted_count": deleted,
-                    "memories_deleted": memories_deleted,
-                }
-            elif type == "notebook":
-                cursor = conn.execute(
-                    "DELETE FROM notebook_entries WHERE name = ?", (target,)
-                )
-                deleted = cursor.rowcount
-                conn.commit()
-                if deleted > 0:
-                    memory.remove_active_notebook_entry(target)
-                return {
-                    "status": "success" if deleted > 0 else "not_found",
-                    "message": f"🗑️ Deleted notebook entry '{target}'"
-                    if deleted > 0
-                    else f"Entry '{target}' not found",
-                    "deleted": deleted > 0,
-                }
-            else:
-                return {
-                    "status": "error",
-                    "message": f"Invalid type '{type}'. Must be 'log' or 'notebook'.",
-                }
-    except Exception as e:
-        return {"status": "error", "message": f"Error deleting: {e!s}"}
+    if type not in ("log", "notebook"):
+        return {
+            "status": "error",
+            "message": f"Invalid type '{type}'. Must be 'log' or 'notebook'.",
+        }
+    return await delete_log_or_notebook_entry(
+        type, target, session_name, log_warning=_stdio_log.warning
+    )

--- a/marm-mcp-server/tests/test_http_tools.py
+++ b/marm-mcp-server/tests/test_http_tools.py
@@ -697,6 +697,22 @@ def test_marm_delete_session_resets_active_log_session(monkeypatch, tmp_path):
     assert still_gone.json().get("total_entries", 0) == 0
 
 
+def test_marm_delete_invalid_type_returns_422(monkeypatch, tmp_path):
+    """log-entry-dedup.md: invalid type="..." must still 422, unchanged by
+    the endpoints/logging.py -> services/log_entry.py extraction. On HTTP
+    this is enforced by DeleteRequest.type's Pydantic Literal before the
+    handler body ever runs (endpoints/logging.py's own type check is an
+    unreachable-in-practice safety net, preserved as-is from the
+    pre-refactor code) -- this test guards the end-to-end contract either
+    way."""
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+
+    resp = client.post("/marm_delete", json={"type": "bogus", "target": "x"})
+
+    assert resp.status_code == 422
+
+
 def test_http_removed_tools_absent_from_openapi_schema(monkeypatch, tmp_path):
     server = load_isolated_server(monkeypatch, tmp_path)
     client = local_client(server.app)

--- a/marm-mcp-server/tests/test_stdio_transport.py
+++ b/marm-mcp-server/tests/test_stdio_transport.py
@@ -291,6 +291,53 @@ def test_stdio_delete_invalid_type_returns_error_dict_not_raise(monkeypatch, tmp
     }
 
 
+def test_stdio_delete_whole_session_keeps_active_session_if_commit_fails(
+    monkeypatch, tmp_path
+):
+    """PR #94 CodeRabbit finding: active_log_session must flip to "main"
+    only after the whole-session delete's conn.commit() actually succeeds
+    -- otherwise a failed commit leaves the runtime pointer saying "main"
+    while the target session's rows are still intact in the DB.
+
+    sqlite3.Connection is an immutable C type (can't monkeypatch .commit
+    on it directly), so this wraps the real connection in a thin proxy
+    that forwards everything except commit(), which raises."""
+    import contextlib
+    import sqlite3
+
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+
+    switch_result = asyncio.run(stdio.marm_log_entry(entry="Session: commit-fail-test"))
+    active_before = switch_result["session_name"]
+    assert active_before != "main"
+
+    class _CommitFailsConn:
+        def __init__(self, real):
+            self._real = real
+
+        def commit(self):
+            raise sqlite3.OperationalError("disk I/O error (forced)")
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real_get_connection = stdio.memory.get_connection
+
+    @contextlib.contextmanager
+    def _patched_get_connection():
+        with real_get_connection() as real_conn:
+            yield _CommitFailsConn(real_conn)
+
+    monkeypatch.setattr(stdio.memory, "get_connection", _patched_get_connection)
+
+    result = asyncio.run(stdio.marm_delete(type="log", target=active_before))
+    assert result["status"] == "error"
+    assert stdio.memory.active_log_session == active_before, (
+        "active_log_session flipped to 'main' even though the delete's "
+        "commit never succeeded"
+    )
+
+
 def test_stdio_delete_notebook_removes_entry_from_active_state(monkeypatch, tmp_path):
     stdio = _isolated_stdio(monkeypatch, tmp_path)
 

--- a/marm-mcp-server/tests/test_stdio_transport.py
+++ b/marm-mcp-server/tests/test_stdio_transport.py
@@ -14,20 +14,20 @@ def _isolated_stdio(monkeypatch, tmp_path):
     import marm_mcp_server.server_stdio as stdio
     import marm_mcp_server.core.stdio_tool_lifecycle as lifecycle
     import marm_mcp_server.services.notebook as notebook_service
-    import marm_mcp_server.services.stdio_entry_tools as stdio_entry_tools
+    import marm_mcp_server.services.log_entry as log_entry
     from marm_mcp_server.core.memory import MARMMemory
 
     mem = MARMMemory(str(tmp_path / "stdio-inprocess.db"))
     mem._encoder_failed = True
     monkeypatch.setattr(stdio, "memory", mem)
     monkeypatch.setattr(notebook_service, "memory", mem)
-    # marm_log_entry's body now lives in services.stdio_entry_tools
-    # (server-stdio-module-split.md Task 3) with its own `memory` binding --
-    # without this, its writes (including the queued semantic-memory store)
-    # silently hit the real production singleton instead of this test's
-    # isolated instance, which can also hang waiting on a write queue that
-    # was never started in-process.
-    monkeypatch.setattr(stdio_entry_tools, "memory", mem)
+    # marm_log_entry/marm_log_show/marm_delete's shared bodies now live in
+    # services.log_entry (log-entry-dedup.md) with their own `memory`
+    # binding -- without this, their writes (including the queued
+    # semantic-memory store) silently hit the real production singleton
+    # instead of this test's isolated instance, which can also hang
+    # waiting on a write queue that was never started in-process.
+    monkeypatch.setattr(log_entry, "memory", mem)
     # _log_tool_call re-resolves the compaction-claim session from
     # memory.active_log_session when the caller omits session_name (PR #88
     # CodeRabbit finding) -- without patching lifecycle's own binding too,
@@ -275,6 +275,22 @@ def test_stdio_compaction_claimed_against_resolved_session_not_literal_default(
     )
 
 
+def test_stdio_delete_invalid_type_returns_error_dict_not_raise(monkeypatch, tmp_path):
+    """log-entry-dedup.md: STDIO has no Pydantic Literal on `type` (it's a
+    plain str param), so delete_entry_stdio's own validation is the only
+    thing rejecting a bad value -- unlike HTTP where it's backstopped by
+    DeleteRequest.type's Literal. Confirms it returns an error dict rather
+    than raising, matching the pre-refactor STDIO contract."""
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+
+    result = asyncio.run(stdio.marm_delete(type="bogus", target="x"))
+
+    assert result == {
+        "status": "error",
+        "message": "Invalid type 'bogus'. Must be 'log' or 'notebook'.",
+    }
+
+
 def test_stdio_delete_notebook_removes_entry_from_active_state(monkeypatch, tmp_path):
     stdio = _isolated_stdio(monkeypatch, tmp_path)
 
@@ -376,6 +392,38 @@ def test_stdio_log_entry_without_session_uses_active_session(monkeypatch, tmp_pa
         f"Expected 2 entries in '{expected_session}'; got {project_count}"
     )
     assert main_count == 0, f"Entry incorrectly landed in 'main'; count={main_count}"
+
+
+def test_stdio_log_entry_error_returns_generic_message_not_leaked_exception(
+    monkeypatch, tmp_path
+):
+    """CWE-209 fix (log-entry-dedup.md): marm_log_entry/marm_log_show/
+    marm_delete over STDIO must return a fixed generic message on failure,
+    not the raw exception text -- matches HTTP's existing contract. Before
+    the fix, STDIO returned f"Error creating log entry: {e!s}" etc."""
+    import marm_mcp_server.services.log_entry as log_entry
+
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("leaked/internal/db/path.sqlite schema detail")
+
+    monkeypatch.setattr(log_entry.memory, "get_connection", _boom)
+
+    entry_result = asyncio.run(stdio.marm_log_entry(entry="should not leak"))
+    assert entry_result == {
+        "status": "error",
+        "message": "Log entry creation failed.",
+    }
+
+    show_result = asyncio.run(stdio.marm_log_show())
+    assert show_result == {"status": "error", "message": "Log show failed."}
+
+    delete_result = asyncio.run(stdio.marm_delete(type="log", target="whatever"))
+    assert delete_result == {"status": "error", "message": "Delete failed."}
+
+    for result in (entry_result, show_result, delete_result):
+        assert "leaked/internal/db/path.sqlite" not in result["message"]
 
 
 def test_stdio_inprocess_client_wraps_notebook_delete_and_log_results(

--- a/marm-mcp-server/tests/test_summary_cache.py
+++ b/marm-mcp-server/tests/test_summary_cache.py
@@ -163,6 +163,34 @@ def test_full_session_delete_removes_cache_row(monkeypatch, tmp_path):
     assert _cache_row(db_path, "s6") is None
 
 
+def test_full_session_delete_survives_missing_summary_cache_table(
+    monkeypatch, tmp_path
+):
+    """log-entry-dedup.md: the whole-session marm_delete branch now guards
+    its session_summary_cache DELETE in try/except (matching every other
+    cache-invalidation call site in services/log_entry.py) instead of
+    letting a cache failure abort the log_entries/sessions/memories
+    deletes that come after it. Dropping the table is a real, not
+    synthetic, way to force that DELETE to raise."""
+    server = load_isolated_server(monkeypatch, tmp_path)
+    client = local_client(server.app)
+    db_path = str(tmp_path / "marm_memory.db")
+
+    _insert_log_entry(db_path, "s7", "entry that must still be deleted")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE session_summary_cache")
+
+    resp = client.post("/marm_delete", json={"type": "log", "target": "s7"})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    with sqlite3.connect(db_path) as conn:
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM log_entries WHERE session_name = ?", ("s7",)
+        ).fetchone()[0]
+    assert remaining == 0
+
+
 # --- disposable mode ---
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP and STDIO log/notebook operations are now consistent, including session switching and deletion behavior.
  * STDIO no longer returns raw exception text; failures use safe, generic messages while server details are logged.
  * Full-session deletion is more resilient (including when summary-cache data is missing) and avoids active-session inconsistencies on commit failure.
  * Invalid deletion types are rejected with clear 422 errors (and STDIO returns safe error dictionaries instead of raising).
* **Documentation**
  * Added unreleased v2.21.3 “Log-Entry Cross-Transport Dedup” changelog notes.
* **Tests**
  * Added regression and end-to-end coverage for the above behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->