### PR TITLE
fix(console): correct earlier context_type fix, backend requires a st…

### DIFF
--- a/marm-console/artifacts/marm-console/src/components/memory/MemoriesTab.tsx
+++ b/marm-console/artifacts/marm-console/src/components/memory/MemoriesTab.tsx
@@ -147,6 +147,10 @@ export function MemoriesTab() {
 
   const handleUpdate = () => {
     if (!selectedMemory) return;
+    // context_type has no null/blank state on the server -- it's a required
+    // non-empty string there (and downstream recall code assumes as much),
+    // so clearing the field falls back to the same 'general' default used
+    // for new memories, not the previous value and not null.
     updateMemory.mutate({
       id: selectedMemory.id,
       data: {
@@ -154,7 +158,7 @@ export function MemoriesTab() {
         session_name: selectedMemory.session_name,
         project: editProject.trim() || null,
         platform: editPlatform.trim() || null,
-        context_type: editContextType.trim() || null,
+        context_type: editContextType.trim() || 'general',
         metadata: selectedMemory.metadata,
       }
     }, {
@@ -165,7 +169,7 @@ export function MemoriesTab() {
           content: editContent,
           project: editProject.trim() || null,
           platform: editPlatform.trim() || null,
-          context_type: editContextType.trim() || null,
+          context_type: editContextType.trim() || 'general',
         });
         setActionNotice({ kind: 'success', message: 'Memory updated.' });
       },

--- a/marm-console/artifacts/marm-console/src/components/memory/MemoriesTab.tsx
+++ b/marm-console/artifacts/marm-console/src/components/memory/MemoriesTab.tsx
@@ -369,7 +369,7 @@ export function MemoriesTab() {
                   <div className="grid grid-cols-3 gap-2">
                     <Input placeholder="Project (blank = null)" value={editProject} onChange={e => setEditProject(e.target.value)} className="text-xs" />
                     <Input placeholder="Platform (blank = null)" value={editPlatform} onChange={e => setEditPlatform(e.target.value)} className="text-xs" />
-                    <Input placeholder="Context type (blank = null)" value={editContextType} onChange={e => setEditContextType(e.target.value)} className="text-xs" />
+                    <Input placeholder="Context type (blank = general)" value={editContextType} onChange={e => setEditContextType(e.target.value)} className="text-xs" />
                   </div>
                   <div className="flex justify-end gap-2">
                     <Button variant="outline" size="sm" onClick={() => setEditMode(false)}>Cancel</Button>


### PR DESCRIPTION
…ring

Follow-up to my earlier fix in this PR that changed the blank fallback from the stale selectedMemory.context_type to null. That was wrong: an independent review caught that marm-mcp-server's internal endpoint declares context_type as a required non-empty str (min_length=1), and its recall path calls .upper() on it unconditionally -- sending null gets rejected with a 422, it doesn't clear the field. The Console-side correction (restoring the backend's blank-to-'general' coercion) landed separately on fix/console-memory-context-type-null since the branch that originally carried this contract (refactor/console-app-py-split) had already merged.

This commit fixes the actual root cause the CodeRabbit finding was pointing at: the fallback used the memory's previous context_type (stale) instead of a fixed default. The correct fallback is 'general' -- the same default already used for new memories -- not null.

tsc --noEmit clean, npm run build succeeds.


Claude-Session: https://claude.ai/code/session_011s8tBNnQTmb1q5nRAKwhvv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated memory editing so clearing the context type consistently saves it as “general” instead of an empty or null value.
  * The selected memory now immediately reflects the default context type after a successful update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->