### PR TITLE
feat(embeddings): migrate default model to jina v2 small

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ MARM is a local-first MCP memory server: Python FastAPI in `marm-mcp-server/`, p
 - **Storage**: SQLite WAL at `~/.marm/marm_memory.db` (connection pool, FTS5 external-content index `memories_fts`, `memory_chunks` for long-memory chunking). The concept graph uses its own database `~/.marm/index/marm_index.db` with its own pool. Never share connections between the two.
 - **Write path**: all memory writes go through the serialized async write queue (one worker). Do not add write paths that bypass it. `marm_log_entry` dual-writes: a `log_entries` row plus a semantic memory in `memories` (via the queue); a semantic-store failure must never fail the log write.
 - **Code graph**: a pinned external binary (codebase-memory-mcp) supervised as a child process over newline-delimited JSON-RPC (`core/graph_supervisor.py`, `core/graph_client.py`). It starts lazily and runs degraded on failure. Graph or concept failures must never break the 7 core memory tools.
-- **Embeddings**: one fastembed `all-MiniLM-L6-v2` encoder, lazy-loaded, serialized behind a lock. Writes must succeed even when the encoder is unavailable.
+- **Embeddings**: one fastembed `jinaai/jina-embeddings-v2-small-en` encoder (512 dimensions), lazy-loaded and serialized behind a lock. Writes must succeed even when the encoder is unavailable. Existing data requires `marm-mcp-server --migrate-embeddings` before restart when upgrading from MiniLM.
 
 ## Consistency Rules
 
@@ -68,9 +68,9 @@ Semver: MAJOR = breaking (schema renames, parameter removals), MINOR = new tools
 - Dev setup: `cd marm-mcp-server && pip install -e ".[dev,concepts]" && python -m spacy download en_core_web_sm`
 - Benchmarks live in `scripts/benchmarking/`: `preformance/bench_hotpath.py` for hot-path performance, `accuracy/locomo/run_eval.py` for LoCoMo retrieval accuracy. Do not publish performance claims neither script can back.
 
-## Current Stats (v2.21.1)
+## Current Stats (v2.24.0)
 
 - 14 MCP tools over HTTP + STDIO
 - 2 isolated SQLite databases (memory + concept graph)
-- Hybrid recall: FTS5 BM25 exact lane + bounded semantic rerank, ~20ms median at N=10,000
+- Hybrid recall: FTS5 BM25 exact lane + bounded semantic rerank
 - Optional extras: `[concepts]` (spaCy extraction), Docker image with the graph engine baked in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>Unreleased: Jina v2 Small Embedding Migration (v2.24.0)</strong></summary>
+
+### Default Embedding Model Changed
+
+- Switched the default semantic encoder from `all-MiniLM-L6-v2` (384 dimensions, 256-token context) to fastembed-backed `jinaai/jina-embeddings-v2-small-en` (512 dimensions, 8,192-token context). Jina v2 Small has 33M parameters, is Apache-2.0 licensed, and does not require separate query/document text prefixes.
+- **Upgrade required for existing data:** stop every MARM HTTP and STDIO process, then run `marm-mcp-server --migrate-embeddings` before restarting MARM. The command refuses when it detects a live HTTP server, but cannot reliably detect STDIO processes, so those must be stopped manually.
+- The migration re-embeds memory, chunk, notebook, and any existing concept-graph embeddings. It reports batch progress, verifies both database files before recording completion, and can be rerun safely after interruption.
+- Existing installations still start before migration, but mixed-dimension embeddings degrade semantic recall; startup and affected recall lanes now log actionable dimension-mismatch warnings.
+- Re-ran both benchmark suites with Jina v2 Small. The hot-path benchmark now publishes the measured latency/write profile; a fresh 10-conversation LoCoMo run reached 53.0% any-hit and 43.4% all-hit at top-5 across 1,977 questions, compared with the prior MiniLM baseline of 37.5% and 29.5%. This is an end-to-end result, not a claim that context length alone caused the change.
+
+</details>
+
+<details>
+<summary><strong>July 18th, 2026: Focused Console and Memory Module Refactors (v2.23.1)</strong></summary>
+
+### Clearer Module Boundaries
+
+- Split MARM Console's large Memory and Knowledge workspace components into focused tab, graph, and dialog modules without changing the Console API or user-facing behavior.
+- Split the Console FastAPI application into endpoint, model, and core modules while preserving the standalone Console entry point and route contract.
+- Split MARM's memory operations into focused internal modules while retaining the existing core-memory compatibility surface, serialized write queue, and public MCP behavior.
+- Added regression coverage around the extracted Console and memory-operation boundaries. No schema, endpoint, or MCP tool-surface changes.
+
+</details>
+
+<details>
 <summary><strong>Unreleased: SQLite Write Atomicity Hardening (v2.23.0)</strong></summary>
 
 ### Multi-Statement Writes Are Now Real Transactions

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.23.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.24.0</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -98,44 +98,67 @@ pip install marm-mcp-server
 | **Private high-throughput swarm** | `python -m marm_mcp_server --swarm-max` | `"agent" mcp add --transport http marm-memory http://localhost:8001/mcp` |
 | **Trusted private lab/server** | `python -m marm_mcp_server --trusted` | `"agent" mcp add --transport http marm-memory http://localhost:8001/mcp` |
 
+### Upgrade Existing Embeddings
+
+The Jina v2 Small default uses 512-dimensional embeddings; older `all-MiniLM-L6-v2` data is 384-dimensional and must be re-embedded after upgrading. Stop every MARM HTTP and STDIO process, then run:
+
+```bash
+marm-mcp-server --migrate-embeddings
+```
+
+The command refuses to continue when it detects a live HTTP server, but STDIO processes cannot be detected reliably and must be stopped manually. It re-embeds memory, chunk, notebook, and any existing concept-graph embeddings, reports batch progress, verifies both databases, and exits. It is resumable: rerun the same command after an interruption. Do not run it against a live server.
+
 ## Performance & Scaling Benchmarks
 
 MARM is tuned for fast recall first, even as memory grows and long memories are chunked behind the scenes.
+
+These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database.
 
 ### 1. Retrieval Latency Scaling
 
 | Session Size ($N$) | Min Latency | Median Latency | p95 Latency |
 | :--- | :--- | :--- | :--- |
-| **N = 100** | 12.3 ms | 13.8 ms | 15.0 ms |
-| **N = 500** | 13.3 ms | 14.1 ms | 16.4 ms |
-| **N = 1,000** | 14.5 ms | 16.2 ms | 17.1 ms |
-| **N = 2,000** | 15.9 ms | 18.4 ms | 20.8 ms |
-| **N = 4,000** | 17.6 ms | 20.8 ms | 22.5 ms |
+| **N = 100** | 6.6 ms | 7.4 ms | 8.0 ms |
+| **N = 500** | 7.1 ms | 8.1 ms | 10.0 ms |
+| **N = 1,000** | 7.6 ms | 8.5 ms | 9.0 ms |
+| **N = 2,000** | 9.3 ms | 10.5 ms | 11.6 ms |
+| **N = 4,000** | 11.5 ms | 12.1 ms | 13.4 ms |
 
 ### 2. Encoder + Concurrency
 
-- **Cold model load:** `972ms`
-- **Warm encode:** median `10.3ms`, p95 `11.2ms`
-- **Concurrent recall:** 10 gathered recalls completed in `394.7ms` vs `436.6ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so this is stable under load rather than true parallel speedup.
+- **Cold model load:** `887ms`
+- **Warm encode:** median `4.0ms`, p95 `4.4ms`
+- **Concurrent recall:** 10 gathered recalls completed in `616.3ms` vs `440.7ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so gathering calls does not create parallel speedup.
 
 ### 3. Write-Time Ingestion Cost
 
-- **Consolidation off:** median `10.3ms`, p95 `11.6ms`
-- **Consolidation on:** median `42.0ms`, p95 `46.3ms`
-- **Tradeoff:** write-time dedupe/clustering adds `4.1x` median cost so recall stays fast and cleaner over time.
+- **Consolidation off:** median `6.8ms`, p95 `7.9ms`
+- **Consolidation on:** median `51.3ms`, p95 `93.7ms`
+- **Tradeoff:** write-time dedupe/clustering adds `7.6x` median cost so recall stays fast and cleaner over time.
 
 ### 4. Hybrid Search Scaling
 
 | Session Size ($N$) | Pure Semantic | Production Hybrid | FTS Filter -> Rerank | Speedup vs Pure |
 | :--- | :--- | :--- | :--- | :--- |
-| **N = 100** | 2.4 ms | 15.1 ms | 2.2 ms | 1.1x |
-| **N = 1,000** | 23.6 ms | 16.2 ms | 2.7 ms | 8.8x |
-| **N = 4,000** | 93.8 ms | 18.3 ms | 4.9 ms | 19.0x |
-| **N = 10,000** | 242.7 ms | 19.7 ms | 5.4 ms | 45.1x |
+| **N = 100** | 2.3 ms | 7.9 ms | 1.9 ms | 1.2x |
+| **N = 1,000** | 23.1 ms | 9.2 ms | 2.5 ms | 9.2x |
+| **N = 4,000** | 106.5 ms | 13.2 ms | 4.7 ms | 22.8x |
+| **N = 10,000** | 267.1 ms | 13.6 ms | 5.3 ms | 50.4x |
 
-Benchmarks used a throwaway real SQLite database and the live fastembed-backed `all-MiniLM-L6-v2` encoder on local hardware. Reproduce them: [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py)
+These Jina v2 Small benchmarks used a throwaway real SQLite database and the live configured encoder on local hardware. Reproduce them: [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py)
 
-### 5. vs Competitors: Architecture
+### 5. LoCoMo Retrieval Accuracy
+
+A fresh Jina v2 Small run ingested all 10 LoCoMo conversations through `marm_log_entry`, then scored top-5 `marm_smart_recall` results against 1,977 evidence-annotated questions. No answer-generation model or LLM judge was used.
+
+| Encoder | Any evidence hit | All evidence hit | Mean evidence recall |
+| :--- | :--- | :--- | :--- |
+| **MiniLM baseline** | 37.5% | 29.5% | not previously published |
+| **Jina v2 Small** | 53.0% | 43.4% | 47.6% |
+
+The Jina run improved both hit metrics in this benchmark. This comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce it with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+
+### 6. vs Competitors: Architecture
 
 MARM targets a specific niche: local-first memory for MCP-connected coding agents, not general personalization memory or a full agent runtime. Here's how it differs architecturally from established names in AI agent memory:
  
@@ -767,7 +790,7 @@ Everything above runs on a small number of deliberate mechanisms. This section i
 - **SQLite in WAL mode** at `~/.marm/marm_memory.db` with a connection pool (5 connections). WAL keeps readers unblocked during writes, which matters when several agents recall while one writes.
 - **FTS5 full-text index** (`memories_fts`) is maintained as an external-content table over the memories table and powers both the exact lane (BM25) and the filter stage of hybrid recall.
 - **Chunk storage**: memories past ~180 words are split into overlapping 150-token chunks (50-token overlap) in a `memory_chunks` table, each with its own embedding. Recall scores chunks and collapses to the parent memory.
-- **Embeddings** come from a fastembed-backed `all-MiniLM-L6-v2` encoder, lazily loaded on first semantic use and serialized behind a lock so concurrent encodes can't corrupt each other. If the encoder is unavailable, writes still succeed; memories are simply stored without embeddings until it loads. Semantic scoring runs as a single NumPy batch (matrix cosine) rather than a Python loop.
+- **Embeddings** come from the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder: 33M parameters, 512 dimensions, an 8,192-token context window, and an Apache-2.0 license. It does not require separate query/document text prefixes. The encoder is lazily loaded on first semantic use and serialized behind a lock so concurrent encodes can't corrupt each other. If it is unavailable, writes still succeed; memories are stored without embeddings until it loads. Semantic scoring runs as a single NumPy batch (matrix cosine) rather than a Python loop.
 - **The concept graph gets its own database** (`~/.marm/index/marm_index.db`) and its own pool, reusing the same pool implementation but never sharing connections with the memory store. Deliberate isolation: an experimental graph build must not be able to stall the production WAL.
 
 ### Write path

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.23.0** - Memory Accurate Response Mode
+**MARM v2.24.0** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---
@@ -552,6 +552,21 @@ curl http://localhost:8001/health
 docker pull lyellr88/marm-mcp-server:latest
 docker stop marm-mcp-server
 docker rm marm-mcp-server
+```
+
+**Migrate existing embeddings** when upgrading to the Jina v2 Small release. With every HTTP and STDIO MARM process stopped, run this against the persistent data volume before starting the updated container:
+
+```bash
+docker run --rm \
+  -v ~/.marm:/home/marm/.marm \
+  lyellr88/marm-mcp-server:latest --migrate-embeddings
+```
+
+The migration command refuses when it detects a live HTTP server, but cannot reliably detect STDIO processes. It re-embeds memory, chunk, notebook, and any existing concept-graph embeddings, and can be rerun safely after interruption.
+
+**Start the updated container:**
+
+```bash
 docker run -d --name marm-mcp-server \
   -p 127.0.0.1:8001:8001 \
   -e SERVER_HOST=0.0.0.0 \
@@ -565,7 +580,14 @@ docker run -d --name marm-mcp-server \
 
 ### **Migration Notes**
 
-- Database schema is compatible - no migration needed
+- The Jina v2 Small upgrade changes stored embeddings from MiniLM's 384 dimensions to 512 dimensions. Migrate the persistent volume with `--migrate-embeddings` before starting the updated container.
+
+```bash
+docker run --rm \
+  -v ~/.marm:/home/marm/.marm \
+  lyellr88/marm-mcp-server:latest --migrate-embeddings
+```
+
 - New tools automatically available after restart
 - Docker images are backward compatible with persistent volumes
 

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.23.0** - Memory Accurate Response Mode
+**MARM v2.24.0** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -320,7 +320,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"
@@ -348,7 +348,15 @@ curl -s http://localhost:8001/health
    pip install marm-mcp-server --upgrade
    ```
 
-4. **Restart Server**: `python3 -m marm_mcp_server`
+4. **Migrate existing embeddings** when upgrading to the Jina v2 Small release:
+
+   ```bash
+   marm-mcp-server --migrate-embeddings
+   ```
+
+   Keep every MARM HTTP and STDIO process stopped while this runs. The command refuses when it detects an HTTP server, but cannot reliably detect STDIO processes. It is resumable after interruption.
+
+5. **Restart Server**: `python3 -m marm_mcp_server`
 
 ---
 
@@ -367,7 +375,7 @@ python3 -m marm_mcp_server
 
 ### **Migration Notes**
 
-- Database schema is compatible - no migration needed
+- The Jina v2 Small upgrade changes stored embeddings from MiniLM's 384 dimensions to 512 dimensions. After upgrading, stop every MARM process and run `marm-mcp-server --migrate-embeddings` before restarting; it migrates memory, chunk, notebook, and any existing concept-graph embeddings.
 - New tools automatically available after restart
 - Docker images are backward compatible with persistent volumes
 
@@ -446,7 +454,7 @@ source ~/.bashrc
 | `MARM_API_KEY` | *(unset)* | Bearer token for all capability endpoints. Auto-generated when `SERVER_HOST=0.0.0.0` and not set. Required for Docker. Generate manually: `python -m marm_mcp_server --generate-key` |
 | `MAX_DB_CONNECTIONS` | `5` | Database connection pool size |
 | `MARM_ANALYTICS_DB_PATH` | `marm_usage_analytics.db` | Override analytics database path |
-| `DEFAULT_SEMANTIC_MODEL` | `all-MiniLM-L6-v2` | AI model for semantic search |
+| `DEFAULT_SEMANTIC_MODEL` | `jinaai/jina-embeddings-v2-small-en` | Default semantic-search model: 512 dimensions, 8,192-token context, 33M parameters, Apache-2.0 licensed; no query/document text prefixes required. |
 | `RECALL_SCAN_LIMIT` | `10000` | Maximum embedded memories semantic recall scans per query before surfacing `recall_scan_truncated=true`. |
 | `MARM_RATE_LIMIT_RPM` | `80` | HTTP rate limit (requests per minute per client IP). Set to `0` to disable. Overridden by `--swarm`, `--swarm-max`, `--trusted` presets. |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialized memory write queue. Set to `0` only for debugging/direct-write comparisons. |

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.23.0 MCP Server - Platform Integration Guide
+# MARM v2.24.0 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -337,6 +337,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 docker pull lyellr88/marm-mcp-server:latest
 docker stop marm-mcp-server
 docker rm marm-mcp-server
+docker run --rm -v ${HOME}\.marm:/home/marm/.marm lyellr88/marm-mcp-server:latest --migrate-embeddings
 docker run -d --name marm-mcp-server -p 127.0.0.1:8001:8001 -e SERVER_HOST=0.0.0.0 -e MARM_API_KEY=your-generated-key -v ${HOME}\.marm:/home/marm/.marm --restart unless-stopped lyellr88/marm-mcp-server:latest
 ```
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.23.0** - Memory Accurate Response Mode
+**MARM v2.24.0** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -293,7 +293,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"
@@ -321,7 +321,15 @@ Invoke-WebRequest -Uri http://localhost:8001/health
    pip install marm-mcp-server --upgrade
    ```
 
-4. **Restart Server**: `python -m marm_mcp_server`
+4. **Migrate existing embeddings** when upgrading to the Jina v2 Small release:
+
+   ```powershell
+   marm-mcp-server --migrate-embeddings
+   ```
+
+   Keep every MARM HTTP and STDIO process stopped while this runs. The command refuses when it detects an HTTP server, but cannot reliably detect STDIO processes. It is resumable after interruption.
+
+5. **Restart Server**: `python -m marm_mcp_server`
 
 **🐳 Docker Update:**
 
@@ -349,7 +357,7 @@ python -m marm_mcp_server
 
 ### **Migration Notes**
 
-- Database schema is compatible - no migration needed
+- The Jina v2 Small upgrade changes stored embeddings from MiniLM's 384 dimensions to 512 dimensions. After upgrading, stop every MARM process and run `marm-mcp-server --migrate-embeddings` before restarting; it migrates memory, chunk, notebook, and any existing concept-graph embeddings.
 - New tools automatically available after restart
 - Docker images are backward compatible with persistent volumes
 
@@ -408,7 +416,7 @@ python -m marm_mcp_server
 | `MARM_API_KEY` | *(unset)* | Bearer token for all capability endpoints. Auto-generated when `SERVER_HOST=0.0.0.0` and not set. Required for Docker. Generate manually: `python -m marm_mcp_server --generate-key` |
 | `MAX_DB_CONNECTIONS` | `5` | Database connection pool size |
 | `MARM_ANALYTICS_DB_PATH` | `marm_usage_analytics.db` | Override analytics database path |
-| `DEFAULT_SEMANTIC_MODEL` | `all-MiniLM-L6-v2` | AI model for semantic search |
+| `DEFAULT_SEMANTIC_MODEL` | `jinaai/jina-embeddings-v2-small-en` | Default semantic-search model: 512 dimensions, 8,192-token context, 33M parameters, Apache-2.0 licensed; no query/document text prefixes required. |
 | `RECALL_SCAN_LIMIT` | `10000` | Maximum embedded memories semantic recall scans per query before surfacing `recall_scan_truncated=true`. |
 | `MARM_RATE_LIMIT_RPM` | `80` | HTTP rate limit (requests per minute per client IP). Set to `0` to disable. Overridden by `--swarm`, `--swarm-max`, `--trusted` presets. |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialized memory write queue. Set to `0` only for debugging/direct-write comparisons. |

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -65,7 +65,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.23.0"
+LABEL org.opencontainers.image.version="2.24.0"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -7,7 +7,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.23.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.24.0</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -100,44 +100,67 @@ pip install marm-mcp-server
 | **Private high-throughput swarm** | `python -m marm_mcp_server --swarm-max` | `"agent" mcp add --transport http marm-memory http://localhost:8001/mcp` |
 | **Trusted private lab/server** | `python -m marm_mcp_server --trusted` | `"agent" mcp add --transport http marm-memory http://localhost:8001/mcp` |
 
+### Upgrade Existing Embeddings
+
+The Jina v2 Small default uses 512-dimensional embeddings; older `all-MiniLM-L6-v2` data is 384-dimensional and must be re-embedded after upgrading. Stop every MARM HTTP and STDIO process, then run:
+
+```bash
+marm-mcp-server --migrate-embeddings
+```
+
+The command refuses to continue when it detects a live HTTP server, but STDIO processes cannot be detected reliably and must be stopped manually. It re-embeds memory, chunk, notebook, and any existing concept-graph embeddings, reports batch progress, verifies both databases, and exits. It is resumable: rerun the same command after an interruption. Do not run it against a live server.
+
 ## Performance & Scaling Benchmarks
 
 MARM is tuned for fast recall first, even as memory grows and long memories are chunked behind the scenes.
+
+These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database.
 
 ### 1. Retrieval Latency Scaling
 
 | Session Size ($N$) | Min Latency | Median Latency | p95 Latency |
 | :--- | :--- | :--- | :--- |
-| **N = 100** | 12.3 ms | 13.8 ms | 15.0 ms |
-| **N = 500** | 13.3 ms | 14.1 ms | 16.4 ms |
-| **N = 1,000** | 14.5 ms | 16.2 ms | 17.1 ms |
-| **N = 2,000** | 15.9 ms | 18.4 ms | 20.8 ms |
-| **N = 4,000** | 17.6 ms | 20.8 ms | 22.5 ms |
+| **N = 100** | 6.6 ms | 7.4 ms | 8.0 ms |
+| **N = 500** | 7.1 ms | 8.1 ms | 10.0 ms |
+| **N = 1,000** | 7.6 ms | 8.5 ms | 9.0 ms |
+| **N = 2,000** | 9.3 ms | 10.5 ms | 11.6 ms |
+| **N = 4,000** | 11.5 ms | 12.1 ms | 13.4 ms |
 
 ### 2. Encoder + Concurrency
 
-- **Cold model load:** `972ms`
-- **Warm encode:** median `10.3ms`, p95 `11.2ms`
-- **Concurrent recall:** 10 gathered recalls completed in `394.7ms` vs `436.6ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so this is stable under load rather than true parallel speedup.
+- **Cold model load:** `887ms`
+- **Warm encode:** median `4.0ms`, p95 `4.4ms`
+- **Concurrent recall:** 10 gathered recalls completed in `616.3ms` vs `440.7ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so gathering calls does not create parallel speedup.
 
 ### 3. Write-Time Ingestion Cost
 
-- **Consolidation off:** median `10.3ms`, p95 `11.6ms`
-- **Consolidation on:** median `42.0ms`, p95 `46.3ms`
-- **Tradeoff:** write-time dedupe/clustering adds `4.1x` median cost so recall stays fast and cleaner over time.
+- **Consolidation off:** median `6.8ms`, p95 `7.9ms`
+- **Consolidation on:** median `51.3ms`, p95 `93.7ms`
+- **Tradeoff:** write-time dedupe/clustering adds `7.6x` median cost so recall stays fast and cleaner over time.
 
 ### 4. Hybrid Search Scaling
 
 | Session Size ($N$) | Pure Semantic | Production Hybrid | FTS Filter -> Rerank | Speedup vs Pure |
 | :--- | :--- | :--- | :--- | :--- |
-| **N = 100** | 2.4 ms | 15.1 ms | 2.2 ms | 1.1x |
-| **N = 1,000** | 23.6 ms | 16.2 ms | 2.7 ms | 8.8x |
-| **N = 4,000** | 93.8 ms | 18.3 ms | 4.9 ms | 19.0x |
-| **N = 10,000** | 242.7 ms | 19.7 ms | 5.4 ms | 45.1x |
+| **N = 100** | 2.3 ms | 7.9 ms | 1.9 ms | 1.2x |
+| **N = 1,000** | 23.1 ms | 9.2 ms | 2.5 ms | 9.2x |
+| **N = 4,000** | 106.5 ms | 13.2 ms | 4.7 ms | 22.8x |
+| **N = 10,000** | 267.1 ms | 13.6 ms | 5.3 ms | 50.4x |
 
-Benchmarks used a throwaway real SQLite database and the live fastembed-backed `all-MiniLM-L6-v2` encoder on local hardware. Reproduce them: [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py)
+These Jina v2 Small benchmarks used a throwaway real SQLite database and the live configured encoder on local hardware. Reproduce them: [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py)
 
-### 5. vs Competitors: Architecture
+### 5. LoCoMo Retrieval Accuracy
+
+A fresh Jina v2 Small run ingested all 10 LoCoMo conversations through `marm_log_entry`, then scored top-5 `marm_smart_recall` results against 1,977 evidence-annotated questions. No answer-generation model or LLM judge was used.
+
+| Encoder | Any evidence hit | All evidence hit | Mean evidence recall |
+| :--- | :--- | :--- | :--- |
+| **MiniLM baseline** | 37.5% | 29.5% | not previously published |
+| **Jina v2 Small** | 53.0% | 43.4% | 47.6% |
+
+The Jina run improved both hit metrics in this benchmark. This comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce it with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+
+### 6. vs Competitors: Architecture
 
 MARM targets a specific niche: local-first memory for MCP-connected coding agents, not general personalization memory or a full agent runtime. Here's how it differs architecturally from established names in AI agent memory:
  
@@ -769,7 +792,7 @@ Everything above runs on a small number of deliberate mechanisms. This section i
 - **SQLite in WAL mode** at `~/.marm/marm_memory.db` with a connection pool (5 connections). WAL keeps readers unblocked during writes, which matters when several agents recall while one writes.
 - **FTS5 full-text index** (`memories_fts`) is maintained as an external-content table over the memories table and powers both the exact lane (BM25) and the filter stage of hybrid recall.
 - **Chunk storage**: memories past ~180 words are split into overlapping 150-token chunks (50-token overlap) in a `memory_chunks` table, each with its own embedding. Recall scores chunks and collapses to the parent memory.
-- **Embeddings** come from a fastembed-backed `all-MiniLM-L6-v2` encoder, lazily loaded on first semantic use and serialized behind a lock so concurrent encodes can't corrupt each other. If the encoder is unavailable, writes still succeed; memories are simply stored without embeddings until it loads. Semantic scoring runs as a single NumPy batch (matrix cosine) rather than a Python loop.
+- **Embeddings** come from the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder: 33M parameters, 512 dimensions, an 8,192-token context window, and an Apache-2.0 license. It does not require separate query/document text prefixes. The encoder is lazily loaded on first semantic use and serialized behind a lock so concurrent encodes can't corrupt each other. If it is unavailable, writes still succeed; memories are stored without embeddings until it loads. Semantic scoring runs as a single NumPy batch (matrix cosine) rather than a Python loop.
 - **The concept graph gets its own database** (`~/.marm/index/marm_index.db`) and its own pool, reusing the same pool implementation but never sharing connections with the memory store. Deliberate isolation: an experimental graph build must not be able to stall the production WAL.
 
 ### Write path

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.23.0
+      - SERVER_VERSION=2.24.0
       
       - SEMANTIC_MODEL=all-MiniLM-L6-v2
       

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       - SERVER_PORT=8001
       - SERVER_VERSION=2.24.0
       
-      - SEMANTIC_MODEL=all-MiniLM-L6-v2
-      
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO
     

--- a/marm-mcp-server/marm-docs/README.md
+++ b/marm-mcp-server/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.23.0
+# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.24.0
 
 ## Table of Contents
 
@@ -66,44 +66,67 @@ pip install marm-mcp-server
 | **Private high-throughput swarm** | `python -m marm_mcp_server --swarm-max` | `"agent" mcp add --transport http marm-memory http://localhost:8001/mcp` |
 | **Trusted private lab/server** | `python -m marm_mcp_server --trusted` | `"agent" mcp add --transport http marm-memory http://localhost:8001/mcp` |
 
+### Upgrade Existing Embeddings
+
+The Jina v2 Small default uses 512-dimensional embeddings; older `all-MiniLM-L6-v2` data is 384-dimensional and must be re-embedded after upgrading. Stop every MARM HTTP and STDIO process, then run:
+
+```bash
+marm-mcp-server --migrate-embeddings
+```
+
+The command refuses to continue when it detects a live HTTP server, but STDIO processes cannot be detected reliably and must be stopped manually. It re-embeds memory, chunk, notebook, and any existing concept-graph embeddings, reports batch progress, verifies both databases, and exits. It is resumable: rerun the same command after an interruption. Do not run it against a live server.
+
 ## Performance & Scaling Benchmarks
 
 MARM is tuned for fast recall first, even as memory grows and long memories are chunked behind the scenes.
+
+These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database.
 
 ### 1. Retrieval Latency Scaling
 
 | Session Size ($N$) | Min Latency | Median Latency | p95 Latency |
 | :--- | :--- | :--- | :--- |
-| **N = 100** | 12.3 ms | 13.8 ms | 15.0 ms |
-| **N = 500** | 13.3 ms | 14.1 ms | 16.4 ms |
-| **N = 1,000** | 14.5 ms | 16.2 ms | 17.1 ms |
-| **N = 2,000** | 15.9 ms | 18.4 ms | 20.8 ms |
-| **N = 4,000** | 17.6 ms | 20.8 ms | 22.5 ms |
+| **N = 100** | 6.6 ms | 7.4 ms | 8.0 ms |
+| **N = 500** | 7.1 ms | 8.1 ms | 10.0 ms |
+| **N = 1,000** | 7.6 ms | 8.5 ms | 9.0 ms |
+| **N = 2,000** | 9.3 ms | 10.5 ms | 11.6 ms |
+| **N = 4,000** | 11.5 ms | 12.1 ms | 13.4 ms |
 
 ### 2. Encoder + Concurrency
 
-- **Cold model load:** `972ms`
-- **Warm encode:** median `10.3ms`, p95 `11.2ms`
-- **Concurrent recall:** 10 gathered recalls completed in `394.7ms` vs `436.6ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so this is stable under load rather than true parallel speedup.
+- **Cold model load:** `887ms`
+- **Warm encode:** median `4.0ms`, p95 `4.4ms`
+- **Concurrent recall:** 10 gathered recalls completed in `616.3ms` vs `440.7ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so gathering calls does not create parallel speedup.
 
 ### 3. Write-Time Ingestion Cost
 
-- **Consolidation off:** median `10.3ms`, p95 `11.6ms`
-- **Consolidation on:** median `42.0ms`, p95 `46.3ms`
-- **Tradeoff:** write-time dedupe/clustering adds `4.1x` median cost so recall stays fast and cleaner over time.
+- **Consolidation off:** median `6.8ms`, p95 `7.9ms`
+- **Consolidation on:** median `51.3ms`, p95 `93.7ms`
+- **Tradeoff:** write-time dedupe/clustering adds `7.6x` median cost so recall stays fast and cleaner over time.
 
 ### 4. Hybrid Search Scaling
 
 | Session Size ($N$) | Pure Semantic | Production Hybrid | FTS Filter -> Rerank | Speedup vs Pure |
 | :--- | :--- | :--- | :--- | :--- |
-| **N = 100** | 2.4 ms | 15.1 ms | 2.2 ms | 1.1x |
-| **N = 1,000** | 23.6 ms | 16.2 ms | 2.7 ms | 8.8x |
-| **N = 4,000** | 93.8 ms | 18.3 ms | 4.9 ms | 19.0x |
-| **N = 10,000** | 242.7 ms | 19.7 ms | 5.4 ms | 45.1x |
+| **N = 100** | 2.3 ms | 7.9 ms | 1.9 ms | 1.2x |
+| **N = 1,000** | 23.1 ms | 9.2 ms | 2.5 ms | 9.2x |
+| **N = 4,000** | 106.5 ms | 13.2 ms | 4.7 ms | 22.8x |
+| **N = 10,000** | 267.1 ms | 13.6 ms | 5.3 ms | 50.4x |
 
-Benchmarks used a throwaway real SQLite database and the live fastembed-backed `all-MiniLM-L6-v2` encoder on local hardware. Reproduce them: [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py)
+These Jina v2 Small benchmarks used a throwaway real SQLite database and the live configured encoder on local hardware. Reproduce them: [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py)
 
-### 5. vs Competitors: Architecture
+### 5. LoCoMo Retrieval Accuracy
+
+A fresh Jina v2 Small run ingested all 10 LoCoMo conversations through `marm_log_entry`, then scored top-5 `marm_smart_recall` results against 1,977 evidence-annotated questions. No answer-generation model or LLM judge was used.
+
+| Encoder | Any evidence hit | All evidence hit | Mean evidence recall |
+| :--- | :--- | :--- | :--- |
+| **MiniLM baseline** | 37.5% | 29.5% | not previously published |
+| **Jina v2 Small** | 53.0% | 43.4% | 47.6% |
+
+The Jina run improved both hit metrics in this benchmark. This comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce it with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+
+### 6. vs Competitors: Architecture
 
 MARM targets a specific niche: local-first memory for MCP-connected coding agents, not general personalization memory or a full agent runtime. Here's how it differs architecturally from established names in AI agent memory:
  
@@ -729,7 +752,7 @@ Everything above runs on a small number of deliberate mechanisms. This section i
 - **SQLite in WAL mode** at `~/.marm/marm_memory.db` with a connection pool (5 connections). WAL keeps readers unblocked during writes, which matters when several agents recall while one writes.
 - **FTS5 full-text index** (`memories_fts`) is maintained as an external-content table over the memories table and powers both the exact lane (BM25) and the filter stage of hybrid recall.
 - **Chunk storage**: memories past ~180 words are split into overlapping 150-token chunks (50-token overlap) in a `memory_chunks` table, each with its own embedding. Recall scores chunks and collapses to the parent memory.
-- **Embeddings** come from a fastembed-backed `all-MiniLM-L6-v2` encoder, lazily loaded on first semantic use and serialized behind a lock so concurrent encodes can't corrupt each other. If the encoder is unavailable, writes still succeed; memories are simply stored without embeddings until it loads. Semantic scoring runs as a single NumPy batch (matrix cosine) rather than a Python loop.
+- **Embeddings** come from the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder: 33M parameters, 512 dimensions, an 8,192-token context window, and an Apache-2.0 license. It does not require separate query/document text prefixes. The encoder is lazily loaded on first semantic use and serialized behind a lock so concurrent encodes can't corrupt each other. If it is unavailable, writes still succeed; memories are stored without embeddings until it loads. Semantic scoring runs as a single NumPy batch (matrix cosine) rather than a Python loop.
 - **The concept graph gets its own database** (`~/.marm/index/marm_index.db`) and its own pool, reusing the same pool implementation but never sharing connections with the memory store. Deliberate isolation: an experimental graph build must not be able to stall the production WAL.
 
 ### Write path

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,10 +14,10 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.23.0
+Version: 2.24.0
 """
 
-__version__ = "2.23.0"
+__version__ = "2.24.0"
 __author__ = "Ryan Lyell"
 __email__ = "lyell@marmsystems.com"
 
@@ -26,8 +26,12 @@ __all__ = ["__version__", "create_server", "main"]
 
 def __getattr__(name):
     """Lazy-load HTTP server exports without side effects during STDIO imports."""
-    if name in {"create_server", "main"}:
-        from .server import create_server, main
+    if name == "create_server":
+        from .server import create_server
 
-        return {"create_server": create_server, "main": main}[name]
+        return create_server
+    if name == "main":
+        from .cli import main
+
+        return main
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/marm-mcp-server/marm_mcp_server/__main__.py
+++ b/marm-mcp-server/marm_mcp_server/__main__.py
@@ -1,4 +1,4 @@
-from .server import main
+from .cli import main
 
 if __name__ == "__main__":
     main()

--- a/marm-mcp-server/marm_mcp_server/cli.py
+++ b/marm-mcp-server/marm_mcp_server/cli.py
@@ -3,6 +3,9 @@
 import asyncio
 import os
 import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
 from typing import Optional
 
 import structlog
@@ -17,7 +20,6 @@ from .config.settings import (
     SERVER_PORT,
     SERVER_VERSION,
 )
-from .core import memory as memory_module
 from .core.rate_limiter import rate_limiter
 from .utils.dependency_check import check_dependencies
 from .utils.security import generate_api_key
@@ -81,6 +83,8 @@ def apply_runtime_preset(
     rate_limit_rpm: Optional[int] = None,
 ) -> dict:
     """Apply CLI rate-limit/write-queue presets to already-imported runtime modules."""
+    from .core import memory as memory_module
+
     if rate_limit_rpm is not None and rate_limit_rpm < 0:
         raise ValueError("--rate-limit-rpm must be 0 or greater")
 
@@ -160,6 +164,11 @@ def main():
         type=int,
         help="Override HTTP rate limit RPM; 0 disables rate limiting",
     )
+    parser.add_argument(
+        "--migrate-embeddings",
+        action="store_true",
+        help="Migrate existing embeddings to the current model and exit",
+    )
     args = parser.parse_args()
 
     if args.generate_key:
@@ -172,6 +181,34 @@ def main():
     if args.check_deps:
         success = check_dependencies()
         sys.exit(0 if success else 1)
+
+    if args.migrate_embeddings:
+        print("Stop every MARM HTTP and STDIO process before migrating embeddings.")
+        print(
+            "STDIO processes cannot be detected reliably and must be stopped manually."
+        )
+        if _http_server_is_running():
+            print(
+                "Migration refused: a MARM HTTP server is still running.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not Path(DEFAULT_DB_PATH).exists():
+            print("No MARM memory database exists; nothing needs migration.")
+            sys.exit(0)
+
+        from .utils.embedding_migration import migrate_embeddings
+
+        try:
+            result = migrate_embeddings(DEFAULT_DB_PATH)
+        except Exception as exc:
+            print(f"Embedding migration failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(
+            "Embedding migration complete: "
+            f"{result['rows_migrated']} vector(s) updated."
+        )
+        sys.exit(0)
 
     try:
         runtime_config = apply_runtime_preset(
@@ -221,3 +258,20 @@ def main():
     except Exception as e:
         logger.error("Server error", error=str(e))
         sys.exit(1)
+
+
+def _http_server_is_running() -> bool:
+    """Best-effort guard against direct migration beside a live HTTP server."""
+    probe_host = SERVER_HOST
+    if probe_host in {"0.0.0.0", "::", "[::]"}:
+        probe_host = "127.0.0.1"
+    request = urllib.request.Request(
+        f"http://{probe_host}:{SERVER_PORT}/health", method="GET"
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=0.75):
+            return True
+    except urllib.error.HTTPError:
+        return True
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -111,7 +111,8 @@ def get_analytics_db_path():
 
 ANALYTICS_DB_PATH = get_analytics_db_path()
 
-DEFAULT_SEMANTIC_MODEL = "all-MiniLM-L6-v2"
+DEFAULT_SEMANTIC_MODEL = "jinaai/jina-embeddings-v2-small-en"
+DEFAULT_SEMANTIC_DIM = 512
 
 SERVER_HOST = os.environ.get("SERVER_HOST", "127.0.0.1")
 _raw_port = _safe_int("SERVER_PORT", 8001)
@@ -121,7 +122,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.23.0"
+SERVER_VERSION = "2.24.0"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 

--- a/marm-mcp-server/marm_mcp_server/core/concept_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/concept_db.py
@@ -16,6 +16,7 @@ from typing import Optional
 import numpy as np
 
 from .memory_db import ConnectionContext, SQLiteConnectionPool
+from .memory_utils import _safe_print
 
 MAX_CONCEPT_DB_CONNECTIONS = 3
 
@@ -292,15 +293,24 @@ class ConceptDB:
 
         vectors = []
         kept_rows = []
+        dim_skipped = 0
         for entity_id, name, emb_bytes in rows:
             try:
                 vector = np.frombuffer(emb_bytes, dtype=np.float32)
             except Exception:
                 continue
             if vector.shape[0] != query_vec.shape[0]:
+                dim_skipped += 1
                 continue
             vectors.append(vector)
             kept_rows.append((entity_id, name))
+
+        if dim_skipped:
+            _safe_print(
+                "Concept similarity skipped "
+                f"{dim_skipped} incompatible embedding vector(s); "
+                "run marm-mcp-server --migrate-embeddings"
+            )
 
         if not vectors:
             return []

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -60,7 +60,12 @@ class _FastEmbedEncoder:
     def __init__(self, model_name: str):
         from fastembed import TextEmbedding
 
-        self._model = TextEmbedding(model_name=f"sentence-transformers/{model_name}")
+        resolved_name = (
+            f"sentence-transformers/{model_name}"
+            if model_name == "all-MiniLM-L6-v2"
+            else model_name
+        )
+        self._model = TextEmbedding(model_name=resolved_name)
 
     def encode(self, text):
         if isinstance(text, str):

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - marm-memory
-Version: 2.23.0
+Version: 2.24.0
 """
 
 import asyncio
@@ -40,8 +40,8 @@ from .middleware.rate_limiting import rate_limit_middleware
 from .services.analytics import track_usage
 from .services.automation import register_event_handlers
 from .utils import logging_filters  # noqa: F401
+from .utils.embedding_state import check_embedding_compatibility
 from .utils.multiprocess_guard import _warn_if_multi_process_requested
-
 
 logger = structlog.get_logger()
 
@@ -58,6 +58,7 @@ async def lifespan(app: FastAPI):
     logger.info(
         "Database locations", memory_db=DEFAULT_DB_PATH, analytics_db=ANALYTICS_DB_PATH
     )
+    check_embedding_compatibility(warn=lambda message: logger.warning(message))
 
     register_event_handlers()
     await memory.start_write_queue()
@@ -138,12 +139,8 @@ mcp = FastApiMCP(app, include_operations=MCP_TOOL_OPERATIONS)
 mcp.mount_http()
 
 
-# Re-export so the pip console script (marm_mcp_server.server:main, see
-# pyproject.toml), the mcp.servers entry point (server:create_server), and
-# marm_mcp_server/__init__.py's lazy `from .server import create_server, main`
-# all keep resolving after these moved to cli.py. Import placed here, after
-# app is fully defined, so cli.py's `from .server import app` doesn't hit a
-# partially-initialized module.
+# Preserve direct imports from server.py while the installed CLI resolves
+# through cli.py and the MCP server entry point continues to use create_server.
 from .cli import create_server, main  # noqa: E402,F401
 
 if __name__ == "__main__":

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -26,6 +26,7 @@ from anyio import BrokenResourceError, ClosedResourceError, EndOfStream  # noqa:
 os.environ["SERVER_HOST"] = "127.0.0.1"
 
 from .core.stdio_logging import _stdio_log  # noqa: E402
+from .utils.embedding_state import check_embedding_compatibility  # noqa: E402
 
 from .core.stdio_tool_lifecycle import _log_tool_call  # noqa: E402
 
@@ -340,6 +341,9 @@ def main() -> None:
         SERVER_VERSION,
         DEFAULT_DB_PATH,
         SEMANTIC_SEARCH_AVAILABLE,
+    )
+    check_embedding_compatibility(
+        warn=lambda message: _stdio_log.warning("%s", message)
     )
     memory.restore_active_session()
     try:

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
@@ -79,23 +79,28 @@ def _migrate_database(
                     conn.execute("ALTER TABLE entities ADD COLUMN name_embedding BLOB")
                 else:
                     continue
-            where_clause = f"{embedding_column} IS NOT NULL"
+            where_clause = f"{text_column} IS NOT NULL"
             params: tuple[int, ...] = ()
             if not force_reencode:
-                where_clause += f" AND LENGTH({embedding_column}) != ?"
+                where_clause += (
+                    f" AND ({embedding_column} IS NULL "
+                    f"OR LENGTH({embedding_column}) != ?)"
+                )
                 params = (target_bytes,)
             total = conn.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE {where_clause}", params
             ).fetchone()[0]
             completed = 0
+            last_rowid = 0
             while completed < total:
                 rows = conn.execute(
                     f"SELECT rowid, {text_column} FROM {table} "
-                    f"WHERE {where_clause} ORDER BY rowid LIMIT ?",
-                    (*params, batch_size),
+                    f"WHERE {where_clause} AND rowid > ? ORDER BY rowid LIMIT ?",
+                    (*params, last_rowid, batch_size),
                 ).fetchall()
                 if not rows:
                     break
+                last_rowid = rows[-1][0]
                 vectors = _encode_batch(encoder, [row[1] for row in rows])
                 try:
                     conn.execute("BEGIN IMMEDIATE")

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
@@ -1,0 +1,157 @@
+"""Resumable, stopped-server migration for persisted embedding vectors."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Callable
+
+from ..config.settings import DEFAULT_SEMANTIC_DIM, DEFAULT_SEMANTIC_MODEL
+from ..core.memory_utils import _embedding_to_bytes
+from .embedding_state import (
+    get_default_concept_db_path,
+    inspect_embedding_state,
+    write_embedding_model_marker,
+)
+
+_MEMORY_TABLES = (
+    ("memories", "content", "embedding"),
+    ("memory_chunks", "chunk_text", "embedding"),
+    ("notebook_entries", "data", "embedding"),
+)
+_CONCEPT_TABLES = (("entities", "name", "name_embedding"),)
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)
+        ).fetchone()
+        is not None
+    )
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    return any(row[1] == column for row in conn.execute(f"PRAGMA table_info({table})"))
+
+
+def _load_encoder():
+    from fastembed import TextEmbedding
+
+    return TextEmbedding(model_name=DEFAULT_SEMANTIC_MODEL)
+
+
+def _encode_batch(encoder, texts: list[str]) -> list:
+    vectors = list(encoder.embed(texts))
+    if len(vectors) != len(texts):
+        raise RuntimeError(
+            f"Encoder returned {len(vectors)} vectors for {len(texts)} texts"
+        )
+    for vector in vectors:
+        if getattr(vector, "shape", (len(vector),))[0] != DEFAULT_SEMANTIC_DIM:
+            raise RuntimeError(
+                "Configured embedding dimension does not match model output: "
+                f"expected {DEFAULT_SEMANTIC_DIM}"
+            )
+    return vectors
+
+
+def _migrate_database(
+    path: Path,
+    tables: tuple[tuple[str, str, str], ...],
+    encoder,
+    batch_size: int,
+    progress: Callable[[str], None],
+) -> int:
+    migrated = 0
+    target_bytes = DEFAULT_SEMANTIC_DIM * 4
+    conn = sqlite3.connect(
+        f"{path.resolve().as_uri()}?mode=rw", uri=True, isolation_level=None
+    )
+    with closing(conn):
+        for table, text_column, embedding_column in tables:
+            if not _table_exists(conn, table):
+                continue
+            if not _column_exists(conn, table, embedding_column):
+                if table == "entities" and embedding_column == "name_embedding":
+                    conn.execute("ALTER TABLE entities ADD COLUMN name_embedding BLOB")
+                else:
+                    continue
+            total = conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE {embedding_column} IS NOT NULL "
+                f"AND LENGTH({embedding_column}) != ?",
+                (target_bytes,),
+            ).fetchone()[0]
+            completed = 0
+            while completed < total:
+                rows = conn.execute(
+                    f"SELECT rowid, {text_column} FROM {table} "
+                    f"WHERE {embedding_column} IS NOT NULL "
+                    f"AND LENGTH({embedding_column}) != ? ORDER BY rowid LIMIT ?",
+                    (target_bytes, batch_size),
+                ).fetchall()
+                if not rows:
+                    break
+                vectors = _encode_batch(encoder, [row[1] for row in rows])
+                try:
+                    conn.execute("BEGIN IMMEDIATE")
+                    conn.executemany(
+                        f"UPDATE {table} SET {embedding_column} = ? WHERE rowid = ?",
+                        [
+                            (_embedding_to_bytes(vector), row[0])
+                            for row, vector in zip(rows, vectors)
+                        ],
+                    )
+                    conn.execute("COMMIT")
+                except Exception:
+                    if conn.in_transaction:
+                        conn.execute("ROLLBACK")
+                    raise
+                completed += len(rows)
+                migrated += len(rows)
+                progress(f"{table}: {completed}/{total}")
+    return migrated
+
+
+def migrate_embeddings(
+    memory_db_path: str,
+    concept_db_path: str | None = None,
+    *,
+    batch_size: int = 100,
+    encoder_factory: Callable[[], object] | None = None,
+    progress: Callable[[str], None] = print,
+) -> dict:
+    """Migrate incompatible vectors and mark success only after both DBs verify."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be greater than zero")
+
+    memory_path = Path(memory_db_path)
+    concept_path = Path(concept_db_path or get_default_concept_db_path())
+    if not memory_path.exists():
+        return {"rows_migrated": 0, "concept_db_present": concept_path.exists()}
+
+    encoder = (encoder_factory or _load_encoder)()
+    _encode_batch(encoder, ["MARM embedding migration dimension check"])
+
+    rows_migrated = _migrate_database(
+        memory_path, _MEMORY_TABLES, encoder, batch_size, progress
+    )
+    if concept_path.exists():
+        rows_migrated += _migrate_database(
+            concept_path, _CONCEPT_TABLES, encoder, batch_size, progress
+        )
+
+    state = inspect_embedding_state(str(memory_path), str(concept_path))
+    if not state.compatible:
+        detail = (
+            "; ".join(state.errors)
+            if state.errors
+            else (f"{state.incompatible} incompatible vector(s) remain")
+        )
+        raise RuntimeError(f"Verification failed: {detail}")
+    write_embedding_model_marker(str(memory_path))
+    return {
+        "rows_migrated": rows_migrated,
+        "concept_db_present": concept_path.exists(),
+    }

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
@@ -63,6 +63,7 @@ def _migrate_database(
     encoder,
     batch_size: int,
     progress: Callable[[str], None],
+    force_reencode: bool = False,
 ) -> int:
     migrated = 0
     target_bytes = DEFAULT_SEMANTIC_DIM * 4
@@ -78,18 +79,20 @@ def _migrate_database(
                     conn.execute("ALTER TABLE entities ADD COLUMN name_embedding BLOB")
                 else:
                     continue
+            where_clause = f"{embedding_column} IS NOT NULL"
+            params: tuple[int, ...] = ()
+            if not force_reencode:
+                where_clause += f" AND LENGTH({embedding_column}) != ?"
+                params = (target_bytes,)
             total = conn.execute(
-                f"SELECT COUNT(*) FROM {table} WHERE {embedding_column} IS NOT NULL "
-                f"AND LENGTH({embedding_column}) != ?",
-                (target_bytes,),
+                f"SELECT COUNT(*) FROM {table} WHERE {where_clause}", params
             ).fetchone()[0]
             completed = 0
             while completed < total:
                 rows = conn.execute(
                     f"SELECT rowid, {text_column} FROM {table} "
-                    f"WHERE {embedding_column} IS NOT NULL "
-                    f"AND LENGTH({embedding_column}) != ? ORDER BY rowid LIMIT ?",
-                    (target_bytes, batch_size),
+                    f"WHERE {where_clause} ORDER BY rowid LIMIT ?",
+                    (*params, batch_size),
                 ).fetchall()
                 if not rows:
                     break
@@ -131,19 +134,31 @@ def migrate_embeddings(
     if not memory_path.exists():
         return {"rows_migrated": 0, "concept_db_present": concept_path.exists()}
 
+    initial_state = inspect_embedding_state(str(memory_path), str(concept_path))
+    force_reencode = (
+        initial_state.marker != DEFAULT_SEMANTIC_MODEL
+        and initial_state.has_vectors
+        and initial_state.incompatible == 0
+    )
     encoder = (encoder_factory or _load_encoder)()
     _encode_batch(encoder, ["MARM embedding migration dimension check"])
 
+    migration_args = (force_reencode,) if force_reencode else ()
     rows_migrated = _migrate_database(
-        memory_path, _MEMORY_TABLES, encoder, batch_size, progress
+        memory_path, _MEMORY_TABLES, encoder, batch_size, progress, *migration_args
     )
     if concept_path.exists():
         rows_migrated += _migrate_database(
-            concept_path, _CONCEPT_TABLES, encoder, batch_size, progress
+            concept_path,
+            _CONCEPT_TABLES,
+            encoder,
+            batch_size,
+            progress,
+            *migration_args,
         )
 
     state = inspect_embedding_state(str(memory_path), str(concept_path))
-    if not state.compatible:
+    if state.incompatible or state.errors:
         detail = (
             "; ".join(state.errors)
             if state.errors
@@ -151,6 +166,10 @@ def migrate_embeddings(
         )
         raise RuntimeError(f"Verification failed: {detail}")
     write_embedding_model_marker(str(memory_path))
+    if not inspect_embedding_state(str(memory_path), str(concept_path)).compatible:
+        raise RuntimeError(
+            "Verification failed: embedding model marker was not recorded"
+        )
     return {
         "rows_migrated": rows_migrated,
         "concept_db_present": concept_path.exists(),

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
@@ -1,0 +1,192 @@
+"""Inspect persisted embedding compatibility without initializing runtime stores."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+from ..config.settings import (
+    DEFAULT_DB_PATH,
+    DEFAULT_SEMANTIC_DIM,
+    DEFAULT_SEMANTIC_MODEL,
+)
+
+EMBEDDING_MODEL_SETTING = "embedding_model"
+_MEMORY_TABLES = (
+    ("memories", "embedding"),
+    ("memory_chunks", "embedding"),
+    ("notebook_entries", "embedding"),
+)
+_CONCEPT_TABLES = (("entities", "name_embedding"),)
+
+
+@dataclass(frozen=True)
+class EmbeddingTableState:
+    database: str
+    table: str
+    total: int
+    incompatible: int
+
+
+@dataclass(frozen=True)
+class EmbeddingState:
+    marker: str | None
+    tables: tuple[EmbeddingTableState, ...]
+    errors: tuple[str, ...] = ()
+
+    @property
+    def incompatible(self) -> int:
+        return sum(table.incompatible for table in self.tables)
+
+    @property
+    def compatible(self) -> bool:
+        return self.incompatible == 0 and not self.errors
+
+
+def get_default_concept_db_path() -> str:
+    """Resolve the concept DB path without creating its parent or database."""
+    configured = os.environ.get("MARM_CONCEPT_DB_PATH")
+    if configured:
+        return configured
+    return str(Path.home() / ".marm" / "index" / "marm_index.db")
+
+
+def _open_read_only(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+
+
+def _open_existing_writable(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"{path.resolve().as_uri()}?mode=rw", uri=True)
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)
+        ).fetchone()
+        is not None
+    )
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    return any(row[1] == column for row in conn.execute(f"PRAGMA table_info({table})"))
+
+
+def _inspect_tables(
+    path: Path, database: str, tables: Iterable[tuple[str, str]]
+) -> list[EmbeddingTableState]:
+    if not path.exists():
+        return []
+
+    states = []
+    with closing(_open_read_only(path)) as conn:
+        for table, column in tables:
+            if not _table_exists(conn, table) or not _column_exists(
+                conn, table, column
+            ):
+                continue
+            total, incompatible = conn.execute(
+                f"SELECT COUNT(*), COALESCE(SUM(LENGTH({column}) != ?), 0) "
+                f"FROM {table} WHERE {column} IS NOT NULL",
+                (DEFAULT_SEMANTIC_DIM * 4,),
+            ).fetchone()
+            states.append(
+                EmbeddingTableState(
+                    database=database,
+                    table=table,
+                    total=int(total),
+                    incompatible=int(incompatible),
+                )
+            )
+    return states
+
+
+def inspect_embedding_state(
+    memory_db_path: str = DEFAULT_DB_PATH,
+    concept_db_path: str | None = None,
+) -> EmbeddingState:
+    """Return persisted vector dimensions without creating either database."""
+    memory_path = Path(memory_db_path)
+    concept_path = Path(concept_db_path or get_default_concept_db_path())
+    tables = []
+    errors = []
+    try:
+        tables.extend(_inspect_tables(memory_path, "memory", _MEMORY_TABLES))
+    except (OSError, sqlite3.Error) as exc:
+        errors.append(f"memory database inspection failed: {exc}")
+    try:
+        tables.extend(_inspect_tables(concept_path, "concept", _CONCEPT_TABLES))
+    except (OSError, sqlite3.Error) as exc:
+        errors.append(f"concept database inspection failed: {exc}")
+
+    marker = None
+    if memory_path.exists():
+        try:
+            with closing(_open_read_only(memory_path)) as conn:
+                if _table_exists(conn, "user_settings"):
+                    row = conn.execute(
+                        "SELECT value FROM user_settings WHERE key = ?",
+                        (EMBEDDING_MODEL_SETTING,),
+                    ).fetchone()
+                    marker = row[0] if row else None
+        except (OSError, sqlite3.Error) as exc:
+            message = f"memory model marker inspection failed: {exc}"
+            if message not in errors:
+                errors.append(message)
+    return EmbeddingState(marker=marker, tables=tuple(tables), errors=tuple(errors))
+
+
+def write_embedding_model_marker(memory_db_path: str = DEFAULT_DB_PATH) -> None:
+    """Persist the current model marker in an already-existing memory database."""
+    memory_path = Path(memory_db_path)
+    if not memory_path.exists():
+        return
+    with closing(_open_existing_writable(memory_path)) as conn:
+        with conn:
+            if not _table_exists(conn, "user_settings"):
+                return
+            conn.execute(
+                "INSERT INTO user_settings (key, value, updated_at) VALUES (?, ?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+                "updated_at = excluded.updated_at",
+                (
+                    EMBEDDING_MODEL_SETTING,
+                    DEFAULT_SEMANTIC_MODEL,
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+
+
+def check_embedding_compatibility(
+    *,
+    memory_db_path: str = DEFAULT_DB_PATH,
+    concept_db_path: str | None = None,
+    warn: Callable[[str], None] | None = None,
+) -> EmbeddingState:
+    """Inspect dimensions, repair a valid marker, or emit one migration warning."""
+    state = inspect_embedding_state(memory_db_path, concept_db_path)
+    if state.compatible:
+        if state.marker != DEFAULT_SEMANTIC_MODEL:
+            write_embedding_model_marker(memory_db_path)
+        return state
+
+    if warn is not None:
+        if state.errors:
+            warn(
+                "Embedding compatibility inspection was incomplete ("
+                + "; ".join(state.errors)
+                + "); core memory remains available, but inspect the database before "
+                "running marm-mcp-server --migrate-embeddings"
+            )
+        else:
+            warn(
+                f"Found {state.incompatible} embedding vector(s) incompatible with "
+                f"{DEFAULT_SEMANTIC_MODEL}; stop MARM and run "
+                "marm-mcp-server --migrate-embeddings"
+            )
+    return state

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
@@ -44,8 +44,18 @@ class EmbeddingState:
         return sum(table.incompatible for table in self.tables)
 
     @property
+    def has_vectors(self) -> bool:
+        return any(table.total for table in self.tables)
+
+    @property
+    def marker_incompatible(self) -> bool:
+        return self.has_vectors and self.marker != DEFAULT_SEMANTIC_MODEL
+
+    @property
     def compatible(self) -> bool:
-        return self.incompatible == 0 and not self.errors
+        return (
+            self.incompatible == 0 and not self.marker_incompatible and not self.errors
+        )
 
 
 def get_default_concept_db_path() -> str:
@@ -168,10 +178,10 @@ def check_embedding_compatibility(
     concept_db_path: str | None = None,
     warn: Callable[[str], None] | None = None,
 ) -> EmbeddingState:
-    """Inspect dimensions, repair a valid marker, or emit one migration warning."""
+    """Inspect vector/model compatibility or emit one migration warning."""
     state = inspect_embedding_state(memory_db_path, concept_db_path)
     if state.compatible:
-        if state.marker != DEFAULT_SEMANTIC_MODEL:
+        if not state.has_vectors and state.marker != DEFAULT_SEMANTIC_MODEL:
             write_embedding_model_marker(memory_db_path)
         return state
 
@@ -182,6 +192,12 @@ def check_embedding_compatibility(
                 + "; ".join(state.errors)
                 + "); core memory remains available, but inspect the database before "
                 "running marm-mcp-server --migrate-embeddings"
+            )
+        elif state.marker_incompatible:
+            prior_model = state.marker or "an unmarked prior model"
+            warn(
+                f"Found embeddings written by {prior_model}; stop MARM and run "
+                "marm-mcp-server --migrate-embeddings"
             )
         else:
             warn(

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
     "flake8>=5.0.0",
     "mypy>=1.0.0",
     "ruff>=0.4.0",
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [tool.setuptools.packages.find]

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.23.0"
+version = "2.24.0"
 description = "marm-memory is a local-first MCP memory layer with hybrid recall, agent coordination, code intelligence, and persistent project context."
 readme = "README.md"
 license = "Apache-2.0"
@@ -53,7 +53,7 @@ Repository = "https://github.com/Lyellr88/marm-memory"
 "Docker Hub" = "https://hub.docker.com/r/lyellr88/marm-mcp-server"
 
 [project.scripts]
-marm-mcp-server = "marm_mcp_server.server:main"
+marm-mcp-server = "marm_mcp_server.cli:main"
 marm-mcp-stdio = "marm_mcp_server.server_stdio:main"
 
 [project.optional-dependencies]

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.23.0",
+      "identifier": "lyellr88/marm-mcp-server:2.24.0",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_chunking.py
+++ b/marm-mcp-server/tests/test_chunking.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import numpy as np
 import pytest
 
+from marm_mcp_server.config.settings import DEFAULT_SEMANTIC_DIM
 from marm_mcp_server.core.memory import (
     MARMMemory,
     _chunk_text,
@@ -15,7 +16,6 @@ from marm_mcp_server.core.memory import (
     CHUNK_TOKEN_LIMIT,
     CHUNK_OVERLAP_TOKENS,
 )
-
 
 # --- _chunk_text unit tests ---
 
@@ -65,7 +65,7 @@ def test_chunk_text_covers_all_words():
 # --- _score_chunk_aware unit tests ---
 
 
-def _make_unit_vec(dim: int = 384) -> np.ndarray:
+def _make_unit_vec(dim: int = DEFAULT_SEMANTIC_DIM) -> np.ndarray:
     v = np.ones(dim, dtype=np.float32)
     return v / np.linalg.norm(v)
 
@@ -96,7 +96,7 @@ def test_score_chunk_aware_uses_parent_embedding_when_no_chunks():
 def test_score_chunk_aware_uses_chunk_embeddings_over_parent():
     unit_vec = _make_unit_vec()
     # Parent embedding is zero (would score 0), chunk embedding is unit (scores 1.0)
-    zero_bytes = np.zeros(384, dtype=np.float32).tobytes()
+    zero_bytes = np.zeros(DEFAULT_SEMANTIC_DIM, dtype=np.float32).tobytes()
     mem_id = str(uuid.uuid4())
     row = _make_sqlite_row(mem_id, zero_bytes)
     chunks_by_id = {mem_id: [unit_vec.tobytes()]}
@@ -108,7 +108,7 @@ def test_score_chunk_aware_uses_chunk_embeddings_over_parent():
 def test_score_chunk_aware_takes_max_over_chunks():
     query = _make_unit_vec()
     # One chunk aligned with query (score ~1.0), one orthogonal (score ~0)
-    ortho = np.zeros(384, dtype=np.float32)
+    ortho = np.zeros(DEFAULT_SEMANTIC_DIM, dtype=np.float32)
     ortho[0] = 1.0
     mem_id = str(uuid.uuid4())
     row = _make_sqlite_row(mem_id, None)

--- a/marm-mcp-server/tests/test_cli_entrypoint.py
+++ b/marm-mcp-server/tests/test_cli_entrypoint.py
@@ -5,7 +5,11 @@ import subprocess
 import sys
 import time
 import importlib
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 import requests
 import pytest

--- a/marm-mcp-server/tests/test_cli_entrypoint.py
+++ b/marm-mcp-server/tests/test_cli_entrypoint.py
@@ -5,8 +5,10 @@ import subprocess
 import sys
 import time
 import importlib
+import tomllib
 
 import requests
+import pytest
 
 
 def test_generate_key_cli_prints_one_key_and_exits_without_starting_server(tmp_path):
@@ -57,6 +59,75 @@ def test_check_deps_cli_reports_dependency_status_without_starting_server(tmp_pa
     assert "MARM MCP Server - Dependency Check" in result.stdout
     assert "All dependencies satisfied!" in result.stdout
     assert "Uvicorn running" not in result.stdout
+
+
+def test_migration_entrypoints_are_side_effect_light_when_database_is_absent(tmp_path):
+    env = os.environ.copy()
+    memory_path = tmp_path / "missing-memory.db"
+    concept_path = tmp_path / "missing-concept.db"
+    env["MARM_DB_PATH"] = str(memory_path)
+    env["MARM_CONCEPT_DB_PATH"] = str(concept_path)
+    env["MARM_ANALYTICS_DB_PATH"] = str(tmp_path / "analytics.db")
+    env["USERPROFILE"] = str(tmp_path)
+    env["HOME"] = str(tmp_path)
+
+    module_result = subprocess.run(
+        [sys.executable, "-m", "marm_mcp_server", "--migrate-embeddings"],
+        cwd=os.getcwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert module_result.returncode == 0, module_result.stderr
+    assert "nothing needs migration" in module_result.stdout
+    assert not memory_path.exists()
+    assert not concept_path.exists()
+
+    command = (
+        "import sys\n"
+        "from marm_mcp_server.cli import main\n"
+        "sys.argv = ['marm-mcp-server', '--migrate-embeddings']\n"
+        "try:\n"
+        "    main()\n"
+        "except SystemExit as exc:\n"
+        "    assert 'marm_mcp_server.server' not in sys.modules\n"
+        "    raise\n"
+    )
+    cli_result = subprocess.run(
+        [sys.executable, "-c", command],
+        cwd=os.getcwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert cli_result.returncode == 0, cli_result.stderr
+    assert not memory_path.exists()
+    assert not concept_path.exists()
+
+    with open("pyproject.toml", "rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+    assert pyproject["project"]["scripts"]["marm-mcp-server"] == (
+        "marm_mcp_server.cli:main"
+    )
+
+
+def test_migration_cli_refuses_live_http_server(monkeypatch, tmp_path, capsys):
+    cli = importlib.import_module("marm_mcp_server.cli")
+    memory_path = tmp_path / "memory.db"
+    memory_path.touch()
+    monkeypatch.setattr(cli, "DEFAULT_DB_PATH", str(memory_path))
+    monkeypatch.setattr(cli, "_http_server_is_running", lambda: True)
+    monkeypatch.setattr(sys, "argv", ["marm-mcp-server", "--migrate-embeddings"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "STDIO processes cannot be detected reliably" in captured.out + captured.err
+    assert "still running" in captured.err
 
 
 def test_import_marm_mcp_server_succeeds_with_clean_stdout(tmp_path):

--- a/marm-mcp-server/tests/test_embedding_migration.py
+++ b/marm-mcp-server/tests/test_embedding_migration.py
@@ -1,0 +1,244 @@
+import sqlite3
+
+import numpy as np
+import pytest
+
+from marm_mcp_server.config.settings import (
+    DEFAULT_SEMANTIC_DIM,
+    DEFAULT_SEMANTIC_MODEL,
+)
+from marm_mcp_server.core.concept_db import init_concept_database
+from marm_mcp_server.core.memory_db import init_database
+from marm_mcp_server.utils import embedding_migration
+from marm_mcp_server.utils.embedding_migration import migrate_embeddings
+from marm_mcp_server.utils.embedding_state import inspect_embedding_state
+
+
+def _vector(dim: int) -> bytes:
+    return np.ones(dim, dtype=np.float32).tobytes()
+
+
+class FakeEncoder:
+    def __init__(self, *, fail_on: str | None = None, dim: int = DEFAULT_SEMANTIC_DIM):
+        self.fail_on = fail_on
+        self.dim = dim
+        self.calls = []
+
+    def embed(self, texts):
+        texts = list(texts)
+        self.calls.append(texts)
+        if self.fail_on and any(self.fail_on in text for text in texts):
+            raise RuntimeError("injected encoder failure")
+        return iter(
+            np.full(self.dim, index + 1, dtype=np.float32)
+            for index, _ in enumerate(texts)
+        )
+
+
+def _seed_databases(memory_path, concept_path):
+    init_database(str(memory_path))
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO memories (id, session_name, content, embedding, timestamp) "
+            "VALUES ('m1', 's1', 'memory text', ?, '2026-01-01T00:00:00Z')",
+            (_vector(384),),
+        )
+        conn.execute(
+            "INSERT INTO memory_chunks (memory_id, chunk_index, chunk_text, embedding) "
+            "VALUES ('m1', 0, 'chunk text', ?)",
+            (_vector(384),),
+        )
+        conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) "
+            "VALUES ('n1', 'notebook text', ?)",
+            (_vector(384),),
+        )
+    init_concept_database(str(concept_path))
+    with sqlite3.connect(concept_path) as conn:
+        conn.execute(
+            "INSERT INTO entities "
+            "(name, type, session_name, project, name_embedding) "
+            "VALUES ('entity text', 'concept', 's1', 'p1', ?)",
+            (_vector(384),),
+        )
+
+
+def test_migrates_both_databases_then_sets_marker_and_is_idempotent(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    _seed_databases(memory_path, concept_path)
+    first_encoder = FakeEncoder()
+
+    result = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        batch_size=2,
+        encoder_factory=lambda: first_encoder,
+        progress=lambda _message: None,
+    )
+
+    assert result == {"rows_migrated": 4, "concept_db_present": True}
+    state = inspect_embedding_state(str(memory_path), str(concept_path))
+    assert state.compatible
+    assert state.marker == DEFAULT_SEMANTIC_MODEL
+
+    second_encoder = FakeEncoder()
+    second = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        encoder_factory=lambda: second_encoder,
+        progress=lambda _message: None,
+    )
+    assert second["rows_migrated"] == 0
+    assert second_encoder.calls == [["MARM embedding migration dimension check"]]
+
+
+def test_missing_concept_database_is_not_created(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "missing" / "concept.db"
+    init_database(str(memory_path))
+
+    result = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        encoder_factory=FakeEncoder,
+        progress=lambda _message: None,
+    )
+
+    assert result == {"rows_migrated": 0, "concept_db_present": False}
+    assert not concept_path.exists()
+
+
+def test_missing_memory_database_exits_without_loading_encoder_or_creating_files(
+    tmp_path,
+):
+    memory_path = tmp_path / "missing-memory.db"
+    concept_path = tmp_path / "missing-concept.db"
+
+    result = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        encoder_factory=lambda: pytest.fail("encoder must not load"),
+        progress=lambda _message: None,
+    )
+
+    assert result == {"rows_migrated": 0, "concept_db_present": False}
+    assert not memory_path.exists()
+    assert not concept_path.exists()
+
+
+def test_pre_embedding_concept_schema_is_upgraded_only_by_migration(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    init_database(str(memory_path))
+    with sqlite3.connect(concept_path) as conn:
+        conn.execute("CREATE TABLE entities (id INTEGER PRIMARY KEY, name TEXT)")
+
+    result = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        encoder_factory=FakeEncoder,
+        progress=lambda _message: None,
+    )
+
+    assert result == {"rows_migrated": 0, "concept_db_present": True}
+    with sqlite3.connect(concept_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(entities)")}
+    assert "name_embedding" in columns
+
+
+def test_interrupted_run_commits_finished_database_and_resumes(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    _seed_databases(memory_path, concept_path)
+
+    with pytest.raises(RuntimeError, match="injected encoder failure"):
+        migrate_embeddings(
+            str(memory_path),
+            str(concept_path),
+            encoder_factory=lambda: FakeEncoder(fail_on="entity text"),
+            progress=lambda _message: None,
+        )
+
+    state = inspect_embedding_state(str(memory_path), str(concept_path))
+    assert state.incompatible == 1
+    assert state.marker is None
+
+    result = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        encoder_factory=FakeEncoder,
+        progress=lambda _message: None,
+    )
+    assert result["rows_migrated"] == 1
+    assert inspect_embedding_state(str(memory_path), str(concept_path)).compatible
+
+
+def test_preflight_dimension_mismatch_aborts_before_writes(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    _seed_databases(memory_path, concept_path)
+
+    with pytest.raises(RuntimeError, match="Configured embedding dimension"):
+        migrate_embeddings(
+            str(memory_path),
+            str(concept_path),
+            encoder_factory=lambda: FakeEncoder(dim=384),
+            progress=lambda _message: None,
+        )
+
+    assert (
+        inspect_embedding_state(str(memory_path), str(concept_path)).incompatible == 4
+    )
+
+
+def test_verification_failure_blocks_marker(tmp_path, monkeypatch):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    _seed_databases(memory_path, concept_path)
+    real_migrate_database = embedding_migration._migrate_database
+
+    def skip_concept(path, tables, encoder, batch_size, progress):
+        if path == concept_path:
+            return 0
+        return real_migrate_database(path, tables, encoder, batch_size, progress)
+
+    monkeypatch.setattr(embedding_migration, "_migrate_database", skip_concept)
+
+    with pytest.raises(RuntimeError, match="Verification failed"):
+        migrate_embeddings(
+            str(memory_path),
+            str(concept_path),
+            encoder_factory=FakeEncoder,
+            progress=lambda _message: None,
+        )
+    with sqlite3.connect(memory_path) as conn:
+        assert (
+            conn.execute(
+                "SELECT value FROM user_settings WHERE key = 'embedding_model'"
+            ).fetchone()
+            is None
+        )
+
+
+def test_concept_similarity_logs_mixed_dimension_skips(tmp_path, capsys):
+    from marm_mcp_server.core.concept_db import ConceptDB
+
+    db = ConceptDB(str(tmp_path / "concept.db"))
+    with db.get_connection() as conn:
+        conn.execute(
+            "INSERT INTO entities "
+            "(name, type, session_name, project, name_embedding) "
+            "VALUES ('old entity', 'concept', 's1', 'p1', ?)",
+            (_vector(384),),
+        )
+        matches = db.find_similar_entities(
+            conn,
+            _vector(DEFAULT_SEMANTIC_DIM),
+            "s1",
+            "p1",
+            0.8,
+        )
+
+    assert matches == []
+    assert "--migrate-embeddings" in capsys.readouterr().err

--- a/marm-mcp-server/tests/test_embedding_migration.py
+++ b/marm-mcp-server/tests/test_embedding_migration.py
@@ -93,6 +93,36 @@ def test_migrates_both_databases_then_sets_marker_and_is_idempotent(tmp_path):
     assert second_encoder.calls == [["MARM embedding migration dimension check"]]
 
 
+def test_migrates_same_dimension_vectors_when_model_marker_differs(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    init_database(str(memory_path))
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) VALUES (?, ?, ?)",
+            ("n1", "same-dimension text", _vector(DEFAULT_SEMANTIC_DIM)),
+        )
+        conn.execute(
+            "INSERT INTO user_settings (key, value) VALUES ('embedding_model', ?)",
+            ("other-512-dimension-model",),
+        )
+
+    encoder = FakeEncoder()
+    result = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        encoder_factory=lambda: encoder,
+        progress=lambda _message: None,
+    )
+
+    assert result == {"rows_migrated": 1, "concept_db_present": False}
+    assert encoder.calls == [
+        ["MARM embedding migration dimension check"],
+        ["same-dimension text"],
+    ]
+    assert inspect_embedding_state(str(memory_path), str(concept_path)).compatible
+
+
 def test_missing_concept_database_is_not_created(tmp_path):
     memory_path = tmp_path / "memory.db"
     concept_path = tmp_path / "missing" / "concept.db"

--- a/marm-mcp-server/tests/test_embedding_migration.py
+++ b/marm-mcp-server/tests/test_embedding_migration.py
@@ -103,6 +103,10 @@ def test_migrates_same_dimension_vectors_when_model_marker_differs(tmp_path):
             ("n1", "same-dimension text", _vector(DEFAULT_SEMANTIC_DIM)),
         )
         conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) VALUES (?, ?, ?)",
+            ("n2", "second same-dimension text", _vector(DEFAULT_SEMANTIC_DIM)),
+        )
+        conn.execute(
             "INSERT INTO user_settings (key, value) VALUES ('embedding_model', ?)",
             ("other-512-dimension-model",),
         )
@@ -111,16 +115,43 @@ def test_migrates_same_dimension_vectors_when_model_marker_differs(tmp_path):
     result = migrate_embeddings(
         str(memory_path),
         str(concept_path),
+        batch_size=1,
         encoder_factory=lambda: encoder,
         progress=lambda _message: None,
     )
 
-    assert result == {"rows_migrated": 1, "concept_db_present": False}
+    assert result == {"rows_migrated": 2, "concept_db_present": False}
     assert encoder.calls == [
         ["MARM embedding migration dimension check"],
         ["same-dimension text"],
+        ["second same-dimension text"],
     ]
     assert inspect_embedding_state(str(memory_path), str(concept_path)).compatible
+
+
+def test_backfills_missing_embeddings_during_normal_migration(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "missing-concept.db"
+    init_database(str(memory_path))
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) VALUES (?, ?, NULL)",
+            ("n1", "missing embedding"),
+        )
+
+    result = migrate_embeddings(
+        str(memory_path),
+        str(concept_path),
+        encoder_factory=FakeEncoder,
+        progress=lambda _message: None,
+    )
+
+    assert result == {"rows_migrated": 1, "concept_db_present": False}
+    with sqlite3.connect(memory_path) as conn:
+        embedding = conn.execute(
+            "SELECT embedding FROM notebook_entries WHERE name = 'n1'"
+        ).fetchone()[0]
+    assert len(embedding) == DEFAULT_SEMANTIC_DIM * 4
 
 
 def test_missing_concept_database_is_not_created(tmp_path):

--- a/marm-mcp-server/tests/test_embedding_state.py
+++ b/marm-mcp-server/tests/test_embedding_state.py
@@ -1,0 +1,188 @@
+import asyncio
+import sqlite3
+
+import numpy as np
+
+from marm_mcp_server.config.settings import DEFAULT_SEMANTIC_MODEL
+from marm_mcp_server.core.memory_db import init_database
+from marm_mcp_server.utils.embedding_state import (
+    check_embedding_compatibility,
+    inspect_embedding_state,
+)
+
+
+def _vector(dim: int) -> bytes:
+    return np.ones(dim, dtype=np.float32).tobytes()
+
+
+def test_fresh_state_seeds_marker_without_creating_concept_db(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "missing" / "marm_index.db"
+    init_database(str(memory_path))
+    warnings = []
+
+    state = check_embedding_compatibility(
+        memory_db_path=str(memory_path),
+        concept_db_path=str(concept_path),
+        warn=warnings.append,
+    )
+
+    assert state.compatible
+    assert warnings == []
+    assert not concept_path.exists()
+    with sqlite3.connect(memory_path) as conn:
+        marker = conn.execute(
+            "SELECT value FROM user_settings WHERE key = 'embedding_model'"
+        ).fetchone()[0]
+    assert marker == DEFAULT_SEMANTIC_MODEL
+
+
+def test_old_notebook_vector_requires_migration_when_memories_are_empty(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    init_database(str(memory_path))
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) VALUES (?, ?, ?)",
+            ("notes", "old notebook vector", _vector(384)),
+        )
+    warnings = []
+
+    state = check_embedding_compatibility(
+        memory_db_path=str(memory_path),
+        concept_db_path=str(tmp_path / "missing.db"),
+        warn=warnings.append,
+    )
+
+    assert state.incompatible == 1
+    assert len(warnings) == 1
+    assert "--migrate-embeddings" in warnings[0]
+    with sqlite3.connect(memory_path) as conn:
+        assert (
+            conn.execute(
+                "SELECT value FROM user_settings WHERE key = 'embedding_model'"
+            ).fetchone()
+            is None
+        )
+
+
+def test_restored_old_concept_vectors_override_current_marker(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    init_database(str(memory_path))
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO user_settings (key, value) VALUES ('embedding_model', ?)",
+            (DEFAULT_SEMANTIC_MODEL,),
+        )
+    with sqlite3.connect(concept_path) as conn:
+        conn.execute(
+            "CREATE TABLE entities (id INTEGER PRIMARY KEY, name_embedding BLOB)"
+        )
+        conn.execute(
+            "INSERT INTO entities (name_embedding) VALUES (?)", (_vector(384),)
+        )
+
+    state = inspect_embedding_state(str(memory_path), str(concept_path))
+
+    assert state.marker == DEFAULT_SEMANTIC_MODEL
+    assert state.incompatible == 1
+    assert not state.compatible
+
+
+def test_pre_embedding_concept_schema_is_inspected_without_ddl(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    init_database(str(memory_path))
+    with sqlite3.connect(concept_path) as conn:
+        conn.execute("CREATE TABLE entities (id INTEGER PRIMARY KEY, name TEXT)")
+
+    state = inspect_embedding_state(str(memory_path), str(concept_path))
+
+    assert state.compatible
+    with sqlite3.connect(concept_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(entities)")}
+    assert "name_embedding" not in columns
+
+
+def test_corrupt_concept_database_warns_without_raising_or_repairing(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    concept_path = tmp_path / "concept.db"
+    init_database(str(memory_path))
+    concept_path.write_bytes(b"not a sqlite database")
+    warnings = []
+
+    state = check_embedding_compatibility(
+        memory_db_path=str(memory_path),
+        concept_db_path=str(concept_path),
+        warn=warnings.append,
+    )
+
+    assert not state.compatible
+    assert len(state.errors) == 1
+    assert len(warnings) == 1
+    assert "core memory remains available" in warnings[0]
+    assert concept_path.read_bytes() == b"not a sqlite database"
+
+
+def test_http_lifespan_runs_shared_compatibility_check(monkeypatch, tmp_path):
+    from conftest import load_isolated_server
+
+    server = load_isolated_server(monkeypatch, tmp_path)
+    memory_path = tmp_path / "marm_memory.db"
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) VALUES (?, ?, ?)",
+            ("old", "old vector", _vector(384)),
+        )
+    warnings = []
+    real_check = check_embedding_compatibility
+    monkeypatch.setattr(
+        server,
+        "check_embedding_compatibility",
+        lambda **kwargs: real_check(
+            memory_db_path=str(memory_path),
+            concept_db_path=str(tmp_path / "missing-concept.db"),
+            warn=warnings.append,
+        ),
+    )
+
+    async def run_lifespan():
+        async with server.lifespan(server.app):
+            pass
+
+    asyncio.run(run_lifespan())
+    assert len(warnings) == 1
+    assert "--migrate-embeddings" in warnings[0]
+
+
+def test_stdio_main_runs_shared_compatibility_check(monkeypatch, tmp_path):
+    from conftest import load_isolated_server
+
+    load_isolated_server(monkeypatch, tmp_path)
+    import marm_mcp_server.server_stdio as stdio
+
+    memory_path = stdio.memory.db_path
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) VALUES (?, ?, ?)",
+            ("stdio-old", "old vector", _vector(384)),
+        )
+    warnings = []
+    real_check = check_embedding_compatibility
+    monkeypatch.setattr(
+        stdio,
+        "check_embedding_compatibility",
+        lambda **kwargs: real_check(
+            memory_db_path=memory_path,
+            concept_db_path=str(tmp_path / "missing-concept.db"),
+            warn=warnings.append,
+        ),
+    )
+    monkeypatch.setattr(stdio.memory, "restore_active_session", lambda: None)
+    monkeypatch.setattr(stdio.mcp, "run", lambda: None)
+    monkeypatch.setattr(stdio, "_stop_graph_supervisor_safely", lambda: None)
+
+    stdio.main()
+
+    assert len(warnings) == 1
+    assert "--migrate-embeddings" in warnings[0]

--- a/marm-mcp-server/tests/test_embedding_state.py
+++ b/marm-mcp-server/tests/test_embedding_state.py
@@ -65,6 +65,38 @@ def test_old_notebook_vector_requires_migration_when_memories_are_empty(tmp_path
         )
 
 
+def test_different_512_dimension_model_marker_requires_migration(tmp_path):
+    memory_path = tmp_path / "memory.db"
+    init_database(str(memory_path))
+    with sqlite3.connect(memory_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_entries (name, data, embedding) VALUES (?, ?, ?)",
+            ("notes", "other model vector", _vector(512)),
+        )
+        conn.execute(
+            "INSERT INTO user_settings (key, value) VALUES ('embedding_model', ?)",
+            ("other-512-dimension-model",),
+        )
+    warnings = []
+
+    state = check_embedding_compatibility(
+        memory_db_path=str(memory_path),
+        concept_db_path=str(tmp_path / "missing.db"),
+        warn=warnings.append,
+    )
+
+    assert state.incompatible == 0
+    assert state.marker_incompatible
+    assert not state.compatible
+    assert len(warnings) == 1
+    assert "other-512-dimension-model" in warnings[0]
+    with sqlite3.connect(memory_path) as conn:
+        marker = conn.execute(
+            "SELECT value FROM user_settings WHERE key = 'embedding_model'"
+        ).fetchone()[0]
+    assert marker == "other-512-dimension-model"
+
+
 def test_restored_old_concept_vectors_override_current_marker(tmp_path):
     memory_path = tmp_path / "memory.db"
     concept_path = tmp_path / "concept.db"

--- a/marm-mcp-server/tests/test_fastembed_encoder.py
+++ b/marm-mcp-server/tests/test_fastembed_encoder.py
@@ -2,13 +2,7 @@
 the .encode(text) shape every caller (and scripts/bench_hotpath.py) already
 expects from SentenceTransformer.
 
-Real cross-backend numerical fidelity (does fastembed's ONNX all-MiniLM-L6-v2
-agree with the PyTorch sentence-transformers version) was already verified
-separately against real model weights: 1.0000 cosine similarity on a
-15-sentence corpus, identical top-5 retrieval ranking. That can't be
-re-verified here -- this sandbox's network policy blocks huggingface.co, so
-the real model can never download in this environment. These tests instead
-target what's actually ours to get wrong: whether the adapter calls
+These tests target what's actually ours to get wrong: whether the adapter calls
 fastembed's real API correctly and preserves SentenceTransformer's
 single-string-vs-list-of-strings polymorphism, which is what
 scripts/bench_hotpath.py:80 depends on.
@@ -18,6 +12,7 @@ import numpy as np
 import pytest
 
 from marm_mcp_server.core.memory import _FastEmbedEncoder
+from marm_mcp_server.config.settings import DEFAULT_SEMANTIC_DIM, DEFAULT_SEMANTIC_MODEL
 
 
 class _FakeTextEmbedding:
@@ -38,14 +33,31 @@ def patched_encoder(monkeypatch):
     import fastembed
 
     monkeypatch.setattr(fastembed, "TextEmbedding", _FakeTextEmbedding)
-    return _FastEmbedEncoder("all-MiniLM-L6-v2")
+    return _FastEmbedEncoder("jinaai/jina-embeddings-v2-small-en")
 
 
-def test_model_name_gets_sentence_transformers_prefix(patched_encoder):
-    """fastembed needs the full HF repo id; DEFAULT_SEMANTIC_MODEL is the
-    short form SentenceTransformer resolved via its own aliasing -- the
-    adapter must add the prefix fastembed requires, not pass the bare name."""
-    assert patched_encoder._model.model_name == "sentence-transformers/all-MiniLM-L6-v2"
+def test_full_model_name_passes_through_unchanged(patched_encoder):
+    assert patched_encoder._model.model_name == "jinaai/jina-embeddings-v2-small-en"
+
+
+def test_legacy_minilm_short_name_keeps_compatibility(monkeypatch):
+    import fastembed
+
+    monkeypatch.setattr(fastembed, "TextEmbedding", _FakeTextEmbedding)
+    encoder = _FastEmbedEncoder("all-MiniLM-L6-v2")
+    assert encoder._model.model_name == "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def test_default_model_registry_metadata_matches_configured_dimension():
+    from fastembed import TextEmbedding
+
+    model = next(
+        item
+        for item in TextEmbedding.list_supported_models()
+        if item["model"] == DEFAULT_SEMANTIC_MODEL
+    )
+    assert model["dim"] == DEFAULT_SEMANTIC_DIM
+    assert "Prefixes for queries/documents: not necessary" in model["description"]
 
 
 def test_encode_single_string_returns_one_vector_not_a_list(patched_encoder):

--- a/scripts/benchmarking/README.md
+++ b/scripts/benchmarking/README.md
@@ -21,7 +21,7 @@ All scripts run from the **repo root**.
 
 ### `bench_hotpath.py`
 
-Measures, against the real `MARMMemory` + fastembed-backed `all-MiniLM-L6-v2` encoder, using a throwaway temp DB (never touches `~/.marm`):
+Measures, against the real `MARMMemory` + configured fastembed-backed semantic encoder, using a throwaway temp DB (never touches `~/.marm`):
 
 1. `encode()` wall time
 2. `recall_similar` latency vs. session size N (FTS filter + bounded embedding rerank)
@@ -89,3 +89,5 @@ Reported per LoCoMo category (single-hop, temporal, multi-hop, open-domain, adve
 - `all_hit_rate`: fraction where every gold evidence turn was recalled (matters for multi-hop questions with multiple evidence IDs).
 - `evidence_recall`: mean fraction of gold evidence turns recalled per question — smoother than the all-or-nothing pair.
 - `semantic_any_hit_rate` / `log_any_hit_rate`: per-lane breakdown of any-hit, showing how much each retrieval lane contributes.
+
+**Latest full run (`jinaai/jina-embeddings-v2-small-en`, top-5):** 1,977 scored questions, 53.0% any-hit, 43.4% all-hit, and 47.6% mean evidence recall. The previous MiniLM baseline was 37.5% any-hit and 29.5% all-hit. This is a measured end-to-end comparison, not proof that context length alone caused the change.

--- a/scripts/benchmarking/performance/bench_hotpath.py
+++ b/scripts/benchmarking/performance/bench_hotpath.py
@@ -1,6 +1,6 @@
 """Hot-path benchmark.
 
-Measures, against the REAL MARMMemory + fastembed-backed all-MiniLM-L6-v2 encoder:
+Measures, against the REAL MARMMemory + configured fastembed-backed semantic encoder:
   1. encode() wall time (the per-call CPU cost)
   2. recall_similar latency vs session size N (FTS filter + bounded embedding rerank)
   3. event-loop blocking: concurrent recalls via asyncio.gather vs serial sum
@@ -35,6 +35,7 @@ sys.path.insert(0, os.path.join(_REPO_ROOT, "marm-mcp-server"))
 from marm_mcp_server.core.memory import MARMMemory, _safe_fts_query  # noqa: E402
 from marm_mcp_server.core import consolidation  # noqa: E402
 from marm_mcp_server.core import memory_ops  # noqa: E402
+from marm_mcp_server.config.settings import DEFAULT_SEMANTIC_DIM  # noqa: E402
 
 try:
     import numpy as np
@@ -67,7 +68,7 @@ VOCAB = (
     "summary cluster threshold nudge staging idempotent transaction lock writer"
 ).split()
 
-EMBEDDING_DIM = 384
+EMBEDDING_DIM = DEFAULT_SEMANTIC_DIM
 EMBEDDING_BYTES = EMBEDDING_DIM * 4
 
 
@@ -250,8 +251,8 @@ async def bench_hybrid_strategies(mem, sizes=None, iters=15):
             try:
                 conn.row_factory = sqlite3.Row
                 rows = conn.execute(
-                    """SELECT id, content, embedding FROM memories 
-                       WHERE session_name = 'bench' AND embedding IS NOT NULL 
+                    """SELECT id, content, embedding FROM memories
+                       WHERE session_name = 'bench' AND embedding IS NOT NULL
                        ORDER BY timestamp DESC LIMIT 10000"""
                 ).fetchall()
 

--- a/scripts/test-scripts/smoke_embedding_chunking.py
+++ b/scripts/test-scripts/smoke_embedding_chunking.py
@@ -39,16 +39,22 @@ os.environ["MARM_DB_PATH"] = _BOOT_DB_PATH
 
 import numpy as np  # noqa: E402
 
-from marm_mcp_server.config.settings import RECALL_SCAN_LIMIT, SEMANTIC_SEARCH_AVAILABLE  # noqa: E402
+from marm_mcp_server.config.settings import (  # noqa: E402
+    DEFAULT_SEMANTIC_DIM,
+    RECALL_SCAN_LIMIT,
+    SEMANTIC_SEARCH_AVAILABLE,
+)
 from marm_mcp_server.core import memory as memory_module  # noqa: E402
 from marm_mcp_server.core.memory import (  # noqa: E402
     MARMMemory,
     _chunk_text,
-    _fetch_and_score_embedding_rows,
-    _score_chunk_aware,
     CHUNK_THRESHOLD_WORDS,
     CHUNK_TOKEN_LIMIT,
     CHUNK_OVERLAP_TOKENS,
+)
+from marm_mcp_server.core.memory_scoring import (  # noqa: E402
+    _fetch_and_score_embedding_rows,
+    _score_chunk_aware,
 )
 
 SEP = "-" * 70
@@ -56,7 +62,7 @@ SESSION = "smoke-chunking"
 
 # Long memory: first ~210 words are generic filler, distinctive phrase
 # "crystallization threshold boundary" only appears near the end.
-# Without chunking MiniLM truncates at ~256 tokens and misses it entirely.
+# Chunking preserves recall of the distinctive late-body phrase.
 _FILLER = (
     "This document covers general system architecture notes for the server. "
     "Connection pools are initialized at startup to reduce open/close overhead. "
@@ -66,7 +72,7 @@ _FILLER = (
     "The write queue serializes concurrent agent writes to prevent contention. "
     "Rate limiting presets are applied per deployment mode at the HTTP layer. "
     "FTS5 uses the porter ascii tokenizer for stemming on all recall queries. "
-    "Embeddings are generated with all-MiniLM-L6-v2 at three hundred eighty four dimensions. "
+    f"Embeddings are generated at {DEFAULT_SEMANTIC_DIM} dimensions. "
     "Compaction candidates are surfaced to agents after the configured write threshold. "
 )
 _LONG_BODY = (_FILLER * 3) + (
@@ -78,7 +84,7 @@ _LONG_BODY = (_FILLER * 3) + (
 SHORT_CONTENT = "MARM stores memories in SQLite with WAL mode."
 
 
-def _unit_vec(dim: int = 384) -> np.ndarray:
+def _unit_vec(dim: int = DEFAULT_SEMANTIC_DIM) -> np.ndarray:
     v = np.ones(dim, dtype=np.float32)
     return v / np.linalg.norm(v)
 
@@ -276,7 +282,7 @@ async def run(require_encoder: bool) -> bool:
         print(SEP)
         print("CHECK 4: _score_chunk_aware — MAX scoring and deduplication")
         print(SEP)
-        ortho = np.zeros(384, dtype=np.float32)
+        ortho = np.zeros(DEFAULT_SEMANTIC_DIM, dtype=np.float32)
         ortho[0] = 1.0
 
         mem_id = str(uuid.uuid4())


### PR DESCRIPTION
## v2.24.0: Jina v2 Small Embedding Migration

This replaces the default semantic encoder with `jinaai/jina-embeddings-v2-small-en` through fastembed.
- Moves from MiniLM’s 384-dimension / 256-token embeddings to Jina’s 512-dimension / 8,192-token embeddings.
- Adds `marm-mcp-server --migrate-embeddings` to safely re-embed existing memories, chunks, notebook entries, and any existing concept-graph embeddings.
- Migration is resumable, reports progress, verifies both databases before recording completion, and refuses to run when it detects a live HTTP MARM server.
- Adds embedding-state tracking and clear warnings when stored vectors do not match the active model, so mixed-dimension data is visible instead of silently degrading semantic recall.
- Updates chunking and benchmark tooling for the new model.

### Benchmark Result

A fresh 10-conversation LoCoMo run improved top-5 retrieval from the MiniLM baseline of **37.5% any-hit / 29.5% all-hit** to **53.0% any-hit / 43.4% all-hit** across **1,977 questions**.

This is an end-to-end retrieval result, not a claim that the model’s larger context window alone caused the improvement.

### Upgrade Note

Existing users must stop MARM processes and run:

```powershell
marm-mcp-server --migrate-embeddings

Before restarting MARM. Existing installations remain usable before migration, but semantic recall quality can be degraded while old and new embedding dimensions coexist.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Switched the default semantic embedding model to Jina v2 Small (512 dimensions) and added a `--migrate-embeddings` command with resumable progress and verification.
  * Added clearer runtime warnings when stored embeddings have incompatible or mixed dimensions to prevent degraded recall.

* **Documentation**
  * Updated installation/upgrade guides and configuration defaults for v2.24.0, including explicit migration steps and what to expect.
  * Refreshed performance/benchmark reporting and architecture docs to reflect the new default embedding setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->