### PR TITLE
Release/v2.25.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ MARM is a local-first MCP memory server: Python FastAPI in `marm-mcp-server/`, p
 - **Storage**: SQLite WAL at `~/.marm/marm_memory.db` (connection pool, FTS5 external-content index `memories_fts`, `memory_chunks` for long-memory chunking). The concept graph uses its own database `~/.marm/index/marm_index.db` with its own pool. Never share connections between the two.
 - **Write path**: all memory writes go through the serialized async write queue (one worker). Do not add write paths that bypass it. `marm_log_entry` dual-writes: a `log_entries` row plus a semantic memory in `memories` (via the queue); a semantic-store failure must never fail the log write.
 - **Code graph**: a pinned external binary (codebase-memory-mcp) supervised as a child process over newline-delimited JSON-RPC (`core/graph_supervisor.py`, `core/graph_client.py`). It starts lazily and runs degraded on failure. Graph or concept failures must never break the 7 core memory tools.
+- **Graph-aware recall**: `marm_smart_recall` keeps primary memory ranking authoritative and may add bounded `graph_context` from the isolated concept database. Graph enrichment is read-only and fail-open; trim graph details before primary results when enforcing response limits.
 - **Embeddings**: one fastembed `jinaai/jina-embeddings-v2-small-en` encoder (512 dimensions), lazy-loaded and serialized behind a lock. Writes must succeed even when the encoder is unavailable. Existing data requires `marm-mcp-server --migrate-embeddings` before restart when upgrading from MiniLM.
 
 ## Consistency Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 <details>
 <summary><strong>Unreleased: Notebook Scratch Pad, Permanent Docs Store, and Chunking Rework (v2.25.0)</strong></summary>
 
+### Concept Context Joins Normal Recall
+
+- `marm_smart_recall` now preserves its existing memory ranking while attaching bounded concept relationships and linked code symbols as an additive `graph_context` sidecar. Missing, empty, incompatible, or unavailable graph data fails open and never blocks core recall.
+- Concept entities and relationships now retain platform provenance alongside session and project scope. Existing concept graphs require one explicit `marm_concept_build(search_all=True)` rebuild; MARM backs up and resets only the derived concept database and never modifies primary memories.
+- `marm_concept_recall` accepts optional platform scope over both HTTP and STDIO while retaining its explicit bounded traversal role.
+- MARM Console's graph explorer now uses a full-atlas mode through 750 entities and 6,000 stored relationships. Oversized graphs use a deterministic connected sample capped at 600 entities and 4,000 aggregated visual edges, with honest full/sampled metadata in the API and UI.
+- Replaced permanently pinned graph coordinates with adaptive force simulation, weighted repeated relationships, focused labels, and reheating when filters or graph membership change.
+
 ### Notebook Is Now a Real Per-Session Scratch Pad
 
 - `notebook_entries` gains `session_name` as part of its identity (was `name`+`project`+`platform` only). Legacy rows migrate to `session_name='main'` on upgrade so nothing already saved becomes unreachable. `add`, `use`, `show`, and `marm_delete(type="notebook")` all now scope by session — a scratch note saved under one session is no longer visible from a different one.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 - marm-console now ships as the local web app for memory, knowledge, projects, and MCP-backed memory mutation actions. Packaging and one-command startup polish are still in progress.
 - **Embedding upgrade:** v2.24 switches MARM to Jina v2 Small. Existing MiniLM data must be migrated before restart: stop MARM, run `marm-mcp-server --migrate-embeddings`, then restart. See [Upgrade Existing Embeddings](#upgrade-existing-embeddings).
+- **Concept graph rebuild:** the platform-aware graph schema requires one full rebuild. After upgrading, run `marm_concept_build(search_all=True)` once. MARM backs up and rebuilds only the derived concept database; memories are not modified.
 - I am waiting to get access back to my PYPI account, till restored pip will be behind a few versions. I will update the README when it is back up to date.
 
 
@@ -574,7 +575,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 | Tool | What it does | Key parameters |
 |------|--------------|----------------|
-| `marm_smart_recall` | Hybrid recall: exact lane for config keys, commands, and file paths; semantic rerank for natural-language queries | `query`, `limit`, `session_name`, `search_all`, `detail=1/2/3`, `project`, `platform`, `exact_mode` |
+| `marm_smart_recall` | Hybrid memory recall with an additive, bounded concept/code graph sidecar when a compatible graph exists | `query`, `limit`, `session_name`, `search_all`, `detail=1/2/3`, `project`, `platform`, `exact_mode` |
 | `marm_log_entry` | Add structured session log entries; each entry is also embedded into semantic memory so `marm_smart_recall` can find it | `entry`, `session_name` |
 | `marm_log_show` | Display all entries and sessions, with filtering | `session_name` |
 | `marm_delete` | Delete a log session, log entry, or notebook entry | `type`, `target`, `session_name`, `project`, `platform` |
@@ -597,7 +598,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 | Tool | What it does | Key parameters |
 |------|--------------|----------------|
 | `marm_concept_build` | Extract entities and typed relationships from stored memories | `session_name`, `project`, or `search_all=True` (one required) |
-| `marm_concept_recall` | Query entities, relationships, and linked code symbols | `query`, `depth` (1-5), `direction`, `project` |
+| `marm_concept_recall` | Explicitly query entities, relationships, and linked code symbols | `query`, `depth` (1-5), `direction`, `project`, `platform` |
 
 All 14 tools are available on both HTTP and STDIO. Behind the tool surface, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks automatically; none of those consume the agent's attention or tokens. The two graph engines start lazily on first use and never block the 7 core memory tools if they fail to start. See [Architecture & Internals](#architecture--internals) for the mechanisms.
 
@@ -765,7 +766,7 @@ Under the hood, the engine is [codebase-memory-mcp](https://github.com/DeusData/
 
 ### Concept Graph: what your memories are about
 
-MARM can extract a knowledge graph from the memories you've already stored. `marm_concept_build` runs entity and relationship extraction over stored memory content, producing typed entities (**concepts, decisions, patterns, errors, tools, people, organizations**) connected by typed relationships (**fixes, implements, depends_on, uses, causes, replaces, extends**). `marm_concept_recall` then answers questions like:
+MARM can extract a knowledge graph from the memories you've already stored. `marm_concept_build` runs entity and relationship extraction over stored memory content, producing typed entities (**concepts, decisions, patterns, errors, tools, people, organizations**) connected by typed relationships (**fixes, implements, depends_on, uses, causes, replaces, extends**). Once built, `marm_smart_recall` automatically adds bounded related entities, relationships, and linked code as a `graph_context` sidecar without changing primary memory ranking. `marm_concept_recall` remains available for explicit graph exploration:
 
 ```text
 marm_concept_recall(query="write queue")            → the entity, its relationships, linked code symbols
@@ -775,10 +776,13 @@ marm_concept_recall(query="related to SQLite", depth=3) → multi-hop traversal 
 How to use it:
 
 - **Build first**: call `marm_concept_build` scoped to a `session_name`, `project`, or `search_all=True`. There is no data until a build has run at least once. Builds are explicit and on-demand, not a live hook into the write path; re-run after logging significant new memories.
+- **Upgrade once**: graphs built before platform attribution require `marm_concept_build(search_all=True)`. A full build backs up and resets only the derived concept database; targeted builds refuse to guess platform ownership.
 - **Bounded by design**: each build is row-capped (`CONCEPT_BUILD_ROW_CAP`, default 500) so a huge store can't turn one tool call into a runaway job.
+- **Recall fails open**: a missing, empty, incompatible, or unavailable concept graph never blocks normal memory recall. The response reports graph status separately.
 - **Code cross-linking**: when the code graph has indexed the same project, concept entities that match code symbols get linked, connecting "what we decided" to "where it lives in the code."
 - **Optional dependency**: real extraction needs the `[concepts]` extra (`pip install marm-mcp-server[concepts]` plus `python -m spacy download en_core_web_sm`). Without it, both concept tools stay registered and return `entities_extracted: 0` instead of erroring. Base installs carry no spaCy dependency.
 - **Isolated storage**: the concept graph lives in its own SQLite database (`~/.marm/index/marm_index.db`) with its own connection pool, so concept-graph writes can never block or corrupt the production memory database.
+- **Console atlas**: MARM Console renders the complete atlas up to 750 entities and 6,000 stored relationships. Larger graphs use a deterministic connected sample of up to 600 entities and 4,000 aggregated visual edges, clearly labelled as sampled.
 
 This fills the cross-session structure gap that flat memory search leaves open: sessions organize memories, but the concept graph *connects* them, so "what depends on the write queue?" is answerable even when the answer spans five sessions from three different agents.
 

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.24.0** - Memory Accurate Response Mode
+**MARM v2.25.0** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.24.0** - Memory Accurate Response Mode
+**MARM v2.25.0** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -320,7 +320,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.24.0 MCP Server - Platform Integration Guide
+# MARM v2.25.0 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.24.0** - Memory Accurate Response Mode
+**MARM v2.25.0** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -293,7 +293,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/PROTOCOL-LITE.md
+++ b/docs/PROTOCOL-LITE.md
@@ -27,6 +27,6 @@ You are under the MARM operating contract. The full protocol was delivered at se
 
 ## When to Act
 
-Log only what matters -- decisions, breakthroughs, completions. Use `marm_smart_recall` before starting work on a known topic. Use `marm_summary` at handoffs and end of sessions. Use `marm_notebook` for early ideas not ready to commit. Skip if the moment does not clearly fit.
+Log only what matters -- decisions, breakthroughs, completions. Use `marm_smart_recall` before starting work on a known topic; it includes bounded concept/code context when a compatible graph exists. Use `marm_summary` at handoffs and end of sessions. Use `marm_notebook` for early ideas not ready to commit. Skip if the moment does not clearly fit.
 
 Retrieve full protocol or any doc via `marm_smart_recall`.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -29,12 +29,12 @@ Execution Policy (adaptive):
 
 Tool Contract (versioned runtime):
 - Surface: 14 MCP tools: 7 core memory/logging/notebook/compaction tools, 5 bundled code-graph tools, and 2 bundled concept-graph tools.
-- Memory: `marm_smart_recall` (semantic retrieval, use `include_logs=True` when logs matter).
+- Memory: `marm_smart_recall` (hybrid retrieval plus bounded graph context when available; use `include_logs=True` when logs matter).
 - Session Logs: `marm_log_entry`, `marm_log_show`. Logged entries are also embedded into semantic memory, so `marm_smart_recall` finds them later.
 - Notebook: `marm_notebook(action="add"|"use"|"show"|"status"|"clear"|"save")`. Scratch entries are per-session; `action="save"` promotes one (or new inline content) into a permanent, concept-graph-linked doc.
 - Workflow: `marm_summary` (handoff/recap), `marm_delete` (explicit delete requests only), `marm_compaction` (agent-assisted memory cleanup).
 - Code Graph: `marm_graph_index`, `marm_code_lookup`, `marm_graph_trace`, `marm_graph_architecture`, `marm_graph_impact` for repo indexing, symbol/source lookup, call tracing, architecture overview, and change-impact checks. Graph starts lazily on first graph call.
-- Concept Graph: `marm_concept_build` (extract entities/relationships from stored memories), `marm_concept_recall` (query entities, relationships, and linked code symbols).
+- Concept Graph: `marm_concept_build` (extract platform-aware entities/relationships from stored memories), `marm_concept_recall` (explicit bounded graph exploration). Normal `marm_smart_recall` responses already include related graph context when a compatible graph exists; graph failures never block memory recall.
 - Session Routing: call `marm_log_entry` with `"Session: [name]"` or `"Topic: [name]"` to switch sessions. The backend auto-tags the date.
 - Lifecycle: protocol delivery, session initialization, documentation loading, and refresh are automatic; do not ask users to run legacy start/refresh/system commands.
 

--- a/marm-console/artifacts/marm-console/src/components/knowledge/ExplorerTab.tsx
+++ b/marm-console/artifacts/marm-console/src/components/knowledge/ExplorerTab.tsx
@@ -110,7 +110,7 @@ export function ExplorerTab() {
     data: overviewGraph,
     isError: overviewError,
     isLoading: overviewLoading,
-  } = useConceptGraph({ limit: 150 }, selectedId === null);
+  } = useConceptGraph(selectedId === null);
   const [graph, setGraph] = useState<Neighborhood | null>(null);
   const [focusedNode, setFocusedNode] = useState<NeighborhoodNode | null>(null);
   const [hiddenPredicates, setHiddenPredicates] = useState<Set<string>>(new Set(DEFAULT_HIDDEN_PREDICATES));
@@ -180,6 +180,7 @@ export function ExplorerTab() {
   const isLoading = selectedId === null ? overviewLoading : neighborhoodLoading;
   const loadError = selectedId === null ? overviewError : neighborhoodError;
   const isEmpty = (summary?.entities ?? 0) === 0;
+  const rebuildRequired = overviewGraph?.schema_status === 'rebuild_required';
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 flex-1 min-h-0 h-full">
@@ -256,6 +257,13 @@ export function ExplorerTab() {
               <ArrowLeft className="w-3 h-3 mr-1" /> Full graph
             </Button>
           )}
+          {selectedId === null && overviewGraph && (
+            <Badge variant="outline" className="h-6 text-[10px] font-mono">
+              {overviewGraph.mode === 'full'
+                ? `Full atlas · ${overviewGraph.rendered.nodes} nodes`
+                : `Connected sample · ${overviewGraph.rendered.nodes}/${overviewGraph.total.nodes} nodes`}
+            </Badge>
+          )}
           {selectedId !== null && (
             <Select value={direction} onValueChange={(value: 'both' | 'incoming' | 'outgoing') => setDirection(value)}>
               <SelectTrigger className="h-6 w-28 text-xs"><SelectValue /></SelectTrigger>
@@ -292,7 +300,15 @@ export function ExplorerTab() {
           ))}
         </div>
         <div className="flex-1 border rounded-lg bg-card overflow-hidden flex flex-col relative shadow-inner">
-          {isEmpty ? (
+          {rebuildRequired ? (
+            <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground gap-3 px-8 text-center">
+              <AlertTriangle className="w-12 h-12 text-amber-500/70" />
+              <p className="font-medium text-foreground">Concept rebuild required</p>
+              <p className="text-sm max-w-md">
+                Run Build Concepts for all memories once to add platform-safe graph scope.
+              </p>
+            </div>
+          ) : isEmpty ? (
             <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground gap-3 px-8 text-center">
               <GitGraph className="w-16 h-16 opacity-20" />
               <p className="font-medium text-foreground">No knowledge graph yet</p>

--- a/marm-console/artifacts/marm-console/src/components/knowledge/GraphViz.tsx
+++ b/marm-console/artifacts/marm-console/src/components/knowledge/GraphViz.tsx
@@ -26,8 +26,8 @@ export function GraphViz({
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [hoverId, setHoverId] = useState<number | null>(null);
   const [paused, setPaused] = useState(false);
+  const pausedRef = useRef(false);
   const didInitialFit = useRef(false);
-  const pinnedRef = useRef<Map<number, { x: number; y: number }>>(new Map());
   const reducedMotion = useMemo(
     () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
     []
@@ -45,6 +45,12 @@ export function GraphViz({
     return () => obs.disconnect();
   }, []);
 
+  useEffect(() => {
+    const fg = fgRef.current;
+    if (!fg || !didInitialFit.current || dimensions.width === 0) return;
+    fg.zoomToFit(reducedMotion ? 0 : 250, 40);
+  }, [dimensions, reducedMotion]);
+
   const gData = useMemo(() => {
     const visibleNodeIds = new Set(
       neighborhood.nodes.filter(n => !hiddenTypes.has(n.type)).map(n => n.id)
@@ -61,7 +67,6 @@ export function GraphViz({
     const nodes = neighborhood.nodes
       .filter(n => visibleNodeIds.has(n.id) && connected.has(n.id))
       .map((n) => {
-        const pinned = pinnedRef.current.get(n.id);
         return {
           id: n.id,
           name: n.name,
@@ -69,7 +74,6 @@ export function GraphViz({
           degree: n.degree ?? n.mention_count,
           hiddenNeighborCount: n.hidden_neighbor_count,
           isSeed: n.id === neighborhood.seed_id,
-          ...(pinned ? { fx: pinned.x, fy: pinned.y } : {}),
         };
       });
     return {
@@ -78,6 +82,7 @@ export function GraphViz({
         source: e.source,
         target: e.target,
         predicate: e.predicate,
+        weight: e.weight ?? e.evidence_count ?? 1,
       })),
     };
   }, [neighborhood, hiddenPredicates, hiddenTypes, focusedId]);
@@ -96,31 +101,45 @@ export function GraphViz({
   }, [gData]);
 
   const hoverNeighbors = hoverId !== null ? adjacency.get(hoverId) : null;
+  const labelledHubIds = useMemo(() => {
+    const labelBudget = Math.min(12, Math.max(4, Math.ceil(Math.sqrt(gData.nodes.length))));
+    const ranked = [...gData.nodes].sort(
+      (a: any, b: any) => b.degree - a.degree || a.id - b.id
+    );
+    const medianDegree = ranked.length
+      ? ranked[Math.floor(ranked.length / 2)].degree
+      : Infinity;
+    return new Set(
+      ranked
+        .filter((node: any) => node.degree > medianDegree)
+        .slice(0, labelBudget)
+        .map((node: any) => node.id)
+    );
+  }, [gData.nodes]);
 
   useEffect(() => {
     const fg = fgRef.current;
     if (!fg) return;
-    fg.d3Force('charge')?.strength(-110).distanceMax(280);
-    fg.d3Force('link')?.distance((l: any) => (l.predicate === 'co_occurs_with' ? 62 : 44));
-    fg.d3Force('collide', forceCollide((n: any) => nodeRadius(n.degree) + 4));
+    const nodeCount = Math.max(gData.nodes.length, 1);
+    const chargeStrength = -Math.max(24, 92 - Math.log2(nodeCount) * 7);
+    fg.d3Force('charge')?.strength(chargeStrength).distanceMax(nodeCount > 300 ? 150 : 240);
+    fg.d3Force('link')
+      ?.distance((l: any) => (l.predicate === 'co_occurs_with' ? 28 : 38))
+      .strength((l: any) => Math.min(0.35, 0.08 + Math.log2((l.weight ?? 1) + 1) * 0.04));
+    fg.d3Force('collide', forceCollide((n: any) => nodeRadius(n.degree) + 1.5).strength(0.65));
+    didInitialFit.current = false;
+    if (!pausedRef.current) fg.d3ReheatSimulation();
   }, [gData]);
 
-  // Pin positions after the first settle so expansions don't re-layout
-  // everything, then frame the graph once.
   const handleEngineStop = useCallback(() => {
     const fg = fgRef.current;
     if (!fg) return;
-    const nodes: any[] = fg.graphData?.().nodes || [];
-    nodes.forEach(n => {
-      if (typeof n.x === 'number' && typeof n.y === 'number') {
-        pinnedRef.current.set(n.id, { x: n.x, y: n.y });
-      }
-    });
     if (!didInitialFit.current) {
       didInitialFit.current = true;
       fg.zoomToFit(reducedMotion ? 0 : 500, 60);
       if (reducedMotion) {
         fg.pauseAnimation();
+        pausedRef.current = true;
         setPaused(true);
       }
     }
@@ -164,7 +183,7 @@ export function GraphViz({
 
     // Labels: hubs always, everything when zoomed in or highlighted.
     const showLabel = !dimmed && (
-      emphasized || r * globalScale > 10 || globalScale > 2.4
+      emphasized || labelledHubIds.has(node.id) || globalScale > 3.2
     );
     if (showLabel) {
       const fontSize = Math.max(11 / globalScale, 2.4);
@@ -188,7 +207,7 @@ export function GraphViz({
       }
     }
     ctx.globalAlpha = 1;
-  }, [hoverId, focusedId, expandingId, isDimmed]);
+  }, [hoverId, focusedId, expandingId, isDimmed, labelledHubIds]);
 
   const paintPointerArea = useCallback((node: any, color: string, ctx: CanvasRenderingContext2D) => {
     ctx.fillStyle = color;
@@ -204,22 +223,27 @@ export function GraphViz({
       if (s === hoverId || t === hoverId) return 'rgba(56, 189, 248, 0.55)';
       return 'rgba(148, 163, 184, 0.04)';
     }
+    const evidence = Math.min(1, Math.log2((link.weight ?? 1) + 1) / 5);
     return link.predicate === 'co_occurs_with'
-      ? 'rgba(148, 163, 184, 0.08)'
-      : 'rgba(148, 163, 184, 0.18)';
+      ? `rgba(100, 116, 139, ${0.035 + evidence * 0.055})`
+      : `rgba(148, 163, 184, ${0.12 + evidence * 0.16})`;
   }, [hoverId]);
 
   const linkWidth = useCallback((link: any) => {
     const s = typeof link.source === 'object' ? link.source.id : link.source;
     const t = typeof link.target === 'object' ? link.target.id : link.target;
-    return hoverId !== null && (s === hoverId || t === hoverId) ? 1.4 : 0.6;
+    if (hoverId !== null && (s === hoverId || t === hoverId)) return 1.5;
+    const evidenceWidth = Math.min(1.8, Math.log2((link.weight ?? 1) + 1) * 0.3);
+    return link.predicate === 'co_occurs_with' ? 0.35 + evidenceWidth * 0.3 : 0.55 + evidenceWidth;
   }, [hoverId]);
 
   const togglePause = () => {
     const fg = fgRef.current;
     if (!fg) return;
-    if (paused) fg.resumeAnimation(); else fg.pauseAnimation();
-    setPaused(!paused);
+    const nextPaused = !pausedRef.current;
+    if (nextPaused) fg.pauseAnimation(); else fg.resumeAnimation();
+    pausedRef.current = nextPaused;
+    setPaused(nextPaused);
   };
 
   const zoomBy = (factor: number) => {
@@ -253,7 +277,8 @@ export function GraphViz({
           }}
           onBackgroundClick={() => setHoverId(null)}
           onEngineStop={handleEngineStop}
-          cooldownTicks={120}
+          warmupTicks={gData.nodes.length > 300 ? 35 : 20}
+          cooldownTicks={gData.nodes.length > 300 ? 220 : 140}
         />
       )}
       <div className="absolute top-4 left-4 flex gap-2 pointer-events-none">

--- a/marm-console/artifacts/marm-console/src/components/knowledge/GraphViz.tsx
+++ b/marm-console/artifacts/marm-console/src/components/knowledge/GraphViz.tsx
@@ -58,14 +58,16 @@ export function GraphViz({
     const visibleEdges = neighborhood.edges.filter(
       e => !hiddenPredicates.has(e.predicate) && visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target)
     );
-    // Filtering edges out must not leave stranded dots: keep only nodes that
-    // still connect to something, plus the seed and the focused node.
+    // Focused neighborhoods omit stranded nodes, but the atlas must retain
+    // isolated entities returned by its overview contract.
     const connected = new Set<number>();
     visibleEdges.forEach(e => { connected.add(e.source); connected.add(e.target); });
     if (neighborhood.seed_id !== null) connected.add(neighborhood.seed_id);
     if (focusedId !== null) connected.add(focusedId);
     const nodes = neighborhood.nodes
-      .filter(n => visibleNodeIds.has(n.id) && connected.has(n.id))
+      .filter(n => visibleNodeIds.has(n.id) && (
+        neighborhood.seed_id === null || connected.has(n.id)
+      ))
       .map((n) => {
         return {
           id: n.id,

--- a/marm-console/artifacts/marm-console/src/components/knowledge/shared.tsx
+++ b/marm-console/artifacts/marm-console/src/components/knowledge/shared.tsx
@@ -1,6 +1,6 @@
 import type { Neighborhood, NeighborhoodNode, NeighborhoodEdge } from '@/lib/marm-types';
 
-export const DEFAULT_HIDDEN_PREDICATES = new Set(['co_occurs_with']);
+export const DEFAULT_HIDDEN_PREDICATES = new Set<string>();
 
 // CVD-validated categorical palette for the dark canvas (dataviz six-checks,
 // surface #040810). Identity is never color alone: labels + legend back it up.

--- a/marm-console/artifacts/marm-console/src/hooks/use-marm-queries.ts
+++ b/marm-console/artifacts/marm-console/src/hooks/use-marm-queries.ts
@@ -19,7 +19,7 @@ export const queryKeys = {
   summary: (baseUrl: string, session: string) => ['summary', baseUrl, session],
   compaction: (baseUrl: string) => ['compaction', baseUrl],
   conceptsSummary: (baseUrl: string) => ['conceptsSummary', baseUrl],
-  conceptsGraph: (baseUrl: string, params?: { limit?: number }) => ['conceptsGraph', baseUrl, params],
+  conceptsGraph: (baseUrl: string) => ['conceptsGraph', baseUrl],
   conceptsSearch: (baseUrl: string, params?: ConceptSearchParams) => ['conceptsSearch', baseUrl, params],
   concept: (baseUrl: string, id: number) => ['concept', baseUrl, id],
   neighborhood: (baseUrl: string, id: number, params?: any) => ['neighborhood', baseUrl, id, params],
@@ -283,11 +283,11 @@ export function useSearchConcepts(params?: ConceptSearchParams) {
   return useQuery({ queryKey: queryKeys.conceptsSearch(baseUrl, params), queryFn: () => client.searchConcepts(params) });
 }
 
-export function useConceptGraph(params?: { limit?: number }, enabled = true) {
+export function useConceptGraph(enabled = true) {
   const { baseUrl, client } = useMarmConfig();
   return useQuery({
-    queryKey: queryKeys.conceptsGraph(baseUrl, params),
-    queryFn: () => client.getConceptGraph(params),
+    queryKey: queryKeys.conceptsGraph(baseUrl),
+    queryFn: client.getConceptGraph,
     enabled,
   });
 }

--- a/marm-console/artifacts/marm-console/src/lib/marm-api.ts
+++ b/marm-console/artifacts/marm-console/src/lib/marm-api.ts
@@ -12,6 +12,7 @@ import type {
   CompactionCandidate,
   ConceptBuildInput,
   ConceptBuildRun,
+  ConceptAtlas,
   ConceptDetail,
   ConceptEntity,
   ConceptSearchParams,
@@ -201,8 +202,8 @@ export function createMarmClient(config: MarmClientConfig) {
       request<ConceptEntity[]>(config, 'GET', '/concepts/search', { query: params }),
     getConcept: (entityId: number) =>
       request<ConceptDetail>(config, 'GET', `/concepts/${entityId}`),
-    getConceptGraph: (params?: { limit?: number }) =>
-      request<Neighborhood>(config, 'GET', '/concepts/graph', { query: params }),
+    getConceptGraph: () =>
+      request<ConceptAtlas>(config, 'GET', '/concepts/graph'),
     getConceptNeighborhood: (
       entityId: number,
       params?: { depth?: number; direction?: string; predicate?: string },

--- a/marm-console/artifacts/marm-console/src/lib/marm-types.ts
+++ b/marm-console/artifacts/marm-console/src/lib/marm-types.ts
@@ -216,6 +216,7 @@ export interface ConceptsSummary {
   by_type: { type: string; count: number }[];
   by_project: { project: string; count: number }[];
   recent_builds: ConceptBuildRun[];
+  schema_status?: 'current' | 'rebuild_required' | 'unavailable';
 }
 
 export interface ConceptEntity {
@@ -224,6 +225,7 @@ export interface ConceptEntity {
   type: string;
   session_name: string | null;
   project: string | null;
+  platform: string | null;
   mention_count: number;
   degree: number;
   created_at: string;
@@ -269,6 +271,8 @@ export interface NeighborhoodEdge {
   target: number;
   predicate: string;
   memory_id: string | null;
+  weight?: number;
+  evidence_count?: number;
 }
 
 export interface Neighborhood {
@@ -277,6 +281,14 @@ export interface Neighborhood {
   edges: NeighborhoodEdge[];
   limits: { nodes: number; edges: number };
   truncated: boolean;
+}
+
+export interface ConceptAtlas extends Neighborhood {
+  mode: 'full' | 'sampled';
+  schema_status: 'current' | 'rebuild_required' | 'unavailable';
+  total: { nodes: number; edges: number };
+  rendered: { nodes: number; edges: number };
+  sample_reason: string | null;
 }
 
 export interface DuplicateCandidate {

--- a/marm-console/server/concept_store.py
+++ b/marm-console/server/concept_store.py
@@ -13,6 +13,7 @@ FULL_ATLAS_MAX_NODES = 750
 FULL_ATLAS_MAX_EDGES = 6000
 SAMPLED_ATLAS_MAX_NODES = 600
 SAMPLED_ATLAS_MAX_EDGES = 4000
+SAMPLED_ATLAS_RAW_EDGE_LIMIT = 12000
 _CURRENT_CONCEPT_SCHEMA_VERSION = "2"
 
 
@@ -445,17 +446,47 @@ def graph_overview(db_path: Path) -> dict:
         total_edges = connection.execute(
             "SELECT COUNT(*) FROM relationships"
         ).fetchone()[0]
-        node_rows = connection.execute("""
+        mode = (
+            "full"
+            if total_nodes <= FULL_ATLAS_MAX_NODES
+            and total_edges <= FULL_ATLAS_MAX_EDGES
+            else "sampled"
+        )
+        node_query = """
             SELECT e.id, e.name, e.type, e.session_name, e.project, e.platform,
                    e.source_memory_ids, e.created_at,
                    (SELECT COUNT(*) FROM relationships r WHERE r.source_id = e.id OR r.target_id = e.id) AS degree
             FROM entities e
-            ORDER BY e.id
-            """).fetchall()
-        raw_edges = connection.execute(
-            """SELECT id, source_id, target_id, predicate, memory_id
-               FROM relationships ORDER BY id"""
-        ).fetchall()
+        """
+        if mode == "full":
+            node_rows = connection.execute(node_query + " ORDER BY e.id").fetchall()
+            raw_edges = connection.execute(
+                """SELECT id, source_id, target_id, predicate, memory_id
+                   FROM relationships ORDER BY id"""
+            ).fetchall()
+        else:
+            node_rows = connection.execute(
+                node_query + " ORDER BY degree DESC, e.id LIMIT ?",
+                (SAMPLED_ATLAS_MAX_NODES,),
+            ).fetchall()
+            raw_edges = connection.execute(
+                """WITH candidates AS (
+                       SELECT e.id
+                       FROM entities e
+                       ORDER BY (
+                           SELECT COUNT(*) FROM relationships r
+                           WHERE r.source_id = e.id OR r.target_id = e.id
+                       ) DESC, e.id
+                       LIMIT ?
+                   )
+                   SELECT id, source_id, target_id, predicate, memory_id
+                   FROM relationships
+                   WHERE source_id IN (SELECT id FROM candidates)
+                     AND target_id IN (SELECT id FROM candidates)
+                   ORDER BY id
+                   LIMIT ?""",
+                (SAMPLED_ATLAS_MAX_NODES, SAMPLED_ATLAS_RAW_EDGE_LIMIT),
+            ).fetchall()
 
     edge_groups: dict[tuple[int, int, str], dict] = {}
     for row in raw_edges:
@@ -475,11 +506,6 @@ def graph_overview(db_path: Path) -> dict:
         group["weight"] += 1
         group["evidence_count"] += 1
 
-    mode = (
-        "full"
-        if total_nodes <= FULL_ATLAS_MAX_NODES and total_edges <= FULL_ATLAS_MAX_EDGES
-        else "sampled"
-    )
     selected_ids = {row["id"] for row in node_rows}
     selected_edge_keys = set(edge_groups)
     limits = {"nodes": FULL_ATLAS_MAX_NODES, "edges": FULL_ATLAS_MAX_EDGES}

--- a/marm-console/server/concept_store.py
+++ b/marm-console/server/concept_store.py
@@ -5,8 +5,15 @@ from __future__ import annotations
 import json
 import sqlite3
 from array import array
+from collections import deque
 from math import sqrt
 from pathlib import Path
+
+FULL_ATLAS_MAX_NODES = 750
+FULL_ATLAS_MAX_EDGES = 6000
+SAMPLED_ATLAS_MAX_NODES = 600
+SAMPLED_ATLAS_MAX_EDGES = 4000
+_CURRENT_CONCEPT_SCHEMA_VERSION = "2"
 
 
 def _connect(db_path: Path) -> sqlite3.Connection | None:
@@ -17,11 +24,50 @@ def _connect(db_path: Path) -> sqlite3.Connection | None:
     return connection
 
 
+def _schema_status(connection: sqlite3.Connection) -> str:
+    try:
+        tables = {
+            row["name"]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        if "entities" not in tables or "relationships" not in tables:
+            return "rebuild_required"
+        entity_columns = {
+            row["name"] for row in connection.execute("PRAGMA table_info(entities)")
+        }
+        relationship_columns = {
+            row["name"]
+            for row in connection.execute("PRAGMA table_info(relationships)")
+        }
+        if "platform" not in entity_columns or "platform" not in relationship_columns:
+            return "rebuild_required"
+        if "concept_schema_metadata" not in tables:
+            return "rebuild_required"
+        row = connection.execute(
+            "SELECT value FROM concept_schema_metadata WHERE key = 'schema_version'"
+        ).fetchone()
+        return (
+            "current"
+            if row is not None and row["value"] == _CURRENT_CONCEPT_SCHEMA_VERSION
+            else "rebuild_required"
+        )
+    except sqlite3.Error:
+        return "unavailable"
+
+
 def summary(db_path: Path) -> dict:
     connection = _connect(db_path)
     if connection is None:
         return _empty_summary()
     with connection:
+        schema_status = _schema_status(connection)
+        if schema_status != "current":
+            return {
+                **_empty_summary(),
+                "schema_status": schema_status,
+            }
         entity_count = connection.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
         relationship_count = connection.execute(
             "SELECT COUNT(*) FROM relationships"
@@ -50,6 +96,7 @@ def summary(db_path: Path) -> dict:
         "by_type": by_type,
         "by_project": by_project,
         "recent_builds": [],
+        "schema_status": schema_status,
     }
 
 
@@ -64,6 +111,8 @@ def search(
 ) -> list[dict]:
     connection = _connect(db_path)
     if connection is None:
+        return []
+    if _schema_status(connection) != "current":
         return []
     clauses: list[str] = []
     params: list[object] = []
@@ -84,7 +133,8 @@ def search(
     with connection:
         rows = connection.execute(
             f"""
-            SELECT e.id, e.name, e.type, e.session_name, e.project, e.source_memory_ids, e.created_at,
+            SELECT e.id, e.name, e.type, e.session_name, e.project, e.platform,
+                   e.source_memory_ids, e.created_at,
                    (SELECT COUNT(*) FROM relationships r WHERE r.source_id = e.id OR r.target_id = e.id) AS degree
             FROM entities e{where}
             ORDER BY degree DESC, e.name COLLATE NOCASE
@@ -104,6 +154,8 @@ def neighborhood(
 ) -> dict | None:
     connection = _connect(db_path)
     if connection is None:
+        return None
+    if _schema_status(connection) != "current":
         return None
     depth = min(max(depth, 1), 3)
     with connection:
@@ -166,7 +218,8 @@ def neighborhood(
         placeholders = ",".join("?" for _ in ids)
         node_rows = connection.execute(
             f"""
-            SELECT e.id, e.name, e.type, e.session_name, e.project, e.source_memory_ids, e.created_at,
+            SELECT e.id, e.name, e.type, e.session_name, e.project, e.platform,
+                   e.source_memory_ids, e.created_at,
                    (SELECT COUNT(*) FROM relationships r WHERE r.source_id = e.id OR r.target_id = e.id) AS degree
             FROM entities e WHERE e.id IN ({placeholders})
             """,
@@ -221,10 +274,13 @@ def get_entity(db_path: Path, entity_id: int) -> dict | None:
     connection = _connect(db_path)
     if connection is None:
         return None
+    if _schema_status(connection) != "current":
+        return None
     with connection:
         row = connection.execute(
             """
-            SELECT e.id, e.name, e.type, e.session_name, e.project, e.source_memory_ids,
+            SELECT e.id, e.name, e.type, e.session_name, e.project, e.platform,
+                   e.source_memory_ids,
                    e.created_at,
                    (SELECT COUNT(*) FROM relationships r
                     WHERE r.source_id = e.id OR r.target_id = e.id) AS degree
@@ -260,6 +316,8 @@ def get_entity(db_path: Path, entity_id: int) -> dict | None:
 def build_runs(db_path: Path, limit: int = 20) -> list[dict]:
     connection = _connect(db_path)
     if connection is None:
+        return []
+    if _schema_status(connection) != "current":
         return []
     try:
         with connection:
@@ -300,11 +358,13 @@ def duplicates(db_path: Path, limit: int = 100, threshold: float = 0.88) -> list
     connection = _connect(db_path)
     if connection is None:
         return []
+    if _schema_status(connection) != "current":
+        return []
     try:
         with connection:
-            rows = connection.execute(
-                """
-                SELECT e.id, e.name, e.type, e.session_name, e.project, e.source_memory_ids,
+            rows = connection.execute("""
+                SELECT e.id, e.name, e.type, e.session_name, e.project, e.platform,
+                       e.source_memory_ids,
                        e.created_at, e.name_embedding,
                        (SELECT COUNT(*) FROM relationships r
                         WHERE r.source_id = e.id OR r.target_id = e.id) AS degree
@@ -312,14 +372,15 @@ def duplicates(db_path: Path, limit: int = 100, threshold: float = 0.88) -> list
                 WHERE e.name_embedding IS NOT NULL
                 ORDER BY degree DESC, e.id
                 LIMIT 300
-                """
-            ).fetchall()
+                """).fetchall()
     except sqlite3.OperationalError:
         return []
 
-    groups: dict[tuple[str | None, str | None], list[sqlite3.Row]] = {}
+    groups: dict[tuple[str | None, str | None, str | None], list[sqlite3.Row]] = {}
     for row in rows:
-        groups.setdefault((row["session_name"], row["project"]), []).append(row)
+        groups.setdefault(
+            (row["session_name"], row["project"], row["platform"]), []
+        ).append(row)
 
     candidates: list[dict] = []
     for scoped_rows in groups.values():
@@ -343,49 +404,176 @@ def duplicates(db_path: Path, limit: int = 100, threshold: float = 0.88) -> list
     return candidates[: min(max(limit, 1), 100)]
 
 
-def graph_overview(db_path: Path, limit_nodes: int = 150) -> dict:
-    """The most-connected slice of the whole graph: top-N entities by degree
-    plus every relationship among them. Landing view for the Knowledge page."""
+def graph_overview(db_path: Path) -> dict:
+    """Return the complete visual graph when safe, else a connected sample."""
     connection = _connect(db_path)
     if connection is None:
         return {
+            "mode": "full",
+            "schema_status": "unavailable",
+            "total": {"nodes": 0, "edges": 0},
+            "rendered": {"nodes": 0, "edges": 0},
+            "sample_reason": None,
             "seed_id": None,
             "nodes": [],
             "edges": [],
-            "limits": {"nodes": limit_nodes, "edges": 600},
+            "limits": {
+                "nodes": FULL_ATLAS_MAX_NODES,
+                "edges": FULL_ATLAS_MAX_EDGES,
+            },
             "truncated": False,
         }
-    limit_nodes = min(max(limit_nodes, 10), 300)
     with connection:
-        node_rows = connection.execute(
-            """
-            SELECT e.id, e.name, e.type, e.session_name, e.project, e.source_memory_ids, e.created_at,
+        schema_status = _schema_status(connection)
+        if schema_status != "current":
+            return {
+                "mode": "full",
+                "schema_status": schema_status,
+                "total": {"nodes": 0, "edges": 0},
+                "rendered": {"nodes": 0, "edges": 0},
+                "sample_reason": "platform-aware concept rebuild required",
+                "seed_id": None,
+                "nodes": [],
+                "edges": [],
+                "limits": {
+                    "nodes": FULL_ATLAS_MAX_NODES,
+                    "edges": FULL_ATLAS_MAX_EDGES,
+                },
+                "truncated": False,
+            }
+        total_nodes = connection.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+        total_edges = connection.execute(
+            "SELECT COUNT(*) FROM relationships"
+        ).fetchone()[0]
+        node_rows = connection.execute("""
+            SELECT e.id, e.name, e.type, e.session_name, e.project, e.platform,
+                   e.source_memory_ids, e.created_at,
                    (SELECT COUNT(*) FROM relationships r WHERE r.source_id = e.id OR r.target_id = e.id) AS degree
             FROM entities e
-            ORDER BY degree DESC, e.name COLLATE NOCASE
-            LIMIT ?
-            """,
-            (limit_nodes,),
+            ORDER BY e.id
+            """).fetchall()
+        raw_edges = connection.execute(
+            """SELECT id, source_id, target_id, predicate, memory_id
+               FROM relationships ORDER BY id"""
         ).fetchall()
-        ids = [row["id"] for row in node_rows]
-        edge_rows: list[sqlite3.Row] = []
-        if ids:
-            placeholders = ",".join("?" for _ in ids)
-            # Deterministic order, typed predicates ahead of co-occurrence,
-            # so truncation always drops the lowest-value edges first.
-            edge_rows = connection.execute(
-                f"""SELECT id, source_id, target_id, predicate, memory_id
-                    FROM relationships
-                    WHERE source_id IN ({placeholders}) AND target_id IN ({placeholders})
-                    ORDER BY CASE WHEN predicate = 'co_occurs_with' THEN 1 ELSE 0 END, id
-                    LIMIT 600""",
-                [*ids, *ids],
-            ).fetchall()
+
+    edge_groups: dict[tuple[int, int, str], dict] = {}
+    for row in raw_edges:
+        key = (row["source_id"], row["target_id"], row["predicate"])
+        group = edge_groups.setdefault(
+            key,
+            {
+                "id": row["id"],
+                "source": row["source_id"],
+                "target": row["target_id"],
+                "predicate": row["predicate"],
+                "memory_id": row["memory_id"],
+                "weight": 0,
+                "evidence_count": 0,
+            },
+        )
+        group["weight"] += 1
+        group["evidence_count"] += 1
+
+    mode = (
+        "full"
+        if total_nodes <= FULL_ATLAS_MAX_NODES and total_edges <= FULL_ATLAS_MAX_EDGES
+        else "sampled"
+    )
+    selected_ids = {row["id"] for row in node_rows}
+    selected_edge_keys = set(edge_groups)
+    limits = {"nodes": FULL_ATLAS_MAX_NODES, "edges": FULL_ATLAS_MAX_EDGES}
+    sample_reason = None
+
+    if mode == "sampled":
+        limits = {
+            "nodes": SAMPLED_ATLAS_MAX_NODES,
+            "edges": SAMPLED_ATLAS_MAX_EDGES,
+        }
+        sample_reason = (
+            f"graph exceeds full atlas budget ({FULL_ATLAS_MAX_NODES} nodes / "
+            f"{FULL_ATLAS_MAX_EDGES} relationships)"
+        )
+        degrees = {row["id"]: row["degree"] for row in node_rows}
+        adjacency: dict[int, list[tuple[int, tuple[int, int, str], int]]] = {}
+        for key, edge in edge_groups.items():
+            source, target, _ = key
+            adjacency.setdefault(source, []).append((target, key, edge["weight"]))
+            adjacency.setdefault(target, []).append((source, key, edge["weight"]))
+
+        selected_ids = set()
+        tree_edge_keys: list[tuple[int, int, str]] = []
+        ranked_nodes = sorted(degrees, key=lambda node_id: (-degrees[node_id], node_id))
+        for root in ranked_nodes:
+            if len(selected_ids) >= SAMPLED_ATLAS_MAX_NODES:
+                break
+            if root in selected_ids:
+                continue
+            selected_ids.add(root)
+            frontier = deque([root])
+            while frontier and len(selected_ids) < SAMPLED_ATLAS_MAX_NODES:
+                current = frontier.popleft()
+                neighbors = sorted(
+                    adjacency.get(current, []),
+                    key=lambda item: (
+                        -item[2],
+                        -degrees.get(item[0], 0),
+                        item[0],
+                        item[1],
+                    ),
+                )
+                for neighbor, edge_key, _ in neighbors:
+                    if neighbor in selected_ids:
+                        continue
+                    selected_ids.add(neighbor)
+                    tree_edge_keys.append(edge_key)
+                    frontier.append(neighbor)
+                    if len(selected_ids) >= SAMPLED_ATLAS_MAX_NODES:
+                        break
+
+        induced_keys = [
+            key
+            for key in edge_groups
+            if key[0] in selected_ids and key[1] in selected_ids
+        ]
+        tree_set = set(tree_edge_keys)
+        induced_keys.sort(
+            key=lambda key: (
+                0 if key in tree_set else 1,
+                1 if key[2] == "co_occurs_with" else 0,
+                -edge_groups[key]["weight"],
+                key,
+            )
+        )
+        selected_edge_keys = set(induced_keys[:SAMPLED_ATLAS_MAX_EDGES])
+
+    selected_nodes = [row for row in node_rows if row["id"] in selected_ids]
+    selected_edges = [
+        edge_groups[key]
+        for key in sorted(
+            selected_edge_keys,
+            key=lambda key: (
+                1 if key[2] == "co_occurs_with" else 0,
+                -edge_groups[key]["weight"],
+                key,
+            ),
+        )
+    ]
     included_edge_count: dict[int, int] = {}
-    for edge in edge_rows:
-        for endpoint in (edge["source_id"], edge["target_id"]):
-            included_edge_count[endpoint] = included_edge_count.get(endpoint, 0) + 1
+    for edge in selected_edges:
+        included_edge_count[edge["source"]] = (
+            included_edge_count.get(edge["source"], 0) + edge["weight"]
+        )
+        included_edge_count[edge["target"]] = (
+            included_edge_count.get(edge["target"], 0) + edge["weight"]
+        )
+
     return {
+        "mode": mode,
+        "schema_status": schema_status,
+        "total": {"nodes": total_nodes, "edges": total_edges},
+        "rendered": {"nodes": len(selected_nodes), "edges": len(selected_edges)},
+        "sample_reason": sample_reason,
         "seed_id": None,
         "nodes": [
             {
@@ -395,20 +583,11 @@ def graph_overview(db_path: Path, limit_nodes: int = 150) -> dict:
                 ),
                 "linked_code": [],
             }
-            for row in node_rows
+            for row in selected_nodes
         ],
-        "edges": [
-            {
-                "id": row["id"],
-                "source": row["source_id"],
-                "target": row["target_id"],
-                "predicate": row["predicate"],
-                "memory_id": row["memory_id"],
-            }
-            for row in edge_rows
-        ],
-        "limits": {"nodes": limit_nodes, "edges": 600},
-        "truncated": len(edge_rows) >= 600,
+        "edges": selected_edges,
+        "limits": limits,
+        "truncated": mode == "sampled",
     }
 
 
@@ -420,6 +599,7 @@ def _entity(row: sqlite3.Row) -> dict:
         "type": row["type"],
         "session_name": row["session_name"],
         "project": row["project"],
+        "platform": row["platform"] if "platform" in row.keys() else None,
         "mention_count": len(source_ids),
         "degree": row["degree"],
         "created_at": row["created_at"],
@@ -465,4 +645,5 @@ def _empty_summary() -> dict:
         "by_type": [],
         "by_project": [],
         "recent_builds": [],
+        "schema_status": "unavailable",
     }

--- a/marm-console/server/endpoints/concepts.py
+++ b/marm-console/server/endpoints/concepts.py
@@ -75,8 +75,8 @@ def search_concepts(
 
 
 @router.get("/api/concepts/graph")
-def get_concept_graph(limit: int = Query(150, ge=10, le=300)) -> dict:
-    return concept_store.graph_overview(get_concept_db_path(), limit_nodes=limit)
+def get_concept_graph() -> dict:
+    return concept_store.graph_overview(get_concept_db_path())
 
 
 @router.get("/api/concepts/{entity_id}")

--- a/marm-console/tests/test_concept_store.py
+++ b/marm-console/tests/test_concept_store.py
@@ -5,10 +5,25 @@ import sqlite3
 from array import array
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import re
 
 
 from server import concept_store
 from server.endpoints import concepts as concepts_endpoint
+
+
+def test_console_schema_version_tracks_mcp_source() -> None:
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "marm-mcp-server"
+        / "marm_mcp_server"
+        / "core"
+        / "concept_db.py"
+    ).read_text(encoding="utf-8")
+    match = re.search(r"CONCEPT_SCHEMA_VERSION = (\d+)", source)
+
+    assert match is not None
+    assert concept_store._CURRENT_CONCEPT_SCHEMA_VERSION == match.group(1)
 
 
 def make_db(tmp_path: Path) -> Path:
@@ -281,6 +296,23 @@ def test_graph_overview_samples_deterministically_and_keeps_connections(
         for endpoint in (edge["source"], edge["target"])
     }
     assert connected_ids == selected_ids
+
+
+def test_graph_overview_bounds_sampled_raw_edge_candidates(tmp_path, monkeypatch):
+    monkeypatch.setattr(concept_store, "FULL_ATLAS_MAX_NODES", 3)
+    monkeypatch.setattr(concept_store, "FULL_ATLAS_MAX_EDGES", 3)
+    monkeypatch.setattr(concept_store, "SAMPLED_ATLAS_MAX_NODES", 4)
+    monkeypatch.setattr(concept_store, "SAMPLED_ATLAS_MAX_EDGES", 4)
+    monkeypatch.setattr(concept_store, "SAMPLED_ATLAS_RAW_EDGE_LIMIT", 2)
+    db = make_db(tmp_path)
+    entities = [add_entity(db, f"node-{index}") for index in range(4)]
+    for index in range(6):
+        add_edge(db, entities[index % 4], entities[(index + 1) % 4], f"uses-{index}")
+
+    result = concept_store.graph_overview(db)
+
+    assert result["mode"] == "sampled"
+    assert len(result["edges"]) <= 2
 
 
 def test_graph_overview_marks_platformless_schema_for_rebuild(tmp_path):

--- a/marm-console/tests/test_concept_store.py
+++ b/marm-console/tests/test_concept_store.py
@@ -22,10 +22,11 @@ def make_db(tmp_path: Path) -> Path:
             type TEXT NOT NULL,
             session_name TEXT,
             project TEXT,
+            platform TEXT,
             source_memory_ids TEXT DEFAULT '[]',
             name_embedding BLOB,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-            UNIQUE(name, session_name, project)
+            UNIQUE(name, session_name, project, platform)
         );
         CREATE TABLE relationships (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -34,6 +35,7 @@ def make_db(tmp_path: Path) -> Path:
             predicate TEXT NOT NULL,
             memory_id TEXT,
             project TEXT,
+            platform TEXT,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY(source_id) REFERENCES entities(id),
             FOREIGN KEY(target_id) REFERENCES entities(id)
@@ -64,6 +66,12 @@ def make_db(tmp_path: Path) -> Path:
             started_at TEXT,
             finished_at TEXT
         );
+        CREATE TABLE concept_schema_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO concept_schema_metadata (key, value)
+        VALUES ('schema_version', '2');
         """
     )
     conn.commit()
@@ -99,6 +107,17 @@ def set_embedding(db_path: Path, entity_id: int, *values: float) -> None:
     )
     conn.commit()
     conn.close()
+
+
+def test_summary_reports_rebuild_for_existing_database_without_graph_schema(tmp_path):
+    db_path = tmp_path / "marm_index.db"
+    sqlite3.connect(db_path).close()
+
+    result = concept_store.summary(db_path)
+
+    assert result["schema_status"] == "rebuild_required"
+    assert result["entities"] == 0
+    assert result["relationships"] == 0
 
 
 def test_neighborhood_enforces_200_node_limit(tmp_path):
@@ -181,24 +200,25 @@ def test_neighborhood_hidden_neighbor_count_reflects_real_degree(tmp_path):
     assert by_id[a]["hidden_neighbor_count"] == 0
 
 
-def test_graph_overview_returns_top_degree_slice_with_real_hidden_counts(tmp_path):
+def test_graph_overview_returns_complete_graph_under_budget(tmp_path):
     db = make_db(tmp_path)
     hub = add_entity(db, "hub")
     spokes = [add_entity(db, f"spoke-{i}") for i in range(20)]
     for spoke in spokes:
         add_edge(db, hub, spoke, "uses")
-    # An isolated entity must never beat connected ones into the overview
     add_entity(db, "isolated")
 
-    result = concept_store.graph_overview(db, limit_nodes=10)
+    result = concept_store.graph_overview(db)
 
     node_ids = {n["id"] for n in result["nodes"]}
-    assert len(result["nodes"]) == 10
+    assert result["mode"] == "full"
+    assert len(result["nodes"]) == 22
     assert hub in node_ids
-    assert "isolated" not in {n["name"] for n in result["nodes"]}
+    assert "isolated" in {n["name"] for n in result["nodes"]}
     by_id = {n["id"]: n for n in result["nodes"]}
-    # hub keeps 9 spokes in a 10-node slice, so 11 of its 20 edges are hidden
-    assert by_id[hub]["hidden_neighbor_count"] == 11
+    assert by_id[hub]["hidden_neighbor_count"] == 0
+    assert result["total"] == {"nodes": 22, "edges": 20}
+    assert result["rendered"] == {"nodes": 22, "edges": 20}
     for edge in result["edges"]:
         assert edge["source"] in node_ids
         assert edge["target"] in node_ids
@@ -211,11 +231,75 @@ def test_graph_overview_is_deterministic_across_calls(tmp_path):
         predicate = "co_occurs_with" if i % 2 else "uses"
         add_edge(db, entities[i], entities[i + 1], predicate)
 
-    first = concept_store.graph_overview(db, limit_nodes=30)
-    second = concept_store.graph_overview(db, limit_nodes=30)
+    first = concept_store.graph_overview(db)
+    second = concept_store.graph_overview(db)
 
     assert [e["id"] for e in first["edges"]] == [e["id"] for e in second["edges"]]
     assert [n["id"] for n in first["nodes"]] == [n["id"] for n in second["nodes"]]
+
+
+def test_graph_overview_aggregates_visual_evidence(tmp_path):
+    db = make_db(tmp_path)
+    source = add_entity(db, "source")
+    target = add_entity(db, "target")
+    add_edge(db, source, target, "uses")
+    add_edge(db, source, target, "uses")
+
+    result = concept_store.graph_overview(db)
+
+    assert result["total"]["edges"] == 2
+    assert result["rendered"]["edges"] == 1
+    assert result["edges"][0]["weight"] == 2
+    assert result["edges"][0]["evidence_count"] == 2
+
+
+def test_graph_overview_samples_deterministically_and_keeps_connections(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(concept_store, "FULL_ATLAS_MAX_NODES", 5)
+    monkeypatch.setattr(concept_store, "FULL_ATLAS_MAX_EDGES", 5)
+    monkeypatch.setattr(concept_store, "SAMPLED_ATLAS_MAX_NODES", 6)
+    monkeypatch.setattr(concept_store, "SAMPLED_ATLAS_MAX_EDGES", 6)
+    db = make_db(tmp_path)
+    entities = [add_entity(db, f"node-{index}") for index in range(12)]
+    for source, target in zip(entities, entities[1:]):
+        add_edge(db, source, target, "uses")
+
+    first = concept_store.graph_overview(db)
+    second = concept_store.graph_overview(db)
+
+    assert first["mode"] == "sampled"
+    assert first["truncated"] is True
+    assert first["rendered"]["nodes"] == 6
+    assert [node["id"] for node in first["nodes"]] == [
+        node["id"] for node in second["nodes"]
+    ]
+    selected_ids = {node["id"] for node in first["nodes"]}
+    connected_ids = {
+        endpoint
+        for edge in first["edges"]
+        for endpoint in (edge["source"], edge["target"])
+    }
+    assert connected_ids == selected_ids
+
+
+def test_graph_overview_marks_platformless_schema_for_rebuild(tmp_path):
+    db = tmp_path / "legacy.db"
+    with sqlite3.connect(db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE entities (id INTEGER PRIMARY KEY, name TEXT, type TEXT);
+            CREATE TABLE relationships (
+                id INTEGER PRIMARY KEY, source_id INTEGER, target_id INTEGER,
+                predicate TEXT
+            );
+            """
+        )
+
+    result = concept_store.graph_overview(db)
+
+    assert result["schema_status"] == "rebuild_required"
+    assert result["nodes"] == []
 
 
 def test_missing_db_and_missing_seed_fail_safely(tmp_path):

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -30,6 +30,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
 
 - marm-console now ships as the local web app for memory, knowledge, projects, and MCP-backed memory mutation actions. Packaging and one-command startup polish are still in progress.
 - **Embedding upgrade:** v2.24 switches MARM to Jina v2 Small. Existing MiniLM data must be migrated before restart: stop MARM, run `marm-mcp-server --migrate-embeddings`, then restart. See [Upgrade Existing Embeddings](#upgrade-existing-embeddings).
+- **Concept graph rebuild:** the platform-aware graph schema requires one full rebuild. After upgrading, run `marm_concept_build(search_all=True)` once. MARM backs up and rebuilds only the derived concept database; memories are not modified.
 - I am waiting to get access back to my PYPI account, till restored pip will be behind a few versions. I will update the README when it is back up to date.
 
 
@@ -576,7 +577,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 | Tool | What it does | Key parameters |
 |------|--------------|----------------|
-| `marm_smart_recall` | Hybrid recall: exact lane for config keys, commands, and file paths; semantic rerank for natural-language queries | `query`, `limit`, `session_name`, `search_all`, `detail=1/2/3`, `project`, `platform`, `exact_mode` |
+| `marm_smart_recall` | Hybrid memory recall with an additive, bounded concept/code graph sidecar when a compatible graph exists | `query`, `limit`, `session_name`, `search_all`, `detail=1/2/3`, `project`, `platform`, `exact_mode` |
 | `marm_log_entry` | Add structured session log entries; each entry is also embedded into semantic memory so `marm_smart_recall` can find it | `entry`, `session_name` |
 | `marm_log_show` | Display all entries and sessions, with filtering | `session_name` |
 | `marm_delete` | Delete a log session, log entry, or notebook entry | `type`, `target`, `session_name`, `project`, `platform` |
@@ -599,7 +600,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 | Tool | What it does | Key parameters |
 |------|--------------|----------------|
 | `marm_concept_build` | Extract entities and typed relationships from stored memories | `session_name`, `project`, or `search_all=True` (one required) |
-| `marm_concept_recall` | Query entities, relationships, and linked code symbols | `query`, `depth` (1-5), `direction`, `project` |
+| `marm_concept_recall` | Explicitly query entities, relationships, and linked code symbols | `query`, `depth` (1-5), `direction`, `project`, `platform` |
 
 All 14 tools are available on both HTTP and STDIO. Behind the tool surface, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks automatically; none of those consume the agent's attention or tokens. The two graph engines start lazily on first use and never block the 7 core memory tools if they fail to start. See [Architecture & Internals](#architecture--internals) for the mechanisms.
 
@@ -767,7 +768,7 @@ Under the hood, the engine is [codebase-memory-mcp](https://github.com/DeusData/
 
 ### Concept Graph: what your memories are about
 
-MARM can extract a knowledge graph from the memories you've already stored. `marm_concept_build` runs entity and relationship extraction over stored memory content, producing typed entities (**concepts, decisions, patterns, errors, tools, people, organizations**) connected by typed relationships (**fixes, implements, depends_on, uses, causes, replaces, extends**). `marm_concept_recall` then answers questions like:
+MARM can extract a knowledge graph from the memories you've already stored. `marm_concept_build` runs entity and relationship extraction over stored memory content, producing typed entities (**concepts, decisions, patterns, errors, tools, people, organizations**) connected by typed relationships (**fixes, implements, depends_on, uses, causes, replaces, extends**). Once built, `marm_smart_recall` automatically adds bounded related entities, relationships, and linked code as a `graph_context` sidecar without changing primary memory ranking. `marm_concept_recall` remains available for explicit graph exploration:
 
 ```text
 marm_concept_recall(query="write queue")            → the entity, its relationships, linked code symbols
@@ -777,10 +778,13 @@ marm_concept_recall(query="related to SQLite", depth=3) → multi-hop traversal 
 How to use it:
 
 - **Build first**: call `marm_concept_build` scoped to a `session_name`, `project`, or `search_all=True`. There is no data until a build has run at least once. Builds are explicit and on-demand, not a live hook into the write path; re-run after logging significant new memories.
+- **Upgrade once**: graphs built before platform attribution require `marm_concept_build(search_all=True)`. A full build backs up and resets only the derived concept database; targeted builds refuse to guess platform ownership.
 - **Bounded by design**: each build is row-capped (`CONCEPT_BUILD_ROW_CAP`, default 500) so a huge store can't turn one tool call into a runaway job.
+- **Recall fails open**: a missing, empty, incompatible, or unavailable concept graph never blocks normal memory recall. The response reports graph status separately.
 - **Code cross-linking**: when the code graph has indexed the same project, concept entities that match code symbols get linked, connecting "what we decided" to "where it lives in the code."
 - **Optional dependency**: real extraction needs the `[concepts]` extra (`pip install marm-mcp-server[concepts]` plus `python -m spacy download en_core_web_sm`). Without it, both concept tools stay registered and return `entities_extracted: 0` instead of erroring. Base installs carry no spaCy dependency.
 - **Isolated storage**: the concept graph lives in its own SQLite database (`~/.marm/index/marm_index.db`) with its own connection pool, so concept-graph writes can never block or corrupt the production memory database.
+- **Console atlas**: MARM Console renders the complete atlas up to 750 entities and 6,000 stored relationships. Larger graphs use a deterministic connected sample of up to 600 entities and 4,000 aggregated visual edges, clearly labelled as sampled.
 
 This fills the cross-session structure gap that flat memory search leaves open: sessions organize memories, but the concept graph *connects* them, so "what depends on the write queue?" is answerable even when the answer spans five sessions from three different agents.
 

--- a/marm-mcp-server/marm-docs/PROTOCOL-LITE.md
+++ b/marm-mcp-server/marm-docs/PROTOCOL-LITE.md
@@ -27,6 +27,6 @@ You are under the MARM operating contract. The full protocol was delivered at se
 
 ## When to Act
 
-Log only what matters -- decisions, breakthroughs, completions. Use `marm_smart_recall` before starting work on a known topic. Use `marm_summary` at handoffs and end of sessions. Use `marm_notebook` for early ideas not ready to commit. Skip if the moment does not clearly fit.
+Log only what matters -- decisions, breakthroughs, completions. Use `marm_smart_recall` before starting work on a known topic; it includes bounded concept/code context when a compatible graph exists. Use `marm_summary` at handoffs and end of sessions. Use `marm_notebook` for early ideas not ready to commit. Skip if the moment does not clearly fit.
 
 Retrieve full protocol or any doc via `marm_smart_recall`.

--- a/marm-mcp-server/marm-docs/PROTOCOL.md
+++ b/marm-mcp-server/marm-docs/PROTOCOL.md
@@ -29,12 +29,12 @@ Execution Policy (adaptive):
 
 Tool Contract (versioned runtime):
 - Surface: 14 MCP tools: 7 core memory/logging/notebook/compaction tools, 5 bundled code-graph tools, and 2 bundled concept-graph tools.
-- Memory: `marm_smart_recall` (semantic retrieval, use `include_logs=True` when logs matter).
+- Memory: `marm_smart_recall` (hybrid retrieval plus bounded graph context when available; use `include_logs=True` when logs matter).
 - Session Logs: `marm_log_entry`, `marm_log_show`. Logged entries are also embedded into semantic memory, so `marm_smart_recall` finds them later.
 - Notebook: `marm_notebook(action="add"|"use"|"show"|"status"|"clear"|"save")`. Scratch entries are per-session; `action="save"` promotes one (or new inline content) into a permanent, concept-graph-linked doc.
 - Workflow: `marm_summary` (handoff/recap), `marm_delete` (explicit delete requests only), `marm_compaction` (agent-assisted memory cleanup).
 - Code Graph: `marm_graph_index`, `marm_code_lookup`, `marm_graph_trace`, `marm_graph_architecture`, `marm_graph_impact` for repo indexing, symbol/source lookup, call tracing, architecture overview, and change-impact checks. Graph starts lazily on first graph call.
-- Concept Graph: `marm_concept_build` (extract entities/relationships from stored memories), `marm_concept_recall` (query entities, relationships, and linked code symbols).
+- Concept Graph: `marm_concept_build` (extract platform-aware entities/relationships from stored memories), `marm_concept_recall` (explicit bounded graph exploration). Normal `marm_smart_recall` responses already include related graph context when a compatible graph exists; graph failures never block memory recall.
 - Session Routing: call `marm_log_entry` with `"Session: [name]"` or `"Topic: [name]"` to switch sessions. The backend auto-tags the date.
 - Lifecycle: protocol delivery, session initialization, documentation loading, and refresh are automatic; do not ask users to run legacy start/refresh/system commands.
 

--- a/marm-mcp-server/marm-docs/README.md
+++ b/marm-mcp-server/marm-docs/README.md
@@ -535,7 +535,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 
 | Tool | What it does | Key parameters |
 |------|--------------|----------------|
-| `marm_smart_recall` | Hybrid recall: exact lane for config keys, commands, and file paths; semantic rerank for natural-language queries | `query`, `limit`, `session_name`, `search_all`, `detail=1/2/3`, `project`, `platform`, `exact_mode` |
+| `marm_smart_recall` | Hybrid memory recall with an additive, bounded concept/code graph sidecar when a compatible graph exists | `query`, `limit`, `session_name`, `search_all`, `detail=1/2/3`, `project`, `platform`, `exact_mode` |
 | `marm_log_entry` | Add structured session log entries; each entry is also embedded into semantic memory so `marm_smart_recall` can find it | `entry`, `session_name` |
 | `marm_log_show` | Display all entries and sessions, with filtering | `session_name` |
 | `marm_delete` | Delete a log session, log entry, or notebook entry | `type`, `target`, `session_name`, `project`, `platform` |
@@ -558,7 +558,7 @@ The AI agent will automatically use the appropriate tools. Manual tool access is
 | Tool | What it does | Key parameters |
 |------|--------------|----------------|
 | `marm_concept_build` | Extract entities and typed relationships from stored memories | `session_name`, `project`, or `search_all=True` (one required) |
-| `marm_concept_recall` | Query entities, relationships, and linked code symbols | `query`, `depth` (1-5), `direction`, `project` |
+| `marm_concept_recall` | Explicitly query entities, relationships, and linked code symbols | `query`, `depth` (1-5), `direction`, `project`, `platform` |
 
 All 14 tools are available on both HTTP and STDIO. Behind the tool surface, the server handles lifecycle setup, protocol refresh, docs indexing, date context, summary-cache maintenance, write queue handling, project/platform attribution, and health checks automatically; none of those consume the agent's attention or tokens. The two graph engines start lazily on first use and never block the 7 core memory tools if they fail to start. See [Architecture & Internals](#architecture--internals) for the mechanisms.
 
@@ -726,7 +726,7 @@ Under the hood, the engine is [codebase-memory-mcp](https://github.com/DeusData/
 
 ### Concept Graph: what your memories are about
 
-MARM can extract a knowledge graph from the memories you've already stored. `marm_concept_build` runs entity and relationship extraction over stored memory content, producing typed entities (**concepts, decisions, patterns, errors, tools, people, organizations**) connected by typed relationships (**fixes, implements, depends_on, uses, causes, replaces, extends**). `marm_concept_recall` then answers questions like:
+MARM can extract a knowledge graph from the memories you've already stored. `marm_concept_build` runs entity and relationship extraction over stored memory content, producing typed entities (**concepts, decisions, patterns, errors, tools, people, organizations**) connected by typed relationships (**fixes, implements, depends_on, uses, causes, replaces, extends**). Once built, `marm_smart_recall` automatically adds bounded related entities, relationships, and linked code as a `graph_context` sidecar without changing primary memory ranking. `marm_concept_recall` remains available for explicit graph exploration:
 
 ```text
 marm_concept_recall(query="write queue")            → the entity, its relationships, linked code symbols
@@ -736,10 +736,13 @@ marm_concept_recall(query="related to SQLite", depth=3) → multi-hop traversal 
 How to use it:
 
 - **Build first**: call `marm_concept_build` scoped to a `session_name`, `project`, or `search_all=True`. There is no data until a build has run at least once. Builds are explicit and on-demand, not a live hook into the write path; re-run after logging significant new memories.
+- **Upgrade once**: graphs built before platform attribution require `marm_concept_build(search_all=True)`. A full build backs up and resets only the derived concept database; targeted builds refuse to guess platform ownership.
 - **Bounded by design**: each build is row-capped (`CONCEPT_BUILD_ROW_CAP`, default 500) so a huge store can't turn one tool call into a runaway job.
+- **Recall fails open**: a missing, empty, incompatible, or unavailable concept graph never blocks normal memory recall. The response reports graph status separately.
 - **Code cross-linking**: when the code graph has indexed the same project, concept entities that match code symbols get linked, connecting "what we decided" to "where it lives in the code."
 - **Optional dependency**: real extraction needs the `[concepts]` extra (`pip install marm-mcp-server[concepts]` plus `python -m spacy download en_core_web_sm`). Without it, both concept tools stay registered and return `entities_extracted: 0` instead of erroring. Base installs carry no spaCy dependency.
 - **Isolated storage**: the concept graph lives in its own SQLite database (`~/.marm/index/marm_index.db`) with its own connection pool, so concept-graph writes can never block or corrupt the production memory database.
+- **Console atlas**: MARM Console renders the complete atlas up to 750 entities and 6,000 stored relationships. Larger graphs use a deterministic connected sample of up to 600 entities and 4,000 aggregated visual edges, clearly labelled as sampled.
 
 This fills the cross-session structure gap that flat memory search leaves open: sessions organize memories, but the concept graph *connects* them, so "what depends on the write queue?" is answerable even when the answer spans five sessions from three different agents.
 

--- a/marm-mcp-server/marm_mcp_server/core/concept_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/concept_db.py
@@ -10,6 +10,8 @@ production-critical memories table's WAL.
 import json
 import os
 import sqlite3
+from contextlib import closing
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -19,6 +21,8 @@ from .memory_db import ConnectionContext, SQLiteConnectionPool
 from .memory_utils import _safe_print
 
 MAX_CONCEPT_DB_CONNECTIONS = 3
+CONCEPT_SCHEMA_VERSION = 2
+_SCHEMA_VERSION_KEY = "schema_version"
 
 
 def get_concept_db_path() -> str:
@@ -39,6 +43,27 @@ def init_concept_database(db_path: str) -> None:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
 
+        existing_tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        if "entities" in existing_tables:
+            entity_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(entities)")
+            }
+            relationship_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(relationships)")
+            }
+            if (
+                "platform" not in entity_columns
+                or "platform" not in relationship_columns
+            ):
+                # Historical graph rows cannot be assigned a trustworthy platform.
+                # Leave the derived database untouched until an explicit full rebuild.
+                return
+
         conn.execute("""
             CREATE TABLE IF NOT EXISTS entities (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -46,9 +71,10 @@ def init_concept_database(db_path: str) -> None:
                 type TEXT NOT NULL,
                 session_name TEXT,
                 project TEXT,
+                platform TEXT,
                 source_memory_ids TEXT DEFAULT '[]',
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE(name, session_name, project)
+                UNIQUE(name, session_name, project, platform)
             )
         """)
 
@@ -69,6 +95,7 @@ def init_concept_database(db_path: str) -> None:
                 predicate TEXT NOT NULL,
                 memory_id TEXT,
                 project TEXT,
+                platform TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY(source_id) REFERENCES entities(id),
                 FOREIGN KEY(target_id) REFERENCES entities(id)
@@ -106,14 +133,15 @@ def init_concept_database(db_path: str) -> None:
         # these to make builds idempotent.
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_relationships_dedup "
-            "ON relationships(source_id, target_id, predicate, memory_id)"
+            "ON relationships(source_id, target_id, predicate, memory_id, "
+            "COALESCE(platform, ''))"
         )
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_code_links_dedup "
             "ON entity_code_links(entity_id, graph_qualified_name)"
         )
 
-        # entities' table-level UNIQUE(name, session_name, project) doesn't
+        # entities' table-level scoped UNIQUE doesn't
         # actually dedupe when session_name/project are NULL -- SQLite treats
         # NULL as distinct from NULL in UNIQUE constraints, so two concurrent
         # get_or_create_entity calls for the same (name, NULL, NULL) can both
@@ -121,7 +149,18 @@ def init_concept_database(db_path: str) -> None:
         # get_or_create_entity's INSERT OR IGNORE relies on for atomicity.
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_entities_dedup "
-            "ON entities(name, COALESCE(session_name, ''), COALESCE(project, ''))"
+            "ON entities(name, COALESCE(session_name, ''), COALESCE(project, ''), "
+            "COALESCE(platform, ''))"
+        )
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS concept_schema_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+        """)
+        conn.execute(
+            "INSERT OR REPLACE INTO concept_schema_metadata (key, value) VALUES (?, ?)",
+            (_SCHEMA_VERSION_KEY, str(CONCEPT_SCHEMA_VERSION)),
         )
         conn.execute("""
             CREATE TABLE IF NOT EXISTS concept_build_runs (
@@ -147,6 +186,85 @@ def init_concept_database(db_path: str) -> None:
         )
 
 
+def inspect_concept_schema(db_path: str) -> str:
+    """Return missing, current, rebuild_required, or unavailable without DDL."""
+    path = Path(db_path)
+    if not path.exists():
+        return "missing"
+    try:
+        uri = f"{path.resolve().as_uri()}?mode=ro"
+        with closing(sqlite3.connect(uri, uri=True)) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).fetchall()
+            }
+            if "entities" not in tables or "relationships" not in tables:
+                return "rebuild_required"
+            entity_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(entities)")
+            }
+            relationship_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(relationships)")
+            }
+            if (
+                "platform" not in entity_columns
+                or "platform" not in relationship_columns
+            ):
+                return "rebuild_required"
+            if "concept_schema_metadata" not in tables:
+                return "rebuild_required"
+            row = conn.execute(
+                "SELECT value FROM concept_schema_metadata WHERE key = ?",
+                (_SCHEMA_VERSION_KEY,),
+            ).fetchone()
+            if row is None or row[0] != str(CONCEPT_SCHEMA_VERSION):
+                return "rebuild_required"
+            return "current"
+    except (OSError, sqlite3.Error):
+        return "unavailable"
+
+
+def backup_and_reset_concept_database(db_path: str) -> str:
+    """Back up derived graph data, replace it, and return the backup path."""
+    path = Path(db_path)
+    if not path.exists():
+        init_concept_database(db_path)
+        return ""
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    backup_path = path.with_name(f"{path.name}.backup-{stamp}")
+    source = sqlite3.connect(db_path)
+    backup = sqlite3.connect(backup_path)
+    try:
+        source.backup(backup)
+    finally:
+        backup.close()
+        source.close()
+
+    reset = sqlite3.connect(db_path, timeout=20.0)
+    try:
+        reset.execute("PRAGMA foreign_keys=OFF")
+        reset.execute("BEGIN IMMEDIATE")
+        for table in (
+            "entity_code_links",
+            "relationships",
+            "entities",
+            "concept_build_runs",
+            "concept_schema_metadata",
+        ):
+            reset.execute(f"DROP TABLE IF EXISTS {table}")
+        reset.execute("COMMIT")
+    except Exception:
+        reset.rollback()
+        raise
+    finally:
+        reset.close()
+    init_concept_database(db_path)
+    return str(backup_path)
+
+
 class ConceptDB:
     """Owns the concept graph's SQLite pool. One instance per process, lazily built."""
 
@@ -159,6 +277,9 @@ class ConceptDB:
 
     def get_connection(self):
         return ConnectionContext(self.connection_pool)
+
+    def close(self) -> None:
+        self.connection_pool.close_all()
 
     def create_build_run(
         self,
@@ -207,6 +328,7 @@ class ConceptDB:
         project: Optional[str],
         memory_id: str,
         name_embedding: Optional[bytes] = None,
+        platform: Optional[str] = None,
     ) -> tuple[int, bool]:
         """Insert a new entity or append memory_id to an existing one's source
         list. Returns (entity_id, was_created) -- callers use was_created to
@@ -230,13 +352,14 @@ class ConceptDB:
         instead of the first-mention path."""
         cursor = conn.execute(
             "INSERT OR IGNORE INTO entities "
-            "(name, type, session_name, project, source_memory_ids, name_embedding) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "(name, type, session_name, project, platform, source_memory_ids, name_embedding) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 name,
                 entity_type,
                 session_name,
                 project,
+                platform,
                 json.dumps([memory_id]),
                 name_embedding,
             ),
@@ -245,8 +368,8 @@ class ConceptDB:
 
         row = conn.execute(
             "SELECT id FROM entities "
-            "WHERE name = ? AND session_name IS ? AND project IS ?",
-            (name, session_name, project),
+            "WHERE name = ? AND session_name IS ? AND project IS ? AND platform IS ?",
+            (name, session_name, project, platform),
         ).fetchone()
         entity_id = row[0]
 
@@ -270,6 +393,7 @@ class ConceptDB:
         project: Optional[str],
         threshold: float,
         exclude_id: Optional[int] = None,
+        platform: Optional[str] = None,
     ) -> list[dict]:
         """Linear cosine-similarity scan against same-scope entities' stored
         name embeddings -- bounded by deployment scale (personal/small-team
@@ -278,9 +402,14 @@ class ConceptDB:
         cosine pattern. Returns candidates >= threshold, most-similar-first."""
         rows = conn.execute(
             "SELECT id, name, name_embedding FROM entities "
-            "WHERE session_name IS ? AND project IS ? "
+            "WHERE session_name IS ? AND project IS ? AND platform IS ? "
             "AND name_embedding IS NOT NULL AND id != ?",
-            (session_name, project, exclude_id if exclude_id is not None else -1),
+            (
+                session_name,
+                project,
+                platform,
+                exclude_id if exclude_id is not None else -1,
+            ),
         ).fetchall()
         if not rows:
             return []
@@ -340,6 +469,7 @@ class ConceptDB:
         predicate: str,
         memory_id: str,
         project: Optional[str],
+        platform: Optional[str] = None,
     ) -> bool:
         """Insert a relationship. Caller must have already confirmed both entity
         ids exist (get_or_create_entity returns real ids) — this only guards
@@ -350,9 +480,9 @@ class ConceptDB:
             return False
         cursor = conn.execute(
             "INSERT OR IGNORE INTO relationships "
-            "(source_id, target_id, predicate, memory_id, project) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (source_id, target_id, predicate, memory_id, project),
+            "(source_id, target_id, predicate, memory_id, project, platform) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (source_id, target_id, predicate, memory_id, project, platform),
         )
         return cursor.rowcount > 0
 

--- a/marm-mcp-server/marm_mcp_server/core/models.py
+++ b/marm-mcp-server/marm_mcp_server/core/models.py
@@ -199,6 +199,10 @@ class ConceptRecallRequest(BaseModel):
         default=None,
         description="Scope to this project. Omit to search across all projects.",
     )
+    platform: Optional[str] = Field(
+        default=None,
+        description="Scope to this platform. Omit to search across all platforms.",
+    )
     limit: int = Field(
         default=10, ge=1, le=100, description="Max entities/relationships returned."
     )

--- a/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
@@ -9,7 +9,6 @@ related-to intent from query shape.
 """
 
 import asyncio
-import json
 import threading
 import time
 import uuid
@@ -24,27 +23,26 @@ from ..config.settings import (
     CONCEPTS_AVAILABLE,
     CONCEPT_DUPLICATE_SIMILARITY_THRESHOLD,
 )
-from ..core.concept_db import ConceptDB
+from ..core.concept_db import (
+    ConceptDB,
+    backup_and_reset_concept_database,
+    get_concept_db_path,
+    inspect_concept_schema,
+)
 from ..core.concept_extraction import extract_entities
 from ..core.graph_client import find_code_match, is_graph_available
 from ..core.memory import memory
 from ..core.memory_utils import _embedding_to_bytes, _safe_print
 from ..core.models import ConceptBuildRequest, ConceptRecallRequest
+from ..services.graph_context import get_graph_context, traverse_graph
 
 logger = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="", tags=["Concepts"])
 
-_RELATED_PREFIXES = (
-    "related to ",
-    "related-to ",
-    "relationships of ",
-    "connected to ",
-    "connections of ",
-)
-
 _concept_db: Optional[ConceptDB] = None
 _concept_db_lock = threading.Lock()
+_concept_build_lock = asyncio.Lock()
 
 
 def _get_concept_db() -> ConceptDB:
@@ -76,7 +74,7 @@ _CONCEPTS_UNAVAILABLE_MESSAGE = (
 
 def _fetch_memory_rows(
     session_name: Optional[str], project: Optional[str], search_all: bool
-) -> list[tuple[str, str, Optional[str], Optional[str]]]:
+) -> list[tuple[str, str, Optional[str], Optional[str], Optional[str]]]:
     """Deterministic row-bounded read from the memory DB layer directly.
     Never goes through marm_smart_recall — no ranking/truncation here.
 
@@ -104,7 +102,7 @@ def _fetch_memory_rows(
             params.append(project)
 
     query = (
-        f"SELECT id, content, session_name, project FROM memories "
+        f"SELECT id, content, session_name, project, platform FROM memories "
         f"WHERE {' AND '.join(conditions)} ORDER BY created_at DESC LIMIT ?"
     )
     params.append(CONCEPT_BUILD_ROW_CAP)
@@ -132,7 +130,9 @@ def _try_embed(name: str) -> Optional[bytes]:
         return None
 
 
-def _run_build(rows: list[tuple[str, str, Optional[str], Optional[str]]]) -> dict:
+def _run_build(
+    rows: list[tuple[str, str, Optional[str], Optional[str], Optional[str]]],
+) -> dict:
     concept_db = _get_concept_db()
     entities_extracted = 0
     relationships_created = 0
@@ -149,7 +149,9 @@ def _run_build(rows: list[tuple[str, str, Optional[str], Optional[str]]]) -> dic
     embed_cache: dict[str, Optional[bytes]] = {}
 
     with concept_db.get_connection() as conn:
-        for mem_id, content, mem_session, mem_project in rows:
+        for row in rows:
+            mem_id, content, mem_session, mem_project = row[:4]
+            mem_platform = row[4] if len(row) > 4 else None
             try:
                 result = extract_entities(content)
             except Exception as e:
@@ -170,6 +172,7 @@ def _run_build(rows: list[tuple[str, str, Optional[str], Optional[str]]]) -> dic
                         mem_project,
                         mem_id,
                         name_embedding=emb_bytes,
+                        platform=mem_platform,
                     )
                 except Exception as e:
                     _safe_print(f"Concept entity write failed for memory {mem_id}: {e}")
@@ -186,6 +189,7 @@ def _run_build(rows: list[tuple[str, str, Optional[str], Optional[str]]]) -> dic
                             mem_project,
                             CONCEPT_DUPLICATE_SIMILARITY_THRESHOLD,
                             exclude_id=entity_id,
+                            platform=mem_platform,
                         )
                     except Exception as e:
                         _safe_print(f"Concept duplicate-candidate scan failed: {e}")
@@ -202,7 +206,13 @@ def _run_build(rows: list[tuple[str, str, Optional[str], Optional[str]]]) -> dic
                     continue
                 try:
                     if concept_db.store_relationship(
-                        conn, id_a, id_b, predicate, mem_id, mem_project
+                        conn,
+                        id_a,
+                        id_b,
+                        predicate,
+                        mem_id,
+                        mem_project,
+                        platform=mem_platform,
                     ):
                         relationships_created += 1
                 except Exception as e:
@@ -269,85 +279,39 @@ def _finish_build_run(run_id: str, **fields) -> None:
         concept_db.update_build_run(conn, run_id, **fields)
 
 
+def _prepare_build_schema(req: ConceptBuildRequest) -> bool:
+    """Return whether a historical graph was backed up and reset."""
+    global _concept_db
+    db_path = get_concept_db_path()
+    state = inspect_concept_schema(db_path)
+    if state == "unavailable":
+        raise RuntimeError("concept database unavailable")
+    if state != "rebuild_required":
+        return False
+    if not req.search_all:
+        raise ValueError("rebuild_required")
+
+    with _concept_db_lock:
+        if _concept_db is not None:
+            _concept_db.close()
+            _concept_db = None
+        backup_and_reset_concept_database(db_path)
+    return True
+
+
 def _traverse(
     conn, seed_ids: list[int], depth: int, direction: str, limit: int
 ) -> list[dict]:
-    """Bounded BFS over entities/relationships -- single connection, one
-    batched SQL query per hop-level, matches this codebase's established
-    IN (...)-in-a-Python-loop convention (compaction.py, memory_delete.py; zero
-    WITH RECURSIVE uses anywhere in this repo). At depth=1 this reproduces
-    the original one-hop outgoing+incoming+union+truncate behavior exactly.
-
-    Two separate sets, not one -- an earlier version pre-seeded a single
-    `visited` set with every seed id, which silently suppressed direct edges
-    *between* two seeds (recall's `name LIKE '%query%'` routinely matches a
-    cluster of related entities that are themselves directly connected --
-    those edges are exactly the most relevant ones to surface). `emitted`
-    tracks what's already in `results` and is NOT pre-seeded, so a seed can
-    be emitted as another seed's hop-1 neighbor. `expanded` IS pre-seeded
-    with every seed id and prevents re-querying from a node whose
-    relationships we've already fetched -- this is what stops multi-node
-    cycles (A->B->C->A) from looping/duplicate-exploding. The `hop > 1`
-    guard is the key: at hop 1, `expanded` never blocks emission (frontier
-    *is* the seed set, so every hop-1 row is by definition a direct edge
-    between two seeds or a seed and a fresh neighbor); from hop 2 onward,
-    re-reaching anything already in `expanded` (including an original seed
-    via a cycle) is genuinely old information, not a new discovery, and is
-    excluded. ORDER BY r.id makes which parent "wins" for path
-    reconstruction deterministic when a node is reachable from two frontier
-    members in the same hop."""
-    emitted: set[int] = set()
-    expanded: set[int] = set(seed_ids)
-    paths: dict[int, list[dict]] = {eid: [] for eid in seed_ids}
-    frontier = list(seed_ids)
-    results: list[dict] = []
-
-    for hop in range(1, depth + 1):
-        if not frontier or len(results) >= limit:
-            break
-        placeholders = ",".join("?" * len(frontier))
-        rows = []
-        if direction in ("outgoing", "both"):
-            rows += conn.execute(
-                f"""SELECT r.source_id, e.id, e.name, e.type, r.predicate FROM relationships r
-                    JOIN entities e ON e.id = r.target_id
-                    WHERE r.source_id IN ({placeholders}) ORDER BY r.id""",
-                frontier,
-            ).fetchall()
-        if direction in ("incoming", "both"):
-            rows += conn.execute(
-                f"""SELECT r.target_id, e.id, e.name, e.type, r.predicate FROM relationships r
-                    JOIN entities e ON e.id = r.source_id
-                    WHERE r.target_id IN ({placeholders}) ORDER BY r.id""",
-                frontier,
-            ).fetchall()
-
-        next_frontier = []
-        for from_id, neighbor_id, name, entity_type, predicate in rows:
-            if neighbor_id in emitted:
-                continue
-            if hop > 1 and neighbor_id in expanded:
-                continue
-            emitted.add(neighbor_id)
-            paths[neighbor_id] = paths[from_id] + [
-                {"predicate": predicate, "name": name}
-            ]
-            entry = {
-                "name": name,
-                "type": entity_type,
-                "predicate": predicate,
-                "hop": hop,
-            }
-            if depth > 1:
-                entry["path"] = paths[neighbor_id]
-            results.append(entry)
-            if neighbor_id not in expanded:
-                expanded.add(neighbor_id)
-                next_frontier.append(neighbor_id)
-            if len(results) >= limit:
-                break
-        frontier = next_frontier
-
+    results, _, _ = traverse_graph(
+        conn,
+        seed_ids,
+        depth=depth,
+        direction=direction,
+        limit=limit,
+        session_name=None,
+        project=None,
+        platform=None,
+    )
     return results
 
 
@@ -358,69 +322,23 @@ def _run_recall(
     depth: int = 1,
     direction: str = "both",
     project: Optional[str] = None,
+    platform: Optional[str] = None,
 ) -> dict:
-    concept_db = _get_concept_db()
-
-    target_name = query
-    for prefix in _RELATED_PREFIXES:
-        if query.lower().startswith(prefix):
-            target_name = query[len(prefix) :].strip()
-            break
-
-    entities: list[dict] = []
-    related_entities: list[dict] = []
-    linked_code: list[dict] = []
-
-    with concept_db.get_connection() as conn:
-        conditions = ["name LIKE ?"]
-        params: list = [f"%{target_name}%"]
-        if session_name:
-            conditions.append("session_name = ?")
-            params.append(session_name)
-        if project:
-            conditions.append("project = ?")
-            params.append(project)
-
-        rows = conn.execute(
-            f"SELECT id, name, type, source_memory_ids FROM entities "
-            f"WHERE {' AND '.join(conditions)} LIMIT ?",
-            [*params, limit],
-        ).fetchall()
-
-        entity_ids = []
-        for entity_id, name, entity_type, source_ids_json in rows:
-            try:
-                mention_count = len(json.loads(source_ids_json))
-            except (TypeError, ValueError):
-                mention_count = 0
-            entities.append(
-                {"name": name, "type": entity_type, "mention_count": mention_count}
-            )
-            entity_ids.append(entity_id)
-
-        if entity_ids:
-            placeholders = ",".join("?" * len(entity_ids))
-
-            related_entities = _traverse(conn, entity_ids, depth, direction, limit)
-
-            code_rows = conn.execute(
-                f"""SELECT graph_qualified_name, label, file_path FROM entity_code_links
-                    WHERE entity_id IN ({placeholders}) LIMIT ?""",
-                [*entity_ids, limit],
-            ).fetchall()
-            for qualified_name, label, file_path in code_rows:
-                linked_code.append(
-                    {
-                        "qualified_name": qualified_name,
-                        "label": label,
-                        "file_path": file_path,
-                    }
-                )
-
+    context = get_graph_context(
+        query=query,
+        session_name=session_name,
+        project=project,
+        platform=platform,
+        limit=limit,
+        depth=depth,
+        direction=direction,
+    )
     return {
-        "entities": entities,
-        "related_entities": related_entities,
-        "linked_code": linked_code,
+        "status": context["status"],
+        "entities": context["entities"],
+        "related_entities": context["related_entities"],
+        "linked_code": context["linked_code"],
+        "truncated": context["truncated"],
     }
 
 
@@ -433,11 +351,35 @@ async def marm_concept_build(req: ConceptBuildRequest) -> dict:
     marm-graph code symbols when available. Call this before marm_concept_recall
     — there's no data until a build has run at least once.
     """
+    async with _concept_build_lock:
+        return await _marm_concept_build(req)
+
+
+async def _marm_concept_build(req: ConceptBuildRequest) -> dict:
     if not (req.session_name or req.project or req.search_all):
         return {"status": "error", "message": _MISSING_BUILD_SCOPE_MESSAGE}
 
     run_id = req.run_id or str(uuid.uuid4())
     created_at = datetime.now(timezone.utc).isoformat()
+    try:
+        graph_rebuilt = await asyncio.to_thread(_prepare_build_schema, req)
+    except ValueError:
+        return {
+            "status": "error",
+            "error_code": "rebuild_required",
+            "message": (
+                "The concept graph must be rebuilt with "
+                "marm_concept_build(search_all=True)."
+            ),
+            "build_run_id": run_id,
+        }
+    except Exception as e:
+        logger.warning("concepts.schema_prepare_error", error=str(e))
+        return {
+            "status": "error",
+            "message": "Concept build failed.",
+            "build_run_id": run_id,
+        }
     try:
         await asyncio.to_thread(_create_build_run, req, run_id, created_at)
     except Exception as e:
@@ -528,6 +470,7 @@ async def marm_concept_build(req: ConceptBuildRequest) -> dict:
         duration_ms=result["duration_ms"],
         finished_at=datetime.now(timezone.utc).isoformat(),
     )
+    result["graph_rebuilt"] = graph_rebuilt
     result["build_run_id"] = run_id
     return result
 
@@ -539,15 +482,14 @@ async def marm_concept_recall(req: ConceptRecallRequest) -> dict:
     Query as a bare concept name for a lookup, or phrase it as "related to X"
     to emphasize traversal — both route from query shape alone. Pass depth
     to traverse multiple hops (default 1 = direct neighbors only), direction
-    to scope traversal (outgoing/incoming/both), project to scope to one
-    project (entities with the same name in different projects are distinct
-    nodes -- omit to search across all). Returns empty lists (not an error)
+    to scope traversal (outgoing/incoming/both), and project/platform to scope
+    provenance (entities with the same name in different scopes are distinct
+    nodes -- omit either filter to search across it). Returns empty lists (not an error)
     when marm_concept_build hasn't run yet or marm-graph has no matching
     code symbols.
     """
     try:
-        return await asyncio.to_thread(
-            _run_recall,
+        args = (
             req.query,
             req.session_name,
             req.limit,
@@ -555,6 +497,9 @@ async def marm_concept_recall(req: ConceptRecallRequest) -> dict:
             req.direction,
             req.project,
         )
+        if req.platform is None:
+            return await asyncio.to_thread(_run_recall, *args)
+        return await asyncio.to_thread(_run_recall, *args, req.platform)
     except Exception as e:
         logger.warning("concepts.recall_error", error=str(e))
         return {"status": "error", "message": "Concept recall failed."}

--- a/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
@@ -361,9 +361,46 @@ async def _marm_concept_build(req: ConceptBuildRequest) -> dict:
 
     run_id = req.run_id or str(uuid.uuid4())
     created_at = datetime.now(timezone.utc).isoformat()
+    if not CONCEPTS_AVAILABLE:
+        try:
+            await asyncio.to_thread(_create_build_run, req, run_id, created_at)
+        except Exception as e:
+            logger.warning("concepts.build_run_create_error", error=str(e))
+            return {"status": "error", "message": "Concept build failed."}
+        result = {
+            "status": "degraded",
+            "error_code": "concepts_unavailable",
+            "message": _CONCEPTS_UNAVAILABLE_MESSAGE,
+            "entities_extracted": 0,
+            "relationships_created": 0,
+            "code_links_created": 0,
+            "possible_duplicates": [],
+            "duration_ms": 0,
+        }
+        await asyncio.to_thread(
+            _finish_build_run,
+            run_id,
+            status="degraded",
+            error_code="concepts_unavailable",
+            finished_at=datetime.now(timezone.utc).isoformat(),
+            duration_ms=0,
+        )
+        result["build_run_id"] = run_id
+        return result
     try:
         graph_rebuilt = await asyncio.to_thread(_prepare_build_schema, req)
     except ValueError:
+        try:
+            await asyncio.to_thread(_create_build_run, req, run_id, created_at)
+            await asyncio.to_thread(
+                _finish_build_run,
+                run_id,
+                status="error",
+                error_code="rebuild_required",
+                finished_at=datetime.now(timezone.utc).isoformat(),
+            )
+        except Exception as e:
+            logger.warning("concepts.build_run_create_error", error=str(e))
         return {
             "status": "error",
             "error_code": "rebuild_required",
@@ -385,28 +422,6 @@ async def _marm_concept_build(req: ConceptBuildRequest) -> dict:
     except Exception as e:
         logger.warning("concepts.build_run_create_error", error=str(e))
         return {"status": "error", "message": "Concept build failed."}
-
-    if not CONCEPTS_AVAILABLE:
-        result = {
-            "status": "degraded",
-            "error_code": "concepts_unavailable",
-            "message": _CONCEPTS_UNAVAILABLE_MESSAGE,
-            "entities_extracted": 0,
-            "relationships_created": 0,
-            "code_links_created": 0,
-            "possible_duplicates": [],
-            "duration_ms": 0,
-        }
-        await asyncio.to_thread(
-            _finish_build_run,
-            run_id,
-            status="degraded",
-            error_code="concepts_unavailable",
-            finished_at=datetime.now(timezone.utc).isoformat(),
-            duration_ms=0,
-        )
-        result["build_run_id"] = run_id
-        return result
 
     start = time.monotonic()
     try:

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -14,6 +14,7 @@ from ..core.memory import memory
 from ..core.response_limiter import MCPResponseLimiter
 from ..core.concept_db import ConceptDB, get_concept_db_path
 from ..services.recall import _apply_detail_level
+from ..services.graph_context import attach_graph_context, get_graph_context
 
 logger = structlog.get_logger(__name__)
 
@@ -263,6 +264,15 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
             project=request.project,
             platform=request.platform,
         )
+        graph_context = await asyncio.to_thread(
+            get_graph_context,
+            query=request.query,
+            memory_ids=[item.get("id") for item in similar_memories],
+            session_name=search_session,
+            project=request.project,
+            platform=request.platform,
+            limit=request.limit,
+        )
 
         if not similar_memories:
             if not request.search_all:
@@ -316,7 +326,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
 
                 if request.include_logs:
                     _inject_log_results(response, log_results)
-                return response
+                return attach_graph_context(response, graph_context)
             else:
                 response = {
                     "status": "no_results",
@@ -330,7 +340,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
                 }
                 if request.include_logs:
                     _inject_log_results(response, log_results)
-                return response
+                return attach_graph_context(response, graph_context)
 
         base_response = {
             "status": "success",
@@ -368,7 +378,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
         if request.include_logs:
             _inject_log_results(final_response, log_results)
 
-        return final_response
+        return attach_graph_context(final_response, graph_context)
     except Exception as e:
         print(f"Unexpected error in marm_smart_recall: {e}")
         return {"status": "error", "message": "Memory recall failed."}

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -67,7 +67,9 @@ async def marm_smart_recall(
     🧠 Recall memories by semantic similarity or keyword match.
 
     Searches stored memories for the most relevant matches to `query`.
-    Returns a ranked list of results with similarity scores.
+    Returns a ranked list of results with similarity scores. When a compatible
+    concept graph exists, the response also includes bounded relationship and
+    linked-code context without changing memory ranking.
 
     Parameters:
     - query: natural language search term or phrase
@@ -87,7 +89,7 @@ async def marm_smart_recall(
     - project: filter results to a specific project (e.g. "marm-memory"); omit to search all
     - platform: filter results to a specific platform (e.g. "claude-code", "cursor"); omit to search all
 
-    Returns: status, results list with id/content/score/project/platform, results_count
+    Returns: status, ranked results, graph_context, and results_count
     """
     return await smart_recall(
         query,

--- a/marm-mcp-server/marm_mcp_server/services/graph_context.py
+++ b/marm-mcp-server/marm_mcp_server/services/graph_context.py
@@ -1,0 +1,332 @@
+"""Bounded, read-only concept context for smart and explicit recall."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Iterable, Optional
+
+from ..core.concept_db import get_concept_db_path, inspect_concept_schema
+from ..core.response_limiter import MCPResponseLimiter
+
+_RELATED_PREFIXES = (
+    "related to ",
+    "related-to ",
+    "relationships of ",
+    "connected to ",
+    "connections of ",
+)
+_MAX_SEEDS = 20
+_MAX_RELATED = 40
+_MAX_CODE_LINKS = 20
+
+
+def _empty_context(status: str) -> dict:
+    return {
+        "status": status,
+        "entities": [],
+        "related_entities": [],
+        "linked_code": [],
+        "seed_sources": {"memory_results": 0, "query_match": 0},
+        "truncated": False,
+    }
+
+
+def _target_name(query: str) -> str:
+    target = query.strip()
+    lowered = target.lower()
+    for prefix in _RELATED_PREFIXES:
+        if lowered.startswith(prefix):
+            return target[len(prefix) :].strip()
+    return target
+
+
+def _scope_sql(
+    alias: str,
+    *,
+    session_name: Optional[str],
+    project: Optional[str],
+    platform: Optional[str],
+) -> tuple[list[str], list[object]]:
+    conditions: list[str] = []
+    params: list[object] = []
+    for column, value in (
+        ("session_name", session_name),
+        ("project", project),
+        ("platform", platform),
+    ):
+        if value is not None:
+            conditions.append(f"{alias}.{column} = ?")
+            params.append(value)
+    return conditions, params
+
+
+def _entity(row: sqlite3.Row) -> dict:
+    try:
+        mention_count = len(json.loads(row["source_memory_ids"] or "[]"))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        mention_count = 0
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "type": row["type"],
+        "mention_count": mention_count,
+    }
+
+
+def traverse_graph(
+    conn: sqlite3.Connection,
+    seed_ids: list[int],
+    *,
+    depth: int,
+    direction: str,
+    limit: int,
+    session_name: Optional[str],
+    project: Optional[str],
+    platform: Optional[str],
+) -> tuple[list[dict], set[int], bool]:
+    emitted: set[int] = set()
+    expanded: set[int] = set(seed_ids)
+    paths: dict[int, list[dict]] = {entity_id: [] for entity_id in seed_ids}
+    frontier = list(seed_ids)
+    results: list[dict] = []
+    related_ids: set[int] = set()
+    truncated = False
+
+    entity_scope, entity_params = _scope_sql(
+        "e", session_name=session_name, project=project, platform=platform
+    )
+    relationship_scope, relationship_params = _scope_sql(
+        "r", session_name=None, project=project, platform=platform
+    )
+    scoped_where = [*entity_scope, *relationship_scope]
+    scope_clause = "" if not scoped_where else " AND " + " AND ".join(scoped_where)
+    scope_params = [*entity_params, *relationship_params]
+
+    for hop in range(1, depth + 1):
+        if not frontier or len(results) >= limit:
+            break
+        placeholders = ",".join("?" for _ in frontier)
+        rows: list[sqlite3.Row] = []
+        if direction in {"outgoing", "both"}:
+            rows.extend(
+                conn.execute(
+                    f"""SELECT r.source_id AS from_id, e.id, e.name, e.type,
+                               e.source_memory_ids, r.predicate
+                        FROM relationships r JOIN entities e ON e.id = r.target_id
+                        WHERE r.source_id IN ({placeholders}){scope_clause}
+                        ORDER BY r.id LIMIT ?""",
+                    [*frontier, *scope_params, limit + 1],
+                ).fetchall()
+            )
+        if direction in {"incoming", "both"}:
+            rows.extend(
+                conn.execute(
+                    f"""SELECT r.target_id AS from_id, e.id, e.name, e.type,
+                               e.source_memory_ids, r.predicate
+                        FROM relationships r JOIN entities e ON e.id = r.source_id
+                        WHERE r.target_id IN ({placeholders}){scope_clause}
+                        ORDER BY r.id LIMIT ?""",
+                    [*frontier, *scope_params, limit + 1],
+                ).fetchall()
+            )
+
+        next_frontier: list[int] = []
+        for row in rows:
+            from_id, neighbor_id, name, entity_type, _, predicate = row
+            if neighbor_id in emitted or (hop > 1 and neighbor_id in expanded):
+                continue
+            if len(results) >= limit:
+                truncated = True
+                break
+            emitted.add(neighbor_id)
+            related_ids.add(neighbor_id)
+            paths[neighbor_id] = [
+                *paths.get(from_id, []),
+                {"predicate": predicate, "name": name},
+            ]
+            item = {
+                "name": name,
+                "type": entity_type,
+                "predicate": predicate,
+                "hop": hop,
+            }
+            if depth > 1:
+                item["path"] = paths[neighbor_id]
+            results.append(item)
+            if neighbor_id not in expanded:
+                expanded.add(neighbor_id)
+                next_frontier.append(neighbor_id)
+        frontier = next_frontier
+
+    return results, related_ids, truncated
+
+
+def get_graph_context(
+    *,
+    query: str,
+    memory_ids: Iterable[object] = (),
+    session_name: Optional[str] = None,
+    project: Optional[str] = None,
+    platform: Optional[str] = None,
+    limit: int = 10,
+    depth: int = 2,
+    direction: str = "both",
+) -> dict:
+    """Read a compact graph sidecar without creating or mutating graph data."""
+    db_path = get_concept_db_path()
+    schema_state = inspect_concept_schema(db_path)
+    if schema_state == "rebuild_required":
+        return _empty_context("rebuild_required")
+    if schema_state != "current":
+        return _empty_context("unavailable")
+
+    seed_limit = min(max(limit, 1), _MAX_SEEDS)
+    related_limit = min(max(limit * 3, limit), _MAX_RELATED)
+    code_limit = min(max(limit * 2, limit), _MAX_CODE_LINKS)
+    memory_values = list(dict.fromkeys(str(value) for value in memory_ids if value))
+
+    try:
+        uri = f"{Path(db_path).resolve().as_uri()}?mode=ro"
+        with closing(sqlite3.connect(uri, uri=True)) as conn:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA query_only=ON")
+            if conn.execute("SELECT COUNT(*) FROM entities").fetchone()[0] == 0:
+                return _empty_context("empty")
+
+            scope_conditions, scope_params = _scope_sql(
+                "e",
+                session_name=session_name,
+                project=project,
+                platform=platform,
+            )
+            seed_rows: dict[int, sqlite3.Row] = {}
+            memory_seed_ids: set[int] = set()
+            query_seed_ids: set[int] = set()
+            seeds_truncated = False
+
+            if memory_values:
+                placeholders = ",".join("?" for _ in memory_values)
+                where = [
+                    f"CAST(j.value AS TEXT) IN ({placeholders})",
+                    *scope_conditions,
+                ]
+                rows = conn.execute(
+                    f"""SELECT DISTINCT e.id, e.name, e.type, e.source_memory_ids
+                        FROM entities e, json_each(e.source_memory_ids) j
+                        WHERE {" AND ".join(where)}
+                        ORDER BY e.id LIMIT ?""",
+                    [*memory_values, *scope_params, seed_limit + 1],
+                ).fetchall()
+                seeds_truncated = len(rows) > seed_limit
+                for row in rows[:seed_limit]:
+                    seed_rows[row["id"]] = row
+                    memory_seed_ids.add(row["id"])
+
+            target = _target_name(query)
+            if target and len(seed_rows) < seed_limit:
+                escaped = (
+                    target.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                )
+                rows = conn.execute(
+                    f"""SELECT e.id, e.name, e.type, e.source_memory_ids
+                        FROM entities e
+                        WHERE e.name LIKE ? ESCAPE '\\'
+                        {"" if not scope_conditions else " AND " + " AND ".join(scope_conditions)}
+                        ORDER BY e.name COLLATE NOCASE, e.id LIMIT ?""",
+                    [f"%{escaped}%", *scope_params, seed_limit + 1],
+                ).fetchall()
+                for row in rows:
+                    if len(seed_rows) >= seed_limit:
+                        seeds_truncated = True
+                        break
+                    seed_rows.setdefault(row["id"], row)
+                    query_seed_ids.add(row["id"])
+
+            if not seed_rows:
+                return _empty_context("empty")
+
+            related, related_ids, traversal_truncated = traverse_graph(
+                conn,
+                list(seed_rows),
+                depth=min(max(depth, 1), 5),
+                direction=direction,
+                limit=related_limit,
+                session_name=session_name,
+                project=project,
+                platform=platform,
+            )
+            link_ids = list(dict.fromkeys([*seed_rows, *related_ids]))
+            linked_code: list[dict] = []
+            link_rows: list[sqlite3.Row] = []
+            if link_ids:
+                placeholders = ",".join("?" for _ in link_ids)
+                link_rows = conn.execute(
+                    f"""SELECT graph_qualified_name, label, file_path
+                        FROM entity_code_links
+                        WHERE entity_id IN ({placeholders})
+                        ORDER BY entity_id, graph_qualified_name LIMIT ?""",
+                    [*link_ids, code_limit + 1],
+                ).fetchall()
+                linked_code = [
+                    {
+                        "qualified_name": row["graph_qualified_name"],
+                        "label": row["label"],
+                        "file_path": row["file_path"],
+                    }
+                    for row in link_rows[:code_limit]
+                ]
+
+            return {
+                "status": "available",
+                "entities": [_entity(row) for row in seed_rows.values()],
+                "related_entities": related,
+                "linked_code": linked_code,
+                "seed_sources": {
+                    "memory_results": len(memory_seed_ids),
+                    "query_match": len(query_seed_ids),
+                },
+                "truncated": (
+                    seeds_truncated
+                    or traversal_truncated
+                    or len(link_rows) > code_limit
+                ),
+            }
+    except (OSError, sqlite3.Error, TypeError, ValueError, json.JSONDecodeError):
+        return _empty_context("unavailable")
+
+
+def attach_graph_context(response: dict, graph_context: dict) -> dict:
+    """Attach graph data while preserving primary results under the MCP limit."""
+    context = {
+        **graph_context,
+        "entities": list(graph_context.get("entities", [])),
+        "related_entities": list(graph_context.get("related_entities", [])),
+        "linked_code": list(graph_context.get("linked_code", [])),
+    }
+    candidate = {**response, "graph_context": context}
+    while (
+        MCPResponseLimiter.estimate_response_size(candidate)
+        > MCPResponseLimiter.CONTENT_LIMIT
+    ):
+        for key in ("linked_code", "related_entities", "entities"):
+            values = context[key]
+            if values:
+                if len(values) == 1:
+                    values.pop()
+                else:
+                    del values[max(1, len(values) // 2) :]
+                context["truncated"] = True
+                candidate = {**response, "graph_context": context}
+                break
+        else:
+            context = _empty_context(graph_context.get("status", "unavailable"))
+            context["truncated"] = True
+            candidate = {**response, "graph_context": context}
+            break
+
+    if response.get("status") == "no_results" and context.get("status") == "available":
+        candidate["status"] = "success"
+    return candidate

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -1,8 +1,11 @@
 """Smart recall logic for MARM MCP Server."""
 
+import asyncio
+
 from ..core.memory import memory
 from ..core.response_limiter import MCPResponseLimiter
 from ..config.settings import SIGNUP_PROMPT_EMAIL
+from .graph_context import attach_graph_context, get_graph_context
 
 _SIGNUP_PROMPT_TEXT = (
     "[MARM_SIGNUP - READ BEFORE RESPONDING]\n\n"
@@ -92,6 +95,15 @@ async def smart_recall(
             project=project,
             platform=platform,
         )
+        graph_context = await asyncio.to_thread(
+            get_graph_context,
+            query=query,
+            memory_ids=[item.get("id") for item in similar_memories],
+            session_name=search_session,
+            project=project,
+            platform=platform,
+            limit=limit,
+        )
 
         if not similar_memories:
             response: dict = {
@@ -144,7 +156,7 @@ async def smart_recall(
                     response["log_results"] = []
                     response["log_results_count"] = 0
                     response["_log_results_truncated"] = True
-            return response
+            return attach_graph_context(response, graph_context)
 
         formatted_results = [
             {
@@ -200,6 +212,8 @@ async def smart_recall(
                 response_data["log_results"] = []
                 response_data["log_results_count"] = 0
                 response_data["_log_results_truncated"] = True
+
+        response_data = attach_graph_context(response_data, graph_context)
 
         if memory.check_and_mark_signup_prompt():
             test_response = {"_signup_prompt": _SIGNUP_PROMPT_TEXT, **response_data}

--- a/marm-mcp-server/marm_mcp_server/services/stdio_graph_tools.py
+++ b/marm-mcp-server/marm_mcp_server/services/stdio_graph_tools.py
@@ -271,6 +271,7 @@ async def marm_concept_recall(
     depth: int = 1,
     direction: Literal["outgoing", "incoming", "both"] = "both",
     project: Optional[str] = None,
+    platform: Optional[str] = None,
 ) -> dict:
     """
     🔎 Search the concept graph: entities, their relationships, and linked code.
@@ -288,6 +289,7 @@ async def marm_concept_recall(
     - direction: outgoing | incoming | both (default both)
     - project: scope to this project; entities with the same name in
       different projects are distinct nodes; omit to search across all (optional)
+    - platform: scope to this client/platform; omit to search across all (optional)
 
     Returns: entities, related_entities, linked_code
     """
@@ -303,9 +305,9 @@ async def marm_concept_recall(
             depth=depth,
             direction=direction,
             project=project,
+            platform=platform,
         )
-        return await asyncio.to_thread(
-            _run_recall,
+        args = (
             req.query,
             req.session_name,
             req.limit,
@@ -313,6 +315,9 @@ async def marm_concept_recall(
             req.direction,
             req.project,
         )
+        if req.platform is None:
+            return await asyncio.to_thread(_run_recall, *args)
+        return await asyncio.to_thread(_run_recall, *args, req.platform)
     except Exception as e:
         # _run_recall failures can include SQLite paths/schema details --
         # log server-side (the HTTP endpoint's own try/except does this via

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "marm_smart_recall",
-      "description": "Intelligent memory recall using semantic search"
+      "description": "Hybrid memory recall with bounded concept and linked-code context when available"
     },
     {
       "name": "marm_summary",
@@ -81,7 +81,7 @@
     },
     {
       "name": "marm_concept_recall",
-      "description": "Query concept-graph entities, relationships, and linked code symbols"
+      "description": "Explicitly query platform-aware concept entities, relationships, and linked code symbols"
     }
   ],
   "capabilities": {

--- a/marm-mcp-server/tests/test_concept_endpoints.py
+++ b/marm-mcp-server/tests/test_concept_endpoints.py
@@ -11,6 +11,8 @@ accuracy, so a fake ExtractionResult at that one boundary is appropriate
 
 import asyncio
 import importlib
+from pathlib import Path
+import sqlite3
 import sys
 
 import numpy as np
@@ -190,6 +192,65 @@ def test_scoped_legacy_build_persists_rebuild_required_run(concepts_env):
             ("legacy-run",),
         ).fetchone()
     assert tuple(run) == ("error", "rebuild_required")
+
+
+def test_full_legacy_build_backs_up_and_resets_graph(concepts_env, monkeypatch):
+    _server, concepts, _memory_module = concepts_env
+    from marm_mcp_server.core.models import ConceptBuildRequest
+
+    concept_db = concepts._get_concept_db()
+    db_path = concept_db.db_path
+    with concept_db.get_connection() as conn:
+        concept_db.get_or_create_entity(
+            conn, "legacy graph", "concept", "sess-a", None, "m1"
+        )
+        conn.execute(
+            "UPDATE concept_schema_metadata SET value = '1' WHERE key = 'schema_version'"
+        )
+
+    monkeypatch.setattr(concepts, "CONCEPTS_AVAILABLE", True)
+    monkeypatch.setattr(
+        concepts,
+        "_run_build",
+        lambda _rows: {
+            "entities_extracted": 0,
+            "relationships_created": 0,
+            "code_links_created": 0,
+            "possible_duplicates": [],
+        },
+    )
+    result = asyncio.run(
+        concepts.marm_concept_build(
+            ConceptBuildRequest(search_all=True, run_id="full-rebuild-run")
+        )
+    )
+
+    backup_paths = list(Path(db_path).parent.glob(f"{Path(db_path).name}.backup-*"))
+    assert result["graph_rebuilt"] is True
+    assert result["build_run_id"] == "full-rebuild-run"
+    assert len(backup_paths) == 1
+    with sqlite3.connect(backup_paths[0]) as backup:
+        assert backup.execute("SELECT COUNT(*) FROM entities").fetchone()[0] == 1
+        assert (
+            backup.execute(
+                "SELECT value FROM concept_schema_metadata WHERE key = 'schema_version'"
+            ).fetchone()[0]
+            == "1"
+        )
+    active_concept_db = concepts._get_concept_db()
+    with active_concept_db.get_connection() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM entities").fetchone()[0] == 0
+        assert (
+            conn.execute(
+                "SELECT value FROM concept_schema_metadata WHERE key = 'schema_version'"
+            ).fetchone()[0]
+            == "2"
+        )
+        run = conn.execute(
+            "SELECT status FROM concept_build_runs WHERE id = ?",
+            ("full-rebuild-run",),
+        ).fetchone()
+    assert run[0] == "success"
 
 
 def test_fetch_memory_rows_excludes_marm_system_session(concepts_env):

--- a/marm-mcp-server/tests/test_concept_endpoints.py
+++ b/marm-mcp-server/tests/test_concept_endpoints.py
@@ -143,14 +143,53 @@ def test_marm_concept_build_reports_degraded_when_concepts_are_unavailable(
     _server, concepts, _memory_module = concepts_env
     from marm_mcp_server.core.models import ConceptBuildRequest
 
+    concept_db = concepts._get_concept_db()
+    with concept_db.get_connection() as conn:
+        concept_db.get_or_create_entity(
+            conn, "existing graph", "concept", "sess-a", None, "m1"
+        )
     monkeypatch.setattr(concepts, "CONCEPTS_AVAILABLE", False)
     result = asyncio.run(
-        concepts.marm_concept_build(ConceptBuildRequest(session_name="sess-a"))
+        concepts.marm_concept_build(
+            ConceptBuildRequest(search_all=True, run_id="unavailable-run")
+        )
     )
 
     assert result["status"] == "degraded"
     assert result["error_code"] == "concepts_unavailable"
     assert result["entities_extracted"] == 0
+    with concept_db.get_connection() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM entities").fetchone()[0] == 1
+        run = conn.execute(
+            "SELECT status, error_code FROM concept_build_runs WHERE id = ?",
+            ("unavailable-run",),
+        ).fetchone()
+    assert tuple(run) == ("degraded", "concepts_unavailable")
+
+
+def test_scoped_legacy_build_persists_rebuild_required_run(concepts_env):
+    _server, concepts, _memory_module = concepts_env
+    from marm_mcp_server.core.models import ConceptBuildRequest
+
+    concept_db = concepts._get_concept_db()
+    with concept_db.get_connection() as conn:
+        conn.execute(
+            "UPDATE concept_schema_metadata SET value = '1' WHERE key = 'schema_version'"
+        )
+
+    result = asyncio.run(
+        concepts.marm_concept_build(
+            ConceptBuildRequest(session_name="sess-a", run_id="legacy-run")
+        )
+    )
+
+    assert result["error_code"] == "rebuild_required"
+    with concept_db.get_connection() as conn:
+        run = conn.execute(
+            "SELECT status, error_code FROM concept_build_runs WHERE id = ?",
+            ("legacy-run",),
+        ).fetchone()
+    assert tuple(run) == ("error", "rebuild_required")
 
 
 def test_fetch_memory_rows_excludes_marm_system_session(concepts_env):

--- a/marm-mcp-server/tests/test_graph_context.py
+++ b/marm-mcp-server/tests/test_graph_context.py
@@ -1,0 +1,294 @@
+import asyncio
+import sqlite3
+
+import pytest
+
+from conftest import load_isolated_server, local_client
+from marm_mcp_server.core.concept_db import (
+    ConceptDB,
+    backup_and_reset_concept_database,
+    inspect_concept_schema,
+)
+from marm_mcp_server.core.response_limiter import MCPResponseLimiter
+from marm_mcp_server.services.graph_context import (
+    attach_graph_context,
+    get_graph_context,
+)
+from marm_mcp_server.services import recall as recall_service
+
+
+def _seed_graph(db_path):
+    graph = ConceptDB(str(db_path))
+    with graph.get_connection() as conn:
+        queue_id, _ = graph.get_or_create_entity(
+            conn,
+            "write queue",
+            "component",
+            "sess-a",
+            "marm-memory",
+            "mem-1",
+            platform="claude-code",
+        )
+        worker_id, _ = graph.get_or_create_entity(
+            conn,
+            "embedding worker",
+            "component",
+            "sess-a",
+            "marm-memory",
+            "mem-1",
+            platform="claude-code",
+        )
+        graph.store_relationship(
+            conn,
+            queue_id,
+            worker_id,
+            "feeds",
+            "mem-1",
+            "marm-memory",
+            platform="claude-code",
+        )
+        cursor_id, _ = graph.get_or_create_entity(
+            conn,
+            "write queue",
+            "component",
+            "sess-a",
+            "marm-memory",
+            "mem-2",
+            platform="cursor",
+        )
+        other_id, _ = graph.get_or_create_entity(
+            conn,
+            "cursor worker",
+            "component",
+            "sess-a",
+            "marm-memory",
+            "mem-2",
+            platform="cursor",
+        )
+        graph.store_relationship(
+            conn,
+            cursor_id,
+            other_id,
+            "feeds",
+            "mem-2",
+            "marm-memory",
+            platform="cursor",
+        )
+    graph.close()
+
+
+def test_graph_context_uses_memory_provenance_and_platform_scope(monkeypatch, tmp_path):
+    db_path = tmp_path / "marm_index.db"
+    monkeypatch.setenv("MARM_CONCEPT_DB_PATH", str(db_path))
+    _seed_graph(db_path)
+
+    context = get_graph_context(
+        query="how are pending writes processed?",
+        memory_ids=["mem-1"],
+        session_name="sess-a",
+        project="marm-memory",
+        platform="claude-code",
+        depth=2,
+    )
+
+    assert context["status"] == "available"
+    assert {entity["name"] for entity in context["entities"]} == {
+        "write queue",
+        "embedding worker",
+    }
+    assert context["seed_sources"]["memory_results"] == 2
+    assert "cursor worker" not in {item["name"] for item in context["related_entities"]}
+
+
+def test_entity_identity_includes_platform(tmp_path):
+    graph = ConceptDB(str(tmp_path / "marm_index.db"))
+    with graph.get_connection() as conn:
+        claude_id, _ = graph.get_or_create_entity(
+            conn, "shared", "concept", "sess", "project", "m1", platform="claude"
+        )
+        cursor_id, _ = graph.get_or_create_entity(
+            conn, "shared", "concept", "sess", "project", "m2", platform="cursor"
+        )
+    graph.close()
+
+    assert claude_id != cursor_id
+
+
+def test_graph_context_direct_name_match_can_upgrade_no_results(monkeypatch, tmp_path):
+    db_path = tmp_path / "marm_index.db"
+    monkeypatch.setenv("MARM_CONCEPT_DB_PATH", str(db_path))
+    _seed_graph(db_path)
+
+    context = get_graph_context(
+        query="write queue",
+        session_name="sess-a",
+        project="marm-memory",
+        platform="claude-code",
+    )
+    response = attach_graph_context(
+        {"status": "no_results", "results": [], "query": "write queue"}, context
+    )
+
+    assert response["status"] == "success"
+    assert response["results"] == []
+    assert response["graph_context"]["seed_sources"]["query_match"] == 1
+
+
+def test_missing_graph_is_not_created_by_recall(monkeypatch, tmp_path):
+    db_path = tmp_path / "missing" / "marm_index.db"
+    monkeypatch.setenv("MARM_CONCEPT_DB_PATH", str(db_path))
+
+    context = get_graph_context(query="anything", session_name="sess-a")
+
+    assert context["status"] == "unavailable"
+    assert not db_path.exists()
+
+
+def test_corrupt_graph_fails_open_without_changing_primary_results(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "marm_index.db"
+    db_path.write_bytes(b"not a sqlite database")
+    monkeypatch.setenv("MARM_CONCEPT_DB_PATH", str(db_path))
+    primary = {"status": "success", "results": [{"id": "m1", "content": "kept"}]}
+
+    context = get_graph_context(query="anything", memory_ids=["m1"])
+    result = attach_graph_context(primary, context)
+
+    assert context["status"] == "unavailable"
+    assert result["status"] == "success"
+    assert result["results"] == primary["results"]
+
+
+def test_platformless_graph_requires_explicit_reset(monkeypatch, tmp_path):
+    db_path = tmp_path / "legacy.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript("""
+            CREATE TABLE entities (
+                id INTEGER PRIMARY KEY, name TEXT, type TEXT,
+                session_name TEXT, project TEXT, source_memory_ids TEXT
+            );
+            CREATE TABLE relationships (
+                id INTEGER PRIMARY KEY, source_id INTEGER, target_id INTEGER,
+                predicate TEXT, memory_id TEXT, project TEXT
+            );
+            INSERT INTO entities VALUES (1, 'legacy', 'concept', 'sess-a', NULL, '["m1"]');
+            """)
+    monkeypatch.setenv("MARM_CONCEPT_DB_PATH", str(db_path))
+
+    assert inspect_concept_schema(str(db_path)) == "rebuild_required"
+    assert get_graph_context(query="legacy")["status"] == "rebuild_required"
+
+    backup = backup_and_reset_concept_database(str(db_path))
+
+    assert backup
+    assert inspect_concept_schema(str(db_path)) == "current"
+    with sqlite3.connect(backup) as conn:
+        assert conn.execute("SELECT name FROM entities").fetchone()[0] == "legacy"
+
+
+def test_targeted_build_cannot_reset_platformless_graph(monkeypatch, tmp_path):
+    from marm_mcp_server.core.models import ConceptBuildRequest
+    from marm_mcp_server.endpoints import concepts
+
+    db_path = tmp_path / "legacy.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript("""
+            CREATE TABLE entities (id INTEGER PRIMARY KEY, name TEXT, type TEXT);
+            CREATE TABLE relationships (
+                id INTEGER PRIMARY KEY, source_id INTEGER, target_id INTEGER,
+                predicate TEXT
+            );
+            """)
+    monkeypatch.setenv("MARM_CONCEPT_DB_PATH", str(db_path))
+    if concepts._concept_db is not None:
+        concepts._concept_db.close()
+    concepts._concept_db = None
+
+    with pytest.raises(ValueError, match="rebuild_required"):
+        concepts._prepare_build_schema(ConceptBuildRequest(session_name="sess-a"))
+
+    assert inspect_concept_schema(str(db_path)) == "rebuild_required"
+    assert concepts._prepare_build_schema(ConceptBuildRequest(search_all=True)) is True
+    assert inspect_concept_schema(str(db_path)) == "current"
+
+
+def test_graph_context_is_reduced_before_primary_results(monkeypatch):
+    monkeypatch.setattr(MCPResponseLimiter, "CONTENT_LIMIT", 700)
+    response = {
+        "status": "success",
+        "results": [{"id": "m1", "content": "primary result"}],
+    }
+    context = {
+        "status": "available",
+        "entities": [{"name": "x" * 100, "type": "concept"}] * 10,
+        "related_entities": [{"name": "y" * 100, "predicate": "uses"}] * 10,
+        "linked_code": [{"qualified_name": "z" * 100}] * 10,
+        "seed_sources": {"memory_results": 1, "query_match": 0},
+        "truncated": False,
+    }
+
+    result = attach_graph_context(response, context)
+
+    assert result["results"] == response["results"]
+    assert result["graph_context"]["truncated"] is True
+    assert MCPResponseLimiter.estimate_response_size(result) <= 700
+
+
+def test_http_graph_only_recall_keeps_empty_primary_results(monkeypatch, tmp_path):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    from marm_mcp_server.endpoints import memory as memory_endpoint
+
+    monkeypatch.setattr(
+        memory_endpoint,
+        "get_graph_context",
+        lambda **kwargs: {
+            "status": "available",
+            "entities": [{"name": "graph-only", "type": "concept"}],
+            "related_entities": [],
+            "linked_code": [],
+            "seed_sources": {"memory_results": 0, "query_match": 1},
+            "truncated": False,
+        },
+    )
+    client = local_client(server.app)
+
+    response = client.post(
+        "/marm_smart_recall",
+        json={"query": "graph-only", "session_name": "sess-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["results"] == []
+    assert response.json()["graph_context"]["status"] == "available"
+
+
+def test_stdio_service_returns_same_graph_only_contract(monkeypatch):
+    class EmptyMemory:
+        async def recall_similar(self, *args, include_scan_metadata=False, **kwargs):
+            if include_scan_metadata:
+                return [], {"scan": "none"}
+            return []
+
+    monkeypatch.setattr(recall_service, "memory", EmptyMemory())
+    monkeypatch.setattr(
+        recall_service,
+        "get_graph_context",
+        lambda **kwargs: {
+            "status": "available",
+            "entities": [{"name": "graph-only", "type": "concept"}],
+            "related_entities": [],
+            "linked_code": [],
+            "seed_sources": {"memory_results": 0, "query_match": 1},
+            "truncated": False,
+        },
+    )
+
+    result = asyncio.run(
+        recall_service.smart_recall("graph-only", search_all=True, limit=5)
+    )
+
+    assert result["status"] == "success"
+    assert result["results"] == []
+    assert result["graph_context"]["status"] == "available"

--- a/marm-mcp-server/tests/test_stdio_transport.py
+++ b/marm-mcp-server/tests/test_stdio_transport.py
@@ -761,6 +761,30 @@ def test_stdio_concept_recall_rejects_out_of_range_limit(monkeypatch, tmp_path):
     assert "Concept recall failed" in result["message"]
 
 
+def test_stdio_concept_recall_forwards_platform_scope(monkeypatch, tmp_path):
+    stdio = _isolated_stdio(monkeypatch, tmp_path)
+    import marm_mcp_server.services.stdio_graph_tools as stdio_graph_tools
+
+    captured = {}
+
+    def _fake_recall(*args):
+        captured["args"] = args
+        return {"status": "success", "entities": []}
+
+    monkeypatch.setattr(stdio_graph_tools, "_run_recall", _fake_recall)
+
+    result = asyncio.run(
+        stdio.marm_concept_recall(
+            query="auth",
+            project="marm-memory",
+            platform="claude-code",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert captured["args"][-2:] == ("marm-memory", "claude-code")
+
+
 def test_stdio_concept_build_uses_same_endpoint_logic(monkeypatch, tmp_path):
     stdio = _isolated_stdio(monkeypatch, tmp_path)
     import marm_mcp_server.services.stdio_graph_tools as stdio_graph_tools


### PR DESCRIPTION
## Graph-aware recall and Console atlas

  - Added bounded, read-only `graph_context` to `marm_smart_recall`. Primary memory ranking stays authoritative, and
  graph lookup fails open when the concept database is missing, empty, unavailable, or needs rebuilding.
  - Added platform provenance to concept entities and relationships. Legacy concept graphs now require one explicit
  `marm_concept_build(search_all=True)` rebuild, with a timestamped backup of only the derived concept database.
  - Added optional `platform` scope to `marm_concept_recall` over both HTTP and STDIO while preserving the existing 14-
  tool public surface.
  - Reworked the Console knowledge graph API for full atlas mode on moderate graphs and deterministic connected sampling
  on large graphs. The UI now uses adaptive force layout, weighted relationships, focused labels, and stable manual
  pause behavior.
  - Updated README, protocol docs, agent instructions, server metadata, and changelog for the graph-aware recall and
  Console behavior.
  - Prepared v2.25.0 package, registry, Docker, and install-document version metadata.

  ### Validation

  - `78 passed` for graph context, concept endpoint, and STDIO transport coverage.
  - `14 passed` for Console concept-store and atlas coverage.
  - Console typecheck and production build passed.
  - `python scripts/find-tools.py` and `validate_server_json.py` passed.
  - `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart recall can attach bounded concept/code graph relationships and linked-code context as an additive sidecar without changing primary memory ranking.
  * Concept recall now supports platform-scoped queries.
  * Console concept explorer adds full-atlas or deterministic sampled graph views with clearer rebuild status.

* **Bug Fixes**
  * Missing/unavailable graph data fails open so primary recall remains unaffected.
  * Graph-context output is trimmed to fit response size limits.

* **Documentation**
  * Added upgrade/rebuild guidance for concept graph updates (`marm_concept_build(search_all=True)`), including legacy/platform-attribution correction notes and updated tool/protocol descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->