### PR TITLE
Replace min-max BM25 fusion with RRF on hybrid recall path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -554,7 +554,7 @@
 
 ### Recall & Search
 
-- Added SQLite FTS5 indexing for memory content with automatic insert/update/delete triggers; `marm_smart_recall` merges semantic similarity with FTS BM25 keyword scoring via `HYBRID_SEARCH_TEXT_WEIGHT`, improving recall for commands, config keys, filenames, and error strings.
+- Added SQLite FTS5 indexing for memory content with automatic insert/update/delete triggers; `marm_smart_recall` merges semantic similarity with FTS BM25 keyword scoring, improving recall for commands, config keys, filenames, and error strings.
 - Added conservative temporal weighting via `TEMPORAL_WEIGHT` and `TEMPORAL_HALF_LIFE_DAYS` for modest recency boost when matches are close; FTS backfill on DB init for existing stores; LIKE fallback for unsanitizable queries.
 - Added 3-layer retrieval depth control (`detail=1/2/3`) with read-time truncation: Layer 1 ~200 chars, Layer 2 ~500 chars, Layer 3 full content; `detail_level` surfaced in recall responses.
 

--- a/README.md
+++ b/README.md
@@ -979,7 +979,6 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `WRITE_QUEUE_ENABLED` | `1` | Serialize writes through one worker |
 | `FTS_CANDIDATE_LIMIT` | `50` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap |
 | `RECALL_SCAN_LIMIT` | `10000` | Cap on the semantic fallback scan; `recall_scan_truncated=true` in responses means it was hit |
-| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.35` | Text-vs-semantic blend in hybrid scoring |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -981,7 +981,6 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `WRITE_QUEUE_ENABLED` | `1` | Serialize writes through one worker |
 | `FTS_CANDIDATE_LIMIT` | `50` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap |
 | `RECALL_SCAN_LIMIT` | `10000` | Cap on the semantic fallback scan; `recall_scan_truncated=true` in responses means it was hit |
-| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.35` | Text-vs-semantic blend in hybrid scoring |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |

--- a/marm-mcp-server/marm-docs/README.md
+++ b/marm-mcp-server/marm-docs/README.md
@@ -947,7 +947,6 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `WRITE_QUEUE_ENABLED` | `1` | Serialize writes through one worker |
 | `FTS_CANDIDATE_LIMIT` | `50` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap |
 | `RECALL_SCAN_LIMIT` | `10000` | Cap on the semantic fallback scan; `recall_scan_truncated=true` in responses means it was hit |
-| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.35` | Text-vs-semantic blend in hybrid scoring |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -228,17 +228,10 @@ if not (0.0 <= _raw_cdst <= 1.0):
         file=sys.stderr,
     )
 
-_raw_hsw = _safe_float("HYBRID_SEARCH_TEXT_WEIGHT", 0.35)
 _raw_tw = _safe_float("TEMPORAL_WEIGHT", 0.1)
 _raw_hld = _safe_float("TEMPORAL_HALF_LIFE_DAYS", 30)
-HYBRID_SEARCH_TEXT_WEIGHT = max(0.0, min(1.0, _raw_hsw))
 TEMPORAL_WEIGHT = max(0.0, min(1.0, _raw_tw))
 TEMPORAL_HALF_LIFE_DAYS = max(1.0, _raw_hld)
-if not (0.0 <= _raw_hsw <= 1.0):
-    print(
-        f"WARNING: HYBRID_SEARCH_TEXT_WEIGHT={_raw_hsw} out of [0, 1], clamped to {HYBRID_SEARCH_TEXT_WEIGHT}",
-        file=sys.stderr,
-    )
 if not (0.0 <= _raw_tw <= 1.0):
     print(
         f"WARNING: TEMPORAL_WEIGHT={_raw_tw} out of [0, 1], clamped to {TEMPORAL_WEIGHT}",

--- a/marm-mcp-server/marm_mcp_server/core/memory_recall.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_recall.py
@@ -9,7 +9,6 @@ from ..config.settings import (
     TEMPORAL_WEIGHT,
     TEMPORAL_HALF_LIFE_DAYS,
     FTS_CANDIDATE_LIMIT,
-    HYBRID_SEARCH_TEXT_WEIGHT,
 )
 from .memory_utils import (
     _safe_print,
@@ -23,6 +22,7 @@ from .memory_scoring import (
     _fetch_and_score_by_ids,
     _fetch_and_score_embedding_rows,
     _fetch_and_score_fts_rows,
+    _rrf_scores,
 )
 
 
@@ -227,7 +227,6 @@ async def _recall_similar(
                 )
                 _recall_debug("FTS filter failed → semantic fallback")
 
-        bm25_by_id = dict(candidates)
         use_semantic_fallback = True
         if candidates:
             similarities, dim_skipped = await asyncio.to_thread(
@@ -265,19 +264,21 @@ async def _recall_similar(
                 f"recall_similar: skipped {dim_skipped} memories with wrong embedding dimension (expected {len(query_embedding)})"
             )
 
-        # Lexical fusion only applies on the FTS filter->rerank path, where every
-        # scored row has a BM25 score. The semantic fallback scan has no lexical
-        # signal, so it keeps the pure semantic+temporal blend.
-        apply_bm25 = not use_semantic_fallback and bool(bm25_by_id)
+        # Hybrid path: fuse BM25 and cosine by Reciprocal Rank Fusion (ranks only).
+        # Semantic fallback has no lexical list, so it keeps pure semantic+temporal.
+        # Similarity magnitudes on the hybrid path are RRF-scaled, not cosine.
+        apply_rrf = not use_semantic_fallback and bool(candidates)
+        rrf_by_id: dict[str, float] = {}
+        if apply_rrf:
+            bm25_ranked = [cid for cid, _ in candidates]
+            cosine_ranked = [mem_row["id"] for mem_row, _ in similarities]
+            rrf_by_id = _rrf_scores([bm25_ranked, cosine_ranked])
 
         combined: dict[str, tuple] = {}
         for mem_row, vec_score in similarities:
             t_score = _temporal_score(mem_row["timestamp"], TEMPORAL_HALF_LIFE_DAYS)
-            if apply_bm25:
-                bm25_score = bm25_by_id.get(mem_row["id"], 0.0)
-                relevance = (
-                    1 - HYBRID_SEARCH_TEXT_WEIGHT
-                ) * vec_score + HYBRID_SEARCH_TEXT_WEIGHT * bm25_score
+            if apply_rrf:
+                relevance = rrf_by_id.get(mem_row["id"], 0.0)
             else:
                 relevance = vec_score
             combined[mem_row["id"]] = (

--- a/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
@@ -19,6 +19,31 @@ def _normalize_bm25(raw_scores: list[float]) -> list[float]:
     return [(max_s - s) / span for s in raw_scores]
 
 
+# Cormack et al. (2009) default; softens top-rank dominance without per-retriever weights.
+RRF_K = 60
+
+
+def _rrf_scores(
+    rank_lists: list[list[str]],
+    *,
+    k: int = RRF_K,
+) -> dict[str, float]:
+    """Reciprocal Rank Fusion over ranked id lists, scaled into roughly [0, 1].
+
+    For each list, rank 1 is best. A document missing from a list contributes
+    nothing for that list (fail-open). Raw RRF is scaled by (k+1)/2 so that
+    rank-1 on exactly two lists maps to 1.0 before any temporal blend.
+    """
+    scores: dict[str, float] = {}
+    for ranked_ids in rank_lists:
+        for rank, doc_id in enumerate(ranked_ids, start=1):
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k + rank)
+    if not scores:
+        return {}
+    scale = (k + 1) / 2.0
+    return {doc_id: score * scale for doc_id, score in scores.items()}
+
+
 def _score_embedding_rows(rows, query_embedding, limit: int):
     """Score embedding rows in one NumPy batch instead of a Python cosine loop."""
     if limit <= 0:

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -621,9 +621,13 @@ async def test_recall_similar_debug_logs_semantic_fallback_path(monkeypatch, tmp
 
 @pytest.mark.asyncio
 async def test_recall_similar_fuses_bm25_into_ranking(monkeypatch, tmp_path):
-    """Two candidates with identical embeddings must be ordered by their BM25
-    score, proving the lexical signal is fused into the blend rather than
-    discarded after the FTS filter."""
+    """RRF must consume the BM25 candidate *order* (stub floats are ignored).
+
+    Cosine scores are forced identical with a fixed return order. When the FTS
+    list agrees with that order, the leader ranks first with a higher score;
+    when FTS order is reversed, RRF contributions cancel and the scores tie —
+    proving the lexical rank list is fused rather than discarded.
+    """
     from marm_mcp_server.core import memory_recall as memory_recall_module
 
     memory = MARMMemory(str(tmp_path / "memory.db"))
@@ -637,23 +641,68 @@ async def test_recall_similar_fuses_bm25_into_ranking(monkeypatch, tmp_path):
         strong_id = _insert_with_embedding(conn, "fuse", "docker deployment", vec)
         weak_id = _insert_with_embedding(conn, "fuse", "docker sidebar", vec)
 
-    # Identical embeddings -> identical vec_score. Only the BM25 term differs,
-    # so any ordering must come from lexical fusion.
+    original_scorer = memory_recall_module._fetch_and_score_by_ids
+
+    def tied_cosine_scorer(db_path, memory_ids, query_embedding):
+        results, skipped = original_scorer(db_path, memory_ids, query_embedding)
+        by_id = {row["id"]: (row, score) for row, score in results}
+        score = next(iter(by_id.values()))[1]
+        return [
+            (by_id[strong_id][0], score),
+            (by_id[weak_id][0], score),
+        ], skipped
+
+    monkeypatch.setattr(
+        memory_recall_module, "_fetch_and_score_by_ids", tied_cosine_scorer
+    )
+    # Neutralize temporal so a pure RRF tie is observable.
+    monkeypatch.setattr(memory_recall_module, "TEMPORAL_WEIGHT", 0.0)
+
     monkeypatch.setattr(
         memory_recall_module,
         "_fetch_fts_candidate_ids",
         lambda *_: [(strong_id, 1.0), (weak_id, 0.0)],
     )
-
-    results = await memory.recall_similar(
+    results_agree = await memory.recall_similar(
         "docker", session="fuse", limit=5, query_vec=vec.copy()
     )
-    ids = [r["id"] for r in results]
+    ids_agree = [r["id"] for r in results_agree]
+    assert ids_agree.index(strong_id) < ids_agree.index(weak_id)
+    assert (
+        results_agree[ids_agree.index(strong_id)]["similarity"]
+        > results_agree[ids_agree.index(weak_id)]["similarity"]
+    )
 
-    assert ids.index(strong_id) < ids.index(weak_id)
-    strong_sim = results[ids.index(strong_id)]["similarity"]
-    weak_sim = results[ids.index(weak_id)]["similarity"]
-    assert strong_sim > weak_sim
+    monkeypatch.setattr(
+        memory_recall_module,
+        "_fetch_fts_candidate_ids",
+        lambda *_: [(weak_id, 1.0), (strong_id, 0.0)],
+    )
+    results_swap = await memory.recall_similar(
+        "docker", session="fuse", limit=5, query_vec=vec.copy()
+    )
+    by_id = {r["id"]: r["similarity"] for r in results_swap}
+    assert by_id[strong_id] == pytest.approx(by_id[weak_id])
+
+
+def test_rrf_scores_known_ranks():
+    """Pure RRF math: known 1-based ranks map to the scaled closed form."""
+    from marm_mcp_server.core.memory_scoring import RRF_K, _rrf_scores
+
+    k = RRF_K
+    scores = _rrf_scores([["a", "b"], ["a", "b"]], k=k)
+    # Rank-1 on both lists: 2/(k+1) * (k+1)/2 = 1.0
+    assert scores["a"] == pytest.approx(1.0)
+    # Rank-2 on both: 2/(k+2) * (k+1)/2 = (k+1)/(k+2)
+    assert scores["b"] == pytest.approx((k + 1) / (k + 2))
+
+    # Present in only one list → half of the two-list ceiling.
+    single = _rrf_scores([["a"], ["b"]], k=k)
+    assert single["a"] == pytest.approx(0.5)
+    assert single["b"] == pytest.approx(0.5)
+
+    assert _rrf_scores([]) == {}
+    assert _rrf_scores([[], []]) == {}
 
 
 def test_normalize_bm25_maps_more_negative_to_higher_score():


### PR DESCRIPTION
**Summary**
Replace min-max BM25 + weighted cosine fusion on the hybrid filter→rerank path with Reciprocal Rank Fusion (Cormack et al., k=60). Exact/lexical lanes and semantic-fallback-only scoring are unchanged. `_normalize_bm25` and its FTS callers are untouched.

**Math**
RRF(d) = sum of 1/(k + rank_r(d)) across the BM25-ranked and cosine-ranked lists, scaled by (k+1)/2, then blended with temporal decay exactly as before: final = (1-w)*s + w*t

Rank-based fusion avoids mixing an absolute cosine score with a per-query relative BM25 stretch, which previously let tight BM25 clusters amplify noise or one outlier crush mid-tier lexical signal.

Implemented in `_rrf_scores` (`memory_scoring.py`) and the hybrid fusion block in `_recall_similar` (`memory_recall.py`). The obsolete `HYBRID_SEARCH_TEXT_WEIGHT` setting has been removed.

**Client note**
Hybrid similarity magnitudes are now RRF-scaled, not a cosine/BM25 convex mix. Don't compare them to old thresholds without recalibration.

**Known follow-up (tracked separately)**
#113 — `find_semantic_duplicate()` checks `results[0]["similarity"] >= CONSOLIDATION_THRESHOLD` (default **0.92**), but hybrid-path `similarity` is RRF-scaled, not cosine. `exact_mode="semantic"` does **not** fix this: it still runs FTS-candidate + RRF fusion whenever FTS returns scoreable candidates (`memory_recall.py` ~208–286). Proposed fix: preserve raw cosine (e.g. `cosine_similarity`) alongside the RRF ranking score so consolidation can gate on the correct quantity. Scope: consolidation only, gated behind `CONSOLIDATION_ENABLED` (default off).

**What I'd do next (other candidates considered)**
- FTS-as-hard-gate: `_recall_similar` only scores the semantic corpus when FTS returns zero candidates. When FTS returns any candidates, semantically close paraphrases that share no/few tokens never enter the pool. Higher impact than the fusion fix but riskier, since it changes candidate generation itself, not just ranking.
- Chunk-pooling bias: `_score_chunk_aware` collapses multi-chunk memories via max-over-chunks, which is statistically biased toward memories with more chunks and discards the parent/summary embedding entirely. A length-corrected max or logsumexp pooling, plus including the parent embedding as a competitor, would fix this cheaply.

I picked the RRF fusion fix because it had the best effort-to-impact ratio: most surgical of the three, has a clean established mathematical justification rather than an ad-hoc formula, and carries the lowest risk since it doesn't touch candidate generation or lane semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Hybrid memory search now combines semantic and keyword rankings using reciprocal rank fusion.
  * Improves relevance stability when semantic similarity and keyword matches disagree; semantic-only fallback behavior remains unchanged.
* **Tests**
  * Added unit coverage for reciprocal-rank-fusion scoring, hybrid ranking behavior under reversed keyword orders, and empty-result edge cases.
* **Documentation**
  * Removed `HYBRID_SEARCH_TEXT_WEIGHT` from configuration/environment variable references and related changelog notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->