### PR TITLE
feat(recall): set keyword ranking weight from benchmark data (v2.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>July 28th, 2026: Keyword Ranking Weight Set From Benchmark Data (v2.32.0)</strong></summary>
+
+### Keyword Relevance Now Contributes to Ranking
+
+- v2.31.0 made the keyword index find candidates for natural-language questions but deliberately left keyword scores out of ranking, because the old 35% weight had been chosen while that path never ran and so had never been validated. The weight has now been swept against the benchmark and is on.
+- `HYBRID_SEARCH_TEXT_WEIGHT` defaults to `0.05`. Swept over `0.00, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.10, 0.15, 0.20, 0.35, 0.50` on LoCoMo (1,977 questions, 5,882 ingested memories, top-5 recall), any-hit peaks across a broad `0.04`-`0.08` plateau at 62.0-62.5%, against 57.4% with keyword scoring off and 57.6% at the old 0.35. `0.05` is the middle of that plateau rather than the single best run, so the default is not fitted to one corpus. Large weights are actively harmful: single-hop accuracy falls from 56.9% at `0.05` to 47.3% at `0.35`.
+- `FTS_CANDIDATE_LIMIT` default raised from `50` to `200`. This was the lever on the multi-hop regression v2.31.0 introduced, and raising it recovers multi-hop any-hit from 34.8% to 39.3%, matching the pre-v2.31.0 baseline, while lifting single-hop 1.1 points and leaving adversarial precision unchanged. Recall costs roughly 3ms more per query. `500` recovers a further 1.1 points of multi-hop but starts giving back the adversarial gain, because a pool that large no longer narrows anything.
+- Combined result versus v2.31.0 measured on the same corpus: any-hit 57.4% to 62.5%, all-hit 47.6% to 52.6%, evidence recall 51.9% to 56.9%. Every question category improves, and multi-hop, the one category v2.31.0 set back, is fully recovered.
+
+### Fixed: Keyword Candidate Selection Was Not Reproducible
+
+- When several memories tied on keyword score at the candidate cutoff, which ones entered the pool depended on the order SQLite happened to return rows, and that order varied between server processes. Ties at the cutoff are the normal case, not an edge case: 53.7% of benchmark queries had one. Two identical benchmark runs disagreed on 18 questions and scored 0.5 points apart, and the same recall could return different results across restarts.
+- Candidate selection now breaks ties on memory ID, so the pool is stable for a given database. Accuracy is unchanged within measurement error; what changes is that results are now reproducible. This also means benchmark differences smaller than roughly 0.1 points are now meaningful, where previously anything under 0.5 points was indistinguishable from noise.
+
+### New Settings
+
+- `FTS_LONE_HIT_SCORE` (default `1.0`) sets the keyword score used when a candidate set is too degenerate to rank, meaning a single match or every match tied. It defaults to no change in behavior: swept over `0.0/0.3/0.5/1.0` with no measurable effect. The offline diagnostic found one degenerate set across 1,982 FTS calls, a count distinct from the benchmark's 1,977 scored-question result set. It is exposed for small stores, where a query matching exactly one memory is common and treating that as a perfect keyword match may not be wanted.
+- `marm-memory doctor` reports the new value in its existing "Recall tuning" section.
+
+</details>
+
+<details>
 <summary><strong>July 26th, 2026: Natural-Language Keyword Retrieval Activated (v2.31.0)</strong></summary>
 
 ### Natural-Language Recall Now Uses the Keyword Index

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you do want to go deeper, MARM is focused on the MCP server, local memory wor
 
 ## Questions or Ideas
 
-Drop a message in [MARM Discord](https://discord.gg/nhyJWPz2cf) or reach out directly at ryanlyell@marmsystems.com.
+Drop a message in [MARM Discord](https://discord.gg/nhyJWPz2cf) or reach out directly at lyellr88@gmail.com.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.31.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.32.0</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -841,7 +841,7 @@ The first query is about *meaning*, so MARM reranks candidates with local vector
 MARM uses **filter→rerank hybrid recall** plus an exact retrieval lane:
 
 1. **Exact lane** (`exact_mode="auto"`, the default): config keys, CLI flags, file paths, API/tool names, dotted namespaces, HTTP routes, URLs, and quoted command strings are detected and routed through deterministic FTS5 BM25 with a LIKE fallback. No embeddings involved, so results are stable and literal.
-2. **Filter→rerank lane**: natural-language queries first pull a bounded candidate set from the FTS index (`FTS_CANDIDATE_LIMIT`, default 50), then semantic embeddings rerank those candidates by meaning. Conservative temporal weighting gives fresher memories a modest boost when matches are otherwise close.
+2. **Filter→rerank lane**: natural-language queries first pull a bounded candidate set from the FTS index (`FTS_CANDIDATE_LIMIT`, default 200), then semantic embeddings rerank those candidates by meaning. Conservative temporal weighting gives fresher memories a modest boost when matches are otherwise close.
 3. **Bounded semantic fallback**: when FTS coverage is weak or unusable, MARM falls back to a bounded semantic scan (`RECALL_SCAN_LIMIT`). If the response includes `recall_scan_truncated=true`, the fallback hit its cap; narrow the session/query or raise the env var for larger stores.
 4. **Chunk-aware scoring**: long memories (roughly 180+ words) are embedded as overlapping chunk rows internally, and recall collapses chunk scores back to one parent memory using the best-matching chunk. Both the rerank lane and the fallback lane are chunk-aware.
 
@@ -979,11 +979,12 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `MARM_PROJECT` / `MARM_PLATFORM` | *(auto-detected)* | Override project/platform attribution |
 | `MARM_RATE_LIMIT_RPM` | `80` | Requests per minute per IP (presets override) |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialize writes through one worker |
-| `FTS_CANDIDATE_LIMIT` | `50` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap |
+| `FTS_CANDIDATE_LIMIT` | `200` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap, lower to tighten results to the closest keyword matches |
 | `RECALL_SCAN_LIMIT` | `10000` | Cap on the semantic fallback scan; `recall_scan_truncated=true` in responses means it was hit |
 | `FTS_QUERY_MODE` | `or_nostop` | How semantic recall builds its keyword query: `or_nostop` ignores filler words then matches any remaining term, `or` matches any term, `and` requires every term (the pre-2.31.0 behavior). The exact/lexical lane always requires every term. |
 | `FTS_EXTRA_STOPWORDS` | *(empty)* | Comma-separated extra words to ignore when building keyword queries, for terms so common in your store they carry no signal |
-| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.0` | How much the keyword score influences ranking. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
+| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.05` | How much the keyword score influences ranking. Set from a benchmark sweep; accuracy peaks across `0.04`-`0.08` and falls off sharply above `0.10`. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
+| `FTS_LONE_HIT_SCORE` | `1.0` | Keyword score used when only one memory matches, or when every match ties. Lower it on small stores if a single keyword match should not count as a perfect one. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please report security issues privately by emailing:
 
-**support@marmsystems.com**
+**lyellr88@gmail.com**
 
 Do not open a public GitHub issue or pull request for vulnerabilities that could expose user memory, logs, notebook data, authentication gaps, deployment risks, secrets, or other sensitive details.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -150,7 +150,7 @@ It can also filter by `project` and `platform` when those metadata fields are av
 
 When the semantic fallback lane reaches its configured scan cap, responses include `recall_scan_truncated=true` and `recall_scan_limit` so agents know that part of recall was bounded. The primary filter→rerank lane does not set truncation because it works over a fixed FTS candidate set instead of a broad embedding scan.
 
-`FTS_CANDIDATE_LIMIT` (default `50`) controls how many keyword candidates are fetched before semantic reranking. On a store of any size, ordinary questions usually fill this pool completely, so it is the main lever on how much recall breadth you get. Raising it helps questions whose answer is spread across several memories that do not all share wording with the question; lowering it tightens results to the closest keyword matches. `FTS_QUERY_MODE` and `FTS_EXTRA_STOPWORDS` control how the keyword query itself is built.
+`FTS_CANDIDATE_LIMIT` (default `200`) controls how many keyword candidates are fetched before semantic reranking. On a store of any size, ordinary questions usually fill this pool completely, so it is the main lever on how much recall breadth you get. Raising it helps questions whose answer is spread across several memories that do not all share wording with the question; lowering it tightens results to the closest keyword matches. `FTS_QUERY_MODE` and `FTS_EXTRA_STOPWORDS` control how the keyword query itself is built.
 
 If you need less context back from each hit, `marm_smart_recall` also supports `detail=1/2/3` so agents can default to short previews and only request full memory bodies when needed.
 

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.31.0** - Memory Accurate Response Mode
+**MARM v2.32.0** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.31.0** - Memory Accurate Response Mode
+**MARM v2.32.0** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -320,7 +320,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.31.0 MCP Server - Platform Integration Guide
+# MARM v2.32.0 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.31.0** - Memory Accurate Response Mode
+**MARM v2.32.0** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -294,7 +294,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/TECHNICAL-OVERVIEW.md
+++ b/docs/TECHNICAL-OVERVIEW.md
@@ -1,6 +1,6 @@
 # MARM Technical Overview
 
-> Current implementation: MARM MCP Server v2.31.0
+> Current implementation: MARM MCP Server v2.32.0
 
 This document explains what MARM is, why it is built this way, and how information moves through the system from an agent writing something to that information being recalled later. It is intended as a technical product overview, not a source-code reference.
 

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -73,7 +73,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.31.0"
+LABEL org.opencontainers.image.version="2.32.0"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -7,7 +7,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.31.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.32.0</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -841,7 +841,7 @@ The first query is about *meaning*, so MARM reranks candidates with local vector
 MARM uses **filter→rerank hybrid recall** plus an exact retrieval lane:
 
 1. **Exact lane** (`exact_mode="auto"`, the default): config keys, CLI flags, file paths, API/tool names, dotted namespaces, HTTP routes, URLs, and quoted command strings are detected and routed through deterministic FTS5 BM25 with a LIKE fallback. No embeddings involved, so results are stable and literal.
-2. **Filter→rerank lane**: natural-language queries first pull a bounded candidate set from the FTS index (`FTS_CANDIDATE_LIMIT`, default 50), then semantic embeddings rerank those candidates by meaning. Conservative temporal weighting gives fresher memories a modest boost when matches are otherwise close.
+2. **Filter→rerank lane**: natural-language queries first pull a bounded candidate set from the FTS index (`FTS_CANDIDATE_LIMIT`, default 200), then semantic embeddings rerank those candidates by meaning. Conservative temporal weighting gives fresher memories a modest boost when matches are otherwise close.
 3. **Bounded semantic fallback**: when FTS coverage is weak or unusable, MARM falls back to a bounded semantic scan (`RECALL_SCAN_LIMIT`). If the response includes `recall_scan_truncated=true`, the fallback hit its cap; narrow the session/query or raise the env var for larger stores.
 4. **Chunk-aware scoring**: long memories (roughly 180+ words) are embedded as overlapping chunk rows internally, and recall collapses chunk scores back to one parent memory using the best-matching chunk. Both the rerank lane and the fallback lane are chunk-aware.
 
@@ -979,11 +979,12 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `MARM_PROJECT` / `MARM_PLATFORM` | *(auto-detected)* | Override project/platform attribution |
 | `MARM_RATE_LIMIT_RPM` | `80` | Requests per minute per IP (presets override) |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialize writes through one worker |
-| `FTS_CANDIDATE_LIMIT` | `50` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap |
+| `FTS_CANDIDATE_LIMIT` | `200` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap, lower to tighten results to the closest keyword matches |
 | `RECALL_SCAN_LIMIT` | `10000` | Cap on the semantic fallback scan; `recall_scan_truncated=true` in responses means it was hit |
 | `FTS_QUERY_MODE` | `or_nostop` | How semantic recall builds its keyword query: `or_nostop` ignores filler words then matches any remaining term, `or` matches any term, `and` requires every term (the pre-2.31.0 behavior). The exact/lexical lane always requires every term. |
 | `FTS_EXTRA_STOPWORDS` | *(empty)* | Comma-separated extra words to ignore when building keyword queries, for terms so common in your store they carry no signal |
-| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.0` | How much the keyword score influences ranking. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
+| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.05` | How much the keyword score influences ranking. Set from a benchmark sweep; accuracy peaks across `0.04`-`0.08` and falls off sharply above `0.10`. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
+| `FTS_LONE_HIT_SCORE` | `1.0` | Keyword score used when only one memory matches, or when every match ties. Lower it on small stores if a single keyword match should not count as a perfect one. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     # :latest is the all-in-one MCP image (memory + graph, one port).
     # Pin :memory-only instead if you need the pre-unification image shape.
-    image: lyellr88/marm-mcp-server:2.31.0
+    image: lyellr88/marm-mcp-server:2.32.0
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -18,7 +18,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.31.0
+      - SERVER_VERSION=2.32.0
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,10 +14,10 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.31.0
+Version: 2.32.0
 """
 
-__version__ = "2.31.0"
+__version__ = "2.32.0"
 __author__ = "Ryan Lyell"
 __email__ = "lyell@marmsystems.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -38,6 +38,23 @@ def _safe_float(env_key: str, default: float) -> float:
         return default
 
 
+def _safe_unit_float(env_key: str, default: float) -> float:
+    """Parse an env var as a float clamped to [0, 1], warning when it was out of range.
+
+    Several settings are weights or similarity scores that only mean anything
+    inside the unit interval; this keeps the parse, the clamp, and the warning in
+    one tested place instead of re-deriving them per setting.
+    """
+    raw = _safe_float(env_key, default)
+    clamped = max(0.0, min(1.0, raw))
+    if raw != clamped:
+        print(
+            f"WARNING: {env_key}={raw} out of [0, 1], clamped to {clamped}",
+            file=sys.stderr,
+        )
+    return clamped
+
+
 def _safe_choice(env_key: str, default: str, allowed: tuple[str, ...]) -> str:
     """Read an env var constrained to a fixed set, falling back on anything else."""
     raw = os.environ.get(env_key)
@@ -318,13 +335,7 @@ FTS_EXTRA_STOPWORDS = _csv_frozenset("FTS_EXTRA_STOPWORDS")
 # of 1,982 LoCoMo queries produced a degenerate set at all. It is exposed for
 # small stores, where a query matching a single memory is common and awarding it
 # a perfect lexical score may not be wanted.
-_raw_flhs = _safe_float("FTS_LONE_HIT_SCORE", 1.0)
-FTS_LONE_HIT_SCORE = max(0.0, min(1.0, _raw_flhs))
-if not (0.0 <= _raw_flhs <= 1.0):
-    print(
-        f"WARNING: FTS_LONE_HIT_SCORE={_raw_flhs} out of [0, 1], clamped to {FTS_LONE_HIT_SCORE}",
-        file=sys.stderr,
-    )
+FTS_LONE_HIT_SCORE = _safe_unit_float("FTS_LONE_HIT_SCORE", 1.0)
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
 _raw_ct = _safe_float("CONSOLIDATION_THRESHOLD", 0.92)

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -144,7 +144,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.31.0"
+SERVER_VERSION = "2.32.0"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 
@@ -250,15 +250,15 @@ if not (0.0 <= _raw_cdst <= 1.0):
         file=sys.stderr,
     )
 
-# Default is 0.0 on purpose -- do not "restore" it to 0.35.
-# Until the FTS candidate-generation fix (v2.31.0), _safe_fts_query AND-ed every
-# query token, so natural-language recall never produced FTS candidates and this
-# weight never applied on that path. Widening candidate generation makes the
-# lexical term live for the first time, so it ships at 0.0 (FTS acts purely as a
-# candidate filter for semantic reranking) until the sweep in
-# docs/current/fts-candidate-generation-fix.md Phase 2 sets an evidence-based
-# default. An explicit env var still overrides this.
-_raw_hsw = _safe_float("HYBRID_SEARCH_TEXT_WEIGHT", 0.0)
+# 0.05 is swept, not guessed -- do not "restore" it to the old 0.35.
+# Until v2.31.0 widened candidate generation this weight never applied to
+# natural-language recall, so it had never been validated. Swept in v2.32.0 over
+# 0.00-0.50 on LoCoMo (1,977 questions, 5,882 memories, deterministic pool):
+# any-hit peaks in a broad 0.04-0.08 plateau at 62.0-62.5%, against 57.4% at 0.0
+# and 57.6% at the old 0.35. High weights collapse single-hop accuracy (56.9% at
+# 0.05 -> 47.3% at 0.35). 0.05 is the plateau centre rather than the argmax, so
+# the default is not fitted to one corpus.
+_raw_hsw = _safe_float("HYBRID_SEARCH_TEXT_WEIGHT", 0.05)
 _raw_tw = _safe_float("TEMPORAL_WEIGHT", 0.1)
 _raw_hld = _safe_float("TEMPORAL_HALF_LIFE_DAYS", 30)
 HYBRID_SEARCH_TEXT_WEIGHT = max(0.0, min(1.0, _raw_hsw))
@@ -280,7 +280,16 @@ if _raw_hld < 1.0:
         file=sys.stderr,
     )
 
-_raw_fcl = _safe_int("FTS_CANDIDATE_LIMIT", 50)
+# Raised 50 -> 200 in v2.32.0. v2.31.0 made this knob load-bearing for the first
+# time (99.4% of LoCoMo queries saturated the old 50) and its cost was a 5.6pp
+# multi-hop regression, since a keyword-filtered pool can drop a required memory
+# that shares no wording with the question. Swept over 50/100/200/500: 200
+# recovers multi-hop to 39.3% (from 34.8% at 50, matching the pre-v2.31.0
+# baseline) and lifts single-hop 1.1pp with adversarial precision unchanged, for
+# roughly 3ms more per recall. 500 buys another 1.1pp of multi-hop but starts
+# giving back the adversarial gain, because a pool that large stops acting as a
+# precision gate.
+_raw_fcl = _safe_int("FTS_CANDIDATE_LIMIT", 200)
 FTS_CANDIDATE_LIMIT = max(1, _raw_fcl)
 if _raw_fcl < 1:
     print(
@@ -299,6 +308,23 @@ FTS_QUERY_MODE = _safe_choice("FTS_QUERY_MODE", "or_nostop", FTS_QUERY_MODES)
 # Extra stopwords appended to the built-in English list used by or_nostop.
 # Additive only -- it cannot remove built-ins. Comma-separated, case-insensitive.
 FTS_EXTRA_STOPWORDS = _csv_frozenset("FTS_EXTRA_STOPWORDS")
+
+# Lexical score given to a degenerate semantic-lane candidate set (one row, or
+# every row tied on BM25), where per-query min-max has no spread to normalize
+# against. The exact lane always uses 1.0.
+#
+# Stays at 1.0: swept over 0.0/0.3/0.5/1.0 in v2.32.0 with no measurable effect,
+# because on a corpus of any size the wide OR fills the candidate pool -- only 1
+# of 1,982 LoCoMo queries produced a degenerate set at all. It is exposed for
+# small stores, where a query matching a single memory is common and awarding it
+# a perfect lexical score may not be wanted.
+_raw_flhs = _safe_float("FTS_LONE_HIT_SCORE", 1.0)
+FTS_LONE_HIT_SCORE = max(0.0, min(1.0, _raw_flhs))
+if not (0.0 <= _raw_flhs <= 1.0):
+    print(
+        f"WARNING: FTS_LONE_HIT_SCORE={_raw_flhs} out of [0, 1], clamped to {FTS_LONE_HIT_SCORE}",
+        file=sys.stderr,
+    )
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"
 _raw_ct = _safe_float("CONSOLIDATION_THRESHOLD", 0.92)

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -331,10 +331,11 @@ FTS_EXTRA_STOPWORDS = _csv_frozenset("FTS_EXTRA_STOPWORDS")
 # against. The exact lane always uses 1.0.
 #
 # Stays at 1.0: swept over 0.0/0.3/0.5/1.0 in v2.32.0 with no measurable effect,
-# because on a corpus of any size the wide OR fills the candidate pool -- only 1
-# of 1,982 LoCoMo queries produced a degenerate set at all. It is exposed for
-# small stores, where a query matching a single memory is common and awarding it
-# a perfect lexical score may not be wanted.
+# because on a corpus of any size the wide OR fills the candidate pool. An offline
+# diagnostic found one degenerate set across 1,982 FTS calls (a call count, not the
+# benchmark's 1,977 scored questions); 1,964 of those calls saturated the pool.
+# Exposed for small stores, where a query matching a single memory is common and
+# awarding it a perfect lexical score may not be wanted.
 FTS_LONE_HIT_SCORE = _safe_unit_float("FTS_LONE_HIT_SCORE", 1.0)
 
 CONSOLIDATION_ENABLED = os.environ.get("CONSOLIDATION_ENABLED", "0") == "1"

--- a/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
@@ -3,18 +3,28 @@
 import sqlite3
 import numpy as np
 
+from ..config.settings import FTS_LONE_HIT_SCORE
 
-def _normalize_bm25(raw_scores: list[float]) -> list[float]:
+
+def _normalize_bm25(
+    raw_scores: list[float], *, lone_hit_score: float = 1.0
+) -> list[float]:
     """Map raw BM25 scores (more-negative = better) to [0, 1] with 1.0 best.
 
-    Single-row or all-equal result sets collapse to 1.0 so a lone lexical hit
-    still contributes its full text weight.
+    Per-query min-max needs a spread to normalize against, so single-row and
+    all-equal result sets are degenerate and get `lone_hit_score` instead.
+
+    How much evidence a degenerate set represents depends on how the MATCH was
+    built, so the caller decides. Under strict AND a lone hit means every query
+    term was present, which justifies the default 1.0. Under the semantic lane's
+    wide OR it can mean one memory contained one non-stopword, so that caller
+    passes FTS_LONE_HIT_SCORE.
     """
     if not raw_scores:
         return []
     min_s, max_s = min(raw_scores), max(raw_scores)
     if max_s == min_s:
-        return [1.0 for _ in raw_scores]
+        return [lone_hit_score for _ in raw_scores]
     span = max_s - min_s
     return [(max_s - s) / span for s in raw_scores]
 
@@ -210,7 +220,7 @@ def _fetch_and_score_fts_rows(
         if platform is not None:
             base += " AND m.platform = ?"
             params.append(platform)
-        base += " ORDER BY score LIMIT ?"
+        base += " ORDER BY score, m.id LIMIT ?"
         params.append(limit)
         rows = conn.execute(base, params).fetchall()
     finally:
@@ -219,6 +229,8 @@ def _fetch_and_score_fts_rows(
     if not rows:
         return []
 
+    # Exact lane: keeps the 1.0 default because this path is only reached with a
+    # strict-AND MATCH, where a lone hit means every query term was present.
     normalized = _normalize_bm25([row["score"] for row in rows])
     return list(zip(rows, normalized))
 
@@ -255,13 +267,20 @@ def _fetch_fts_candidate_ids(
         if platform is not None:
             base += " AND m.platform = ?"
             params.append(platform)
-        base += " ORDER BY bm25(memories_fts) LIMIT ?"
+        # m.id breaks BM25 ties so the LIMIT cutoff is reproducible. Measured on
+        # the LoCoMo corpus: 53.7% of queries have a tie straddling the 50-row
+        # boundary, and without a tiebreak SQLite's row order there varied
+        # between processes -- identical configs scored up to 0.5pp apart, which
+        # is larger than several of the effects this pool is used to measure.
+        base += " ORDER BY bm25(memories_fts), m.id LIMIT ?"
         params.append(limit)
         rows = conn.execute(base, params).fetchall()
     finally:
         conn.close()
 
-    normalized = _normalize_bm25([row[1] for row in rows])
+    normalized = _normalize_bm25(
+        [row[1] for row in rows], lone_hit_score=FTS_LONE_HIT_SCORE
+    )
     return [(row[0], score) for row, score in zip(rows, normalized)]
 
 

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/FAQ.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/FAQ.md
@@ -150,7 +150,7 @@ It can also filter by `project` and `platform` when those metadata fields are av
 
 When the semantic fallback lane reaches its configured scan cap, responses include `recall_scan_truncated=true` and `recall_scan_limit` so agents know that part of recall was bounded. The primary filter→rerank lane does not set truncation because it works over a fixed FTS candidate set instead of a broad embedding scan.
 
-`FTS_CANDIDATE_LIMIT` (default `50`) controls how many keyword candidates are fetched before semantic reranking. On a store of any size, ordinary questions usually fill this pool completely, so it is the main lever on how much recall breadth you get. Raising it helps questions whose answer is spread across several memories that do not all share wording with the question; lowering it tightens results to the closest keyword matches. `FTS_QUERY_MODE` and `FTS_EXTRA_STOPWORDS` control how the keyword query itself is built.
+`FTS_CANDIDATE_LIMIT` (default `200`) controls how many keyword candidates are fetched before semantic reranking. On a store of any size, ordinary questions usually fill this pool completely, so it is the main lever on how much recall breadth you get. Raising it helps questions whose answer is spread across several memories that do not all share wording with the question; lowering it tightens results to the closest keyword matches. `FTS_QUERY_MODE` and `FTS_EXTRA_STOPWORDS` control how the keyword query itself is built.
 
 If you need less context back from each hit, `marm_smart_recall` also supports `detail=1/2/3` so agents can default to short previews and only request full memory bodies when needed.
 

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.31.0</h1>
+# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.32.0</h1>
 
 ## Important Messages
 
@@ -807,7 +807,7 @@ The first query is about *meaning*, so MARM reranks candidates with local vector
 MARM uses **filter→rerank hybrid recall** plus an exact retrieval lane:
 
 1. **Exact lane** (`exact_mode="auto"`, the default): config keys, CLI flags, file paths, API/tool names, dotted namespaces, HTTP routes, URLs, and quoted command strings are detected and routed through deterministic FTS5 BM25 with a LIKE fallback. No embeddings involved, so results are stable and literal.
-2. **Filter→rerank lane**: natural-language queries first pull a bounded candidate set from the FTS index (`FTS_CANDIDATE_LIMIT`, default 50), then semantic embeddings rerank those candidates by meaning. Conservative temporal weighting gives fresher memories a modest boost when matches are otherwise close.
+2. **Filter→rerank lane**: natural-language queries first pull a bounded candidate set from the FTS index (`FTS_CANDIDATE_LIMIT`, default 200), then semantic embeddings rerank those candidates by meaning. Conservative temporal weighting gives fresher memories a modest boost when matches are otherwise close.
 3. **Bounded semantic fallback**: when FTS coverage is weak or unusable, MARM falls back to a bounded semantic scan (`RECALL_SCAN_LIMIT`). If the response includes `recall_scan_truncated=true`, the fallback hit its cap; narrow the session/query or raise the env var for larger stores.
 4. **Chunk-aware scoring**: long memories (roughly 180+ words) are embedded as overlapping chunk rows internally, and recall collapses chunk scores back to one parent memory using the best-matching chunk. Both the rerank lane and the fallback lane are chunk-aware.
 
@@ -945,11 +945,12 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `MARM_PROJECT` / `MARM_PLATFORM` | *(auto-detected)* | Override project/platform attribution |
 | `MARM_RATE_LIMIT_RPM` | `80` | Requests per minute per IP (presets override) |
 | `WRITE_QUEUE_ENABLED` | `1` | Serialize writes through one worker |
-| `FTS_CANDIDATE_LIMIT` | `50` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap |
+| `FTS_CANDIDATE_LIMIT` | `200` | BM25 candidates fetched before semantic reranking; raise for stores with weak keyword overlap, lower to tighten results to the closest keyword matches |
 | `RECALL_SCAN_LIMIT` | `10000` | Cap on the semantic fallback scan; `recall_scan_truncated=true` in responses means it was hit |
 | `FTS_QUERY_MODE` | `or_nostop` | How semantic recall builds its keyword query: `or_nostop` ignores filler words then matches any remaining term, `or` matches any term, `and` requires every term (the pre-2.31.0 behavior). The exact/lexical lane always requires every term. |
 | `FTS_EXTRA_STOPWORDS` | *(empty)* | Comma-separated extra words to ignore when building keyword queries, for terms so common in your store they carry no signal |
-| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.0` | How much the keyword score influences ranking. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
+| `HYBRID_SEARCH_TEXT_WEIGHT` | `0.05` | How much the keyword score influences ranking. Set from a benchmark sweep; accuracy peaks across `0.04`-`0.08` and falls off sharply above `0.10`. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
+| `FTS_LONE_HIT_SCORE` | `1.0` | Keyword score used when only one memory matches, or when every match ties. Lower it on small stores if a single keyword match should not count as a perfect one. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - marm-memory
-Version: 2.31.0
+Version: 2.32.0
 """
 
 import os

--- a/marm-mcp-server/marm_mcp_server/services/cli_output.py
+++ b/marm-mcp-server/marm_mcp_server/services/cli_output.py
@@ -99,6 +99,7 @@ def _print_doctor(payload: dict[str, Any]) -> None:
             f"  Keyword weight: {weight}"
             + (" (keyword matching narrows results only)" if weight == 0 else "")
         )
+        print(f"  Single-match score: {retrieval.get('fts_lone_hit_score')}")
         extra = retrieval.get("fts_extra_stopwords") or []
         if extra:
             print(f"  Ignored words added: {', '.join(extra)}")

--- a/marm-mcp-server/marm_mcp_server/services/runtime_status.py
+++ b/marm-mcp-server/marm_mcp_server/services/runtime_status.py
@@ -21,6 +21,7 @@ from ..config.settings import (
     FTS_CANDIDATE_LIMIT,
     FTS_EXTRA_STOPWORDS,
     FTS_QUERY_MODE,
+    FTS_LONE_HIT_SCORE,
     HYBRID_SEARCH_TEXT_WEIGHT,
     SERVER_HOST,
     SERVER_PORT,
@@ -230,6 +231,7 @@ def doctor_status() -> dict[str, Any]:
             "fts_query_mode": FTS_QUERY_MODE,
             "fts_candidate_limit": FTS_CANDIDATE_LIMIT,
             "hybrid_search_text_weight": HYBRID_SEARCH_TEXT_WEIGHT,
+            "fts_lone_hit_score": FTS_LONE_HIT_SCORE,
             "fts_extra_stopwords": sorted(FTS_EXTRA_STOPWORDS),
         },
     }

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.31.0"
+version = "2.32.0"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indices & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.31.0",
+      "identifier": "lyellr88/marm-mcp-server:2.32.0",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -1,5 +1,7 @@
 import os
+import pathlib
 import sqlite3
+import sys
 import uuid as _uuid_module
 from datetime import datetime, timezone as _timezone
 
@@ -959,12 +961,57 @@ def test_fts_lone_hit_score_clamped_to_unit_range(monkeypatch, capsys):
 
 def test_fts_lone_hit_score_default_is_unchanged_behavior():
     """The swept value is the pre-existing 1.0: the parameter ships as a no-op,
-    since only 1 of 1,982 benchmark queries reached the degenerate branch."""
+    since an offline diagnostic found one degenerate set across 1,982 FTS calls (a
+    call count, not the benchmark's 1,977 scored questions)."""
     from marm_mcp_server.config import settings
 
     if "FTS_LONE_HIT_SCORE" in os.environ:
         pytest.skip("environment pins FTS_LONE_HIT_SCORE; default not observable")
     assert settings.FTS_LONE_HIT_SCORE == 1.0
+
+
+def _import_settings_with(env_value: str) -> tuple[str, str]:
+    """Import settings.py in a clean process with FTS_LONE_HIT_SCORE set.
+
+    A fresh interpreter is the only way to observe an import-time constant more
+    than once per suite: monkeypatching the env after import is too late, and
+    importlib.reload raises ImportError once another test has evicted the module.
+    """
+    import subprocess
+
+    env = dict(os.environ)
+    env["FTS_LONE_HIT_SCORE"] = env_value
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from marm_mcp_server.config.settings import FTS_LONE_HIT_SCORE as v;"
+            "print(repr(v))",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(pathlib.Path(__file__).resolve().parent.parent),
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip(), proc.stderr
+
+
+def test_fts_lone_hit_score_env_override_reaches_the_constant():
+    """Covers the import-time assignment, not just the helper behind it.
+
+    The helper test above would still pass if settings.py were changed to call
+    `_safe_float` directly, silently dropping the clamp from the shipped value.
+    This asserts the constant the rest of the code imports, in a real process, for
+    a non-default in-range value and for one that must be clamped.
+    """
+    value, stderr = _import_settings_with("0.3")
+    assert value == "0.3"
+    assert "FTS_LONE_HIT_SCORE" not in stderr
+
+    value, stderr = _import_settings_with("2.5")
+    assert value == "1.0", "out-of-range value reached the constant unclamped"
+    assert "FTS_LONE_HIT_SCORE=2.5 out of [0, 1], clamped to 1.0" in stderr
 
 
 def test_fetch_fts_candidate_ids_returns_normalized_bm25_from_real_index(tmp_path):

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -921,19 +921,50 @@ def test_tied_bm25_candidates_cut_off_deterministically(tmp_path):
     assert [row["id"] for row, _ in rows] == ["id-1", "id-2", "id-3"]
 
 
-def test_fts_lone_hit_score_clamped_to_unit_range(monkeypatch):
-    """Out-of-range values clamp rather than propagate an invalid weight into
-    ranking, matching the neighbouring settings' clamp-and-warn contract."""
-    from marm_mcp_server.config.settings import _safe_float
+def test_fts_lone_hit_score_clamped_to_unit_range(monkeypatch, capsys):
+    """Out-of-range values clamp rather than propagate an invalid weight into ranking.
+
+    Exercises `_safe_unit_float`, the helper `FTS_LONE_HIT_SCORE` is actually
+    built from, so the parse, the clamp, and the warning are all covered by the
+    real code path. Reloading `settings` would be the other way to reach the
+    constant itself, but it raises ImportError once another test in the suite has
+    evicted the module, which is why the clamp lives in a callable helper.
+    """
+    from marm_mcp_server.config.settings import _safe_unit_float
 
     monkeypatch.setenv("FTS_LONE_HIT_SCORE", "2.5")
-    assert max(0.0, min(1.0, _safe_float("FTS_LONE_HIT_SCORE", 1.0))) == 1.0
+    assert _safe_unit_float("FTS_LONE_HIT_SCORE", 1.0) == 1.0
+    assert "out of [0, 1], clamped to 1.0" in capsys.readouterr().err
 
     monkeypatch.setenv("FTS_LONE_HIT_SCORE", "-1")
-    assert max(0.0, min(1.0, _safe_float("FTS_LONE_HIT_SCORE", 1.0))) == 0.0
+    assert _safe_unit_float("FTS_LONE_HIT_SCORE", 1.0) == 0.0
+    assert "out of [0, 1], clamped to 0.0" in capsys.readouterr().err
 
+    # Unparseable input falls back to the default and must not be reported as a
+    # clamp, which would be a misleading diagnostic.
     monkeypatch.setenv("FTS_LONE_HIT_SCORE", "not-a-number")
-    assert _safe_float("FTS_LONE_HIT_SCORE", 1.0) == 1.0
+    assert _safe_unit_float("FTS_LONE_HIT_SCORE", 1.0) == 1.0
+    err = capsys.readouterr().err
+    assert "not a valid number" in err
+    assert "clamped" not in err
+
+    # In-range values pass through silently.
+    monkeypatch.setenv("FTS_LONE_HIT_SCORE", "0.3")
+    assert _safe_unit_float("FTS_LONE_HIT_SCORE", 1.0) == 0.3
+    assert capsys.readouterr().err == ""
+
+    monkeypatch.delenv("FTS_LONE_HIT_SCORE")
+    assert _safe_unit_float("FTS_LONE_HIT_SCORE", 1.0) == 1.0
+
+
+def test_fts_lone_hit_score_default_is_unchanged_behavior():
+    """The swept value is the pre-existing 1.0: the parameter ships as a no-op,
+    since only 1 of 1,982 benchmark queries reached the degenerate branch."""
+    from marm_mcp_server.config import settings
+
+    if "FTS_LONE_HIT_SCORE" in os.environ:
+        pytest.skip("environment pins FTS_LONE_HIT_SCORE; default not observable")
+    assert settings.FTS_LONE_HIT_SCORE == 1.0
 
 
 def test_fetch_fts_candidate_ids_returns_normalized_bm25_from_real_index(tmp_path):

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -160,13 +160,12 @@ def test_extra_stopwords_parsing(monkeypatch):
     assert _csv_frozenset("FTS_EXTRA_STOPWORDS") == frozenset()
 
 
-def test_hybrid_search_text_weight_defaults_to_zero():
-    """Phase 1 ships lexical scoring off on purpose.
+def test_hybrid_search_text_weight_default_is_the_swept_value():
+    """The weight is the one number this whole change exists to establish.
 
-    The widened builder makes the BM25 term live on natural-language recall for
-    the first time. Until the weight is swept against the benchmark it stays at
-    0.0, so FTS acts purely as a candidate filter. Guards against a well-meaning
-    "restore" to the old 0.35.
+    0.05 came from a LoCoMo sweep over 0.00-0.50 where any-hit peaked in a broad
+    0.04-0.08 plateau, well above both 0.0 (lexical scoring off) and the old
+    unvalidated 0.35. Guards against a silent drift back to either.
     """
     from marm_mcp_server.config import settings
 
@@ -174,7 +173,18 @@ def test_hybrid_search_text_weight_defaults_to_zero():
         pytest.skip(
             "environment pins HYBRID_SEARCH_TEXT_WEIGHT; default not observable"
         )
-    assert settings.HYBRID_SEARCH_TEXT_WEIGHT == 0.0
+    assert settings.HYBRID_SEARCH_TEXT_WEIGHT == 0.05
+
+
+def test_fts_candidate_limit_default_is_the_swept_value():
+    """200 was chosen to recover the multi-hop recall that v2.31.0's 50-candidate
+    pool cost. Below ~200 multi-hop drops; far above it the pool stops acting as
+    a precision gate and the adversarial gain erodes."""
+    from marm_mcp_server.config import settings
+
+    if "FTS_CANDIDATE_LIMIT" in os.environ:
+        pytest.skip("environment pins FTS_CANDIDATE_LIMIT; default not observable")
+    assert settings.FTS_CANDIDATE_LIMIT == 200
 
 
 # --- FTS5 schema ---
@@ -764,10 +774,9 @@ async def test_recall_similar_fuses_bm25_into_ranking(monkeypatch, tmp_path):
         strong_id = _insert_with_embedding(conn, "fuse", "docker deployment", vec)
         weak_id = _insert_with_embedding(conn, "fuse", "docker sidebar", vec)
 
-    # HYBRID_SEARCH_TEXT_WEIGHT ships at 0.0 (see settings.py), which by design
-    # makes the lexical term contribute nothing. This test covers the fusion
-    # mechanism itself, so it pins a non-zero weight rather than depending on the
-    # shipped default.
+    # The shipped 0.05 weight is deliberately small. This test covers the fusion
+    # mechanism itself, so it pins a larger non-zero weight rather than depending
+    # on the shipped default.
     monkeypatch.setattr(memory_recall_module, "HYBRID_SEARCH_TEXT_WEIGHT", 0.35)
 
     # Identical embeddings -> identical vec_score. Only the BM25 term differs,
@@ -799,6 +808,132 @@ def test_normalize_bm25_maps_more_negative_to_higher_score():
     assert _normalize_bm25([]) == []
     # All-equal scores collapse to 1.0 so a lone lexical hit keeps full weight.
     assert _normalize_bm25([-2.0, -2.0]) == [1.0, 1.0]
+
+
+def test_normalize_bm25_lone_hit_score_covers_both_degenerate_shapes():
+    """`lone_hit_score` must apply to every set min-max cannot normalize.
+
+    Both a single row and a multi-row set where every score ties are degenerate:
+    there is no spread, so the caller's value is used verbatim. The all-equal
+    shape is the one easily missed -- a wide OR query where several memories hit
+    the same number of terms lands there, not on the single-row branch.
+    """
+    from marm_mcp_server.core.memory_scoring import _normalize_bm25
+
+    assert _normalize_bm25([-2.0], lone_hit_score=0.3) == [0.3]
+    assert _normalize_bm25([-2.0, -2.0, -2.0], lone_hit_score=0.3) == [0.3, 0.3, 0.3]
+    assert _normalize_bm25([], lone_hit_score=0.3) == []
+    # Zero is a real choice (ignore the lexical signal entirely), not "unset".
+    assert _normalize_bm25([-2.0], lone_hit_score=0.0) == [0.0]
+
+
+def test_normalize_bm25_lone_hit_score_ignored_when_spread_exists():
+    """A set with real spread must normalize identically regardless of the
+    parameter. Guards against the value leaking into the non-degenerate math."""
+    from marm_mcp_server.core.memory_scoring import _normalize_bm25
+
+    assert _normalize_bm25([-5.0, -3.0, -1.0], lone_hit_score=0.0) == [1.0, 0.5, 0.0]
+
+
+def test_lone_hit_score_applies_to_semantic_lane_but_not_exact_lane(
+    tmp_path, monkeypatch
+):
+    """The two lanes must diverge on the same degenerate result set.
+
+    One memory matches, so both fetchers see a single row and take the
+    degenerate branch. The semantic lane's pool comes from a wide OR where a
+    lone hit means one term matched, so it gets FTS_LONE_HIT_SCORE. The exact
+    lane's strict AND means a lone hit contained every term, so it keeps 1.0.
+    Asserting both against one real FTS5 index is what proves the wiring went
+    to the right call site.
+    """
+    from marm_mcp_server.core import memory_scoring
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    with memory.get_connection() as conn:
+        only_id = _insert_with_embedding(
+            conn, "lone", "The quarterly budget was approved.", vec
+        )
+        _insert_with_embedding(conn, "lone", "Unrelated note about weather.", vec)
+
+    monkeypatch.setattr(memory_scoring, "FTS_LONE_HIT_SCORE", 0.25)
+
+    pairs = memory_scoring._fetch_fts_candidate_ids(
+        memory.db_path, "lone", '"budget"', 50
+    )
+    assert pairs == [(only_id, 0.25)]
+
+    exact = memory_scoring._fetch_and_score_fts_rows(
+        memory.db_path, "lone", '"budget"', 50
+    )
+    assert [score for _, score in exact] == [1.0]
+
+
+def test_tied_bm25_candidates_cut_off_deterministically(tmp_path):
+    """The candidate pool must not depend on SQLite's incidental row order.
+
+    BM25 ties at the LIMIT boundary are the common case, not an edge case: 53.7%
+    of LoCoMo queries had one at the 50-row cutoff. Without a tiebreak, which
+    candidates entered the pool varied between processes, and identical
+    benchmark configs scored up to 0.5pp apart -- larger than several of the
+    effects the pool is used to measure.
+
+    Six identical documents tie exactly, so only the ORDER BY tiebreak decides
+    which three survive a LIMIT 3. They are inserted in scrambled id order, so a
+    fetcher relying on scan order would return the insertion-order prefix
+    instead of the id-sorted one.
+    """
+    from marm_mcp_server.core.memory_scoring import (
+        _fetch_and_score_fts_rows,
+        _fetch_fts_candidate_ids,
+    )
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    insertion_order = ["id-5", "id-2", "id-6", "id-1", "id-4", "id-3"]
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+    with memory.get_connection() as conn:
+        for mem_id in insertion_order:
+            conn.execute(
+                "INSERT INTO memories"
+                " (id, session_name, content, embedding, content_hash, timestamp,"
+                "  context_type, metadata)"
+                " VALUES (?, 'tie', 'tiebreak marker', ?, ?, ?, 'general', '{}')",
+                (
+                    mem_id,
+                    vec.tobytes(),
+                    f"hash-{mem_id}",
+                    datetime.now(_timezone.utc).isoformat(),
+                ),
+            )
+
+    pairs = _fetch_fts_candidate_ids(memory.db_path, "tie", '"marker"', 3)
+    assert [cid for cid, _ in pairs] == ["id-1", "id-2", "id-3"]
+
+    rows = _fetch_and_score_fts_rows(memory.db_path, "tie", '"marker"', 3)
+    assert [row["id"] for row, _ in rows] == ["id-1", "id-2", "id-3"]
+
+
+def test_fts_lone_hit_score_clamped_to_unit_range(monkeypatch):
+    """Out-of-range values clamp rather than propagate an invalid weight into
+    ranking, matching the neighbouring settings' clamp-and-warn contract."""
+    from marm_mcp_server.config.settings import _safe_float
+
+    monkeypatch.setenv("FTS_LONE_HIT_SCORE", "2.5")
+    assert max(0.0, min(1.0, _safe_float("FTS_LONE_HIT_SCORE", 1.0))) == 1.0
+
+    monkeypatch.setenv("FTS_LONE_HIT_SCORE", "-1")
+    assert max(0.0, min(1.0, _safe_float("FTS_LONE_HIT_SCORE", 1.0))) == 0.0
+
+    monkeypatch.setenv("FTS_LONE_HIT_SCORE", "not-a-number")
+    assert _safe_float("FTS_LONE_HIT_SCORE", 1.0) == 1.0
 
 
 def test_fetch_fts_candidate_ids_returns_normalized_bm25_from_real_index(tmp_path):

--- a/scripts/benchmarking/performance/bench_hotpath.py
+++ b/scripts/benchmarking/performance/bench_hotpath.py
@@ -37,10 +37,13 @@ _REPO_ROOT = os.path.dirname(
 )
 sys.path.insert(0, os.path.join(_REPO_ROOT, "marm-mcp-server"))
 
-from marm_mcp_server.core.memory import MARMMemory, _safe_fts_query  # noqa: E402
+from marm_mcp_server.core.memory import MARMMemory, _wide_fts_query  # noqa: E402
 from marm_mcp_server.core import consolidation  # noqa: E402
 from marm_mcp_server.core import memory_ops  # noqa: E402
-from marm_mcp_server.config.settings import DEFAULT_SEMANTIC_DIM  # noqa: E402
+from marm_mcp_server.config.settings import (  # noqa: E402
+    DEFAULT_SEMANTIC_DIM,
+    FTS_CANDIDATE_LIMIT,
+)
 
 NUMPY_AVAILABLE = importlib.util.find_spec("numpy") is not None
 
@@ -247,7 +250,10 @@ async def bench_hybrid_strategies(mem, sizes=None, iters=15):
         for iter_num in range(iters):
             query = test_queries[iter_num % len(test_queries)]
             query_vec = mem._encode_sync(query)
-            fts_query = _safe_fts_query(query)
+            # Must match what recall_similar actually runs. These queries are all
+            # non-exact, so the timed path uses the wide builder; counting strict-AND
+            # matches described a query the measured path never issues.
+            fts_query = _wide_fts_query(query)
 
             # Alternate order so one path does not always benefit from a warmed cache.
             if iter_num % 2 == 0:
@@ -294,7 +300,7 @@ async def bench_hybrid_strategies(mem, sizes=None, iters=15):
                            WHERE memories_fts MATCH ? AND m.session_name = 'bench'""",
                         (fts_query,),
                     ).fetchone()[0]
-                fts_hits.append(min(matched, 50))
+                fts_hits.append(min(matched, FTS_CANDIDATE_LIMIT))
 
         results["full_scan"][n] = scan_samples
         results["production_hybrid"][n] = prod_samples
@@ -364,7 +370,7 @@ async def main():
 
             print(
                 f"{n:<8} {scan_med:>7.1f}ms     {prod_med:>7.1f}ms      "
-                f"{speedup:>5.1f}x     {fts_hit_rate:>4.1f}/50"
+                f"{speedup:>5.1f}x     {fts_hit_rate:>4.1f}/{FTS_CANDIDATE_LIMIT}"
             )
 
         print("\nKey points:")
@@ -376,7 +382,8 @@ async def main():
         )
         print("  • Speedup = full scan / production hybrid (both real code paths)")
         print(
-            "  • FTS Hits: avg candidates the keyword prefilter matched (capped at 50)\n"
+            "  • FTS Hits: avg candidates the keyword prefilter matched "
+            f"(capped at FTS_CANDIDATE_LIMIT={FTS_CANDIDATE_LIMIT})\n"
         )
 
 

--- a/scripts/benchmarking/performance/bench_hotpath.py
+++ b/scripts/benchmarking/performance/bench_hotpath.py
@@ -45,6 +45,16 @@ from marm_mcp_server.config.settings import (  # noqa: E402
     FTS_CANDIDATE_LIMIT,
 )
 
+# Top-K every timed recall in this script requests.
+RECALL_LIMIT = 5
+
+# The candidate pool recall_similar actually fetches for that limit
+# (memory_recall.py: max(limit, FTS_CANDIDATE_LIMIT)). Equal to FTS_CANDIDATE_LIMIT at
+# any sane setting; it diverges only when the limit is configured below RECALL_LIMIT,
+# where production still fetches RECALL_LIMIT rows. Reporting saturation against
+# anything else prints a denominator production never used.
+EFFECTIVE_FTS_CAP = max(RECALL_LIMIT, FTS_CANDIDATE_LIMIT)
+
 NUMPY_AVAILABLE = importlib.util.find_spec("numpy") is not None
 
 
@@ -153,7 +163,7 @@ async def bench_recall_vs_n(mem, sizes, iters=15):
         for k in range(iters):
             t0 = time.perf_counter()
             q = f"{VOCAB[k % len(VOCAB)]} {VOCAB[(k + 1) % len(VOCAB)]}"
-            await mem.recall_similar(q, session="bench", limit=5)
+            await mem.recall_similar(q, session="bench", limit=RECALL_LIMIT)
             samples.append((time.perf_counter() - t0) * 1000)
         results[n] = samples
     return results
@@ -166,12 +176,12 @@ async def bench_concurrency(mem, n=1000, concurrency=10):
 
     t0 = time.perf_counter()
     for q in queries:
-        await mem.recall_similar(q, session="bench", limit=5)
+        await mem.recall_similar(q, session="bench", limit=RECALL_LIMIT)
     serial_ms = (time.perf_counter() - t0) * 1000
 
     t0 = time.perf_counter()
     await asyncio.gather(
-        *(mem.recall_similar(q, session="bench", limit=5) for q in queries)
+        *(mem.recall_similar(q, session="bench", limit=RECALL_LIMIT) for q in queries)
     )
     gather_ms = (time.perf_counter() - t0) * 1000
     return serial_ms, gather_ms
@@ -270,13 +280,13 @@ async def bench_hybrid_strategies(mem, sizes=None, iters=15):
 
                 t0 = time.perf_counter()
                 await mem.recall_similar(
-                    query, session="bench", limit=5, query_vec=query_vec
+                    query, session="bench", limit=RECALL_LIMIT, query_vec=query_vec
                 )
                 prod_samples.append((time.perf_counter() - t0) * 1000)
             else:
                 t0 = time.perf_counter()
                 await mem.recall_similar(
-                    query, session="bench", limit=5, query_vec=query_vec
+                    query, session="bench", limit=RECALL_LIMIT, query_vec=query_vec
                 )
                 prod_samples.append((time.perf_counter() - t0) * 1000)
 
@@ -300,7 +310,7 @@ async def bench_hybrid_strategies(mem, sizes=None, iters=15):
                            WHERE memories_fts MATCH ? AND m.session_name = 'bench'""",
                         (fts_query,),
                     ).fetchone()[0]
-                fts_hits.append(min(matched, FTS_CANDIDATE_LIMIT))
+                fts_hits.append(min(matched, EFFECTIVE_FTS_CAP))
 
         results["full_scan"][n] = scan_samples
         results["production_hybrid"][n] = prod_samples
@@ -370,7 +380,7 @@ async def main():
 
             print(
                 f"{n:<8} {scan_med:>7.1f}ms     {prod_med:>7.1f}ms      "
-                f"{speedup:>5.1f}x     {fts_hit_rate:>4.1f}/{FTS_CANDIDATE_LIMIT}"
+                f"{speedup:>5.1f}x     {fts_hit_rate:>4.1f}/{EFFECTIVE_FTS_CAP}"
             )
 
         print("\nKey points:")
@@ -383,7 +393,7 @@ async def main():
         print("  • Speedup = full scan / production hybrid (both real code paths)")
         print(
             "  • FTS Hits: avg candidates the keyword prefilter matched "
-            f"(capped at FTS_CANDIDATE_LIMIT={FTS_CANDIDATE_LIMIT})\n"
+            f"(capped at the pool recall_similar fetches, {EFFECTIVE_FTS_CAP})\n"
         )
 
 

--- a/scripts/benchmarking/performance/bench_hotpath.py
+++ b/scripts/benchmarking/performance/bench_hotpath.py
@@ -274,7 +274,7 @@ async def bench_hybrid_strategies(mem, sizes=None, iters=15):
                     "bench",
                     n,
                     query_vec,
-                    5,
+                    RECALL_LIMIT,
                 )
                 scan_samples.append((time.perf_counter() - t0) * 1000)
 
@@ -297,7 +297,7 @@ async def bench_hybrid_strategies(mem, sizes=None, iters=15):
                     "bench",
                     n,
                     query_vec,
-                    5,
+                    RECALL_LIMIT,
                 )
                 scan_samples.append((time.perf_counter() - t0) * 1000)
 


### PR DESCRIPTION
v2.31.0 activated keyword candidates for natural-language recall but left keyword scores out of ranking, because the old 0.35 weight had been chosen while that path never ran. This sweeps it and turns it on.

Defaults, both measured on LoCoMo (1,977 questions, 5,882 memories, top-5):
- HYBRID_SEARCH_TEXT_WEIGHT 0.0 -> 0.05. Swept over 13 points; any-hit peaks across a broad 0.04-0.08 plateau at 62.0-62.5% against 57.4% with keyword scoring off and 57.6% at the old 0.35. 0.05 is the plateau centre rather than the argmax, so the default is not fitted to one corpus. High weights are actively harmful: single-hop falls 56.9% -> 47.3% between 0.05 and 0.35.
- FTS_CANDIDATE_LIMIT 50 -> 200. This was the lever on the multi-hop regression v2.31.0 introduced; 200 recovers multi-hop any-hit 34.8% -> 39.3%, matching the pre-v2.31.0 baseline, lifts single-hop 1.1pp, leaves adversarial precision unchanged, and costs ~3ms per recall. 500 buys 1.1pp more multi-hop but erodes the adversarial gain, since a pool that large stops narrowing anything.

Combined vs v2.31.0 on the same corpus: any-hit 57.4% -> 62.5%, all-hit 47.6% -> 52.6%, evidence recall 51.9% -> 56.9%. Every category improves.

Also fixes non-reproducible candidate selection, found because two identical benchmark runs scored 0.5pp apart while disagreeing on 18 questions. Ties at the candidate cutoff are the normal case (53.7% of queries) and SQLite ordered those rows differently between processes, so the pool varied across restarts. Candidate selection now breaks ties on memory ID. Accuracy is unchanged within measurement error; results are now reproducible, which also drops the benchmark's resolution floor from ~0.5pp to ~0.1pp. The fusion bake-off compares methods that can differ by less than the old floor, so it could not have been measured on the previous harness.

New setting FTS_LONE_HIT_SCORE (default 1.0) sets the keyword score for a candidate set too degenerate to rank. It ships as a no-op: swept over 0.0/0.3/0.5/1.0 with no measurable effect, because only 1 of 1,982 queries produced such a set on a store this size. Exposed for small stores, where a query matching exactly one memory is routine. The spec had called the previous hardcoded 1.0 an active ranking bug; measurement says otherwise, since under wide OR a degenerate set means one memory held the only match for any query term, which is discriminative rather than weak evidence.

No schema change, no migration, no re-embedding. Recall ordering changes by design; explicit env overrides are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keyword/semantic ranking with updated default weighting.
  * Increased the default keyword candidate limit from 50 to 200.
  * Added `FTS_LONE_HIT_SCORE` to control scoring for single/tied keyword matches.
  * Retrieval diagnostics now display the single-match score.
* **Bug Fixes**
  * Made keyword candidate selection deterministic on tie scores for consistent results across runs.
* **Documentation**
  * Updated configuration, FAQ, and installation materials to reflect v2.32.0 and the new default settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->