### PR TITLE
Release/v2.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>July 29th, 2026: Recall Keeps Working When the Embedding Model Does Not (v2.33.0)</strong></summary>
+
+### Fixed: Recall Returned Nothing When the Embedding Model Was Unavailable
+
+- MARM falls back to keyword-only search when the embedding model cannot load or errors during a recall. That fallback was building its keyword query with strict AND, so it only matched a memory containing *every* word of the question, including words like "what" and "the". Natural-language questions matched nothing, and the last-resort search then looked for the entire question as one literal substring, which also matched nothing.
+- The practical effect: if the model failed to load, recall returned an empty result for effectively every question asked. Measured on LoCoMo (1,977 questions, 5,882 memories, top-5, model disabled): 0.1% of questions returned any correct memory. Two questions out of 1,977.
+- The fallback now uses the same broader keyword matching the main search lane has used since v2.31.0. Same benchmark: **any-hit 0.1% to 55.4%, all-hit 0.1% to 46.7%, evidence recall 0.1% to 50.5%**. Every question category improved, and adversarial questions went from 0.0% to 51.8%. For reference, recall with the model loaded scores 62.5% on this corpus, so the degraded path now reaches about 89% of full accuracy instead of being unusable.
+- The exact-lookup lane is deliberately unchanged and still requires all terms. Its results are returned in raw keyword-score order with nothing reranking them, so broadening it would cost precision on the config-key and file-path lookups it exists for. `FTS_QUERY_MODE=and` still forces strict matching everywhere for anyone who wants it.
+
+### Fixed: FTS_LONE_HIT_SCORE Did Not Apply to the Fallback Lane
+
+- `FTS_LONE_HIT_SCORE` sets the keyword score reported when only one memory matches, or when every match ties. The keyword-only fallback lane shares its row fetcher with the exact-lookup lane, so it always reported `1.0` there and ignored the setting. Now that the fallback lane matches on a broad keyword query, a single match can mean one memory happened to share one word, which is exactly the case the setting exists to let you score lower.
+- The fallback lane now honors it; the exact-lookup lane still always uses `1.0`, because its strict all-terms match means a single hit contained every word of the query. No change at the default of `1.0`.
+
+### New Settings
+
+- `SEMANTIC_SEARCH_ENABLED` (default `1`). Set it to `0` to run exactly as though the embedding model were not installed: no model load, no embeddings written, recall served by keyword matching. It was added because the degraded path above could not be measured any other way, and it also lets a low-memory host skip loading the model. `marm-memory doctor` reports "Meaning-based search: off (keyword matching only)" when it is disabled.
+
+</details>
+
+<details>
 <summary><strong>July 28th, 2026: Keyword Ranking Weight Set From Benchmark Data (v2.32.0)</strong></summary>
 
 ### Keyword Relevance Now Contributes to Ranking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you do want to go deeper, MARM is focused on the MCP server, local memory wor
 
 ## Questions or Ideas
 
-Drop a message in [MARM Discord](https://discord.gg/nhyJWPz2cf) or reach out directly at lyellr88@gmail.com.
+Drop a message in [MARM Discord](https://discord.gg/nhyJWPz2cf) or reach out directly at support@marmemory.com.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.32.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.0</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -985,6 +985,7 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `FTS_EXTRA_STOPWORDS` | *(empty)* | Comma-separated extra words to ignore when building keyword queries, for terms so common in your store they carry no signal |
 | `HYBRID_SEARCH_TEXT_WEIGHT` | `0.05` | How much the keyword score influences ranking. Set from a benchmark sweep; accuracy peaks across `0.04`-`0.08` and falls off sharply above `0.10`. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
 | `FTS_LONE_HIT_SCORE` | `1.0` | Keyword score used when only one memory matches, or when every match ties. Lower it on small stores if a single keyword match should not count as a perfect one. |
+| `SEMANTIC_SEARCH_ENABLED` | `1` | Set to `0` to run without the embedding model: nothing is loaded, no embeddings are written, and recall falls back to keyword matching. Useful on low-memory hosts, or to see how recall behaves when the model is unavailable. `marm-memory doctor` reports when it is off. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please report security issues privately by emailing:
 
-**lyellr88@gmail.com**
+**support@marmemory.com**
 
 Do not open a public GitHub issue or pull request for vulnerabilities that could expose user memory, logs, notebook data, authentication gaps, deployment risks, secrets, or other sensitive details.
 

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.32.0** - Memory Accurate Response Mode
+**MARM v2.33.0** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.32.0** - Memory Accurate Response Mode
+**MARM v2.33.0** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -320,7 +320,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.32.0 MCP Server - Platform Integration Guide
+# MARM v2.33.0 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.32.0** - Memory Accurate Response Mode
+**MARM v2.33.0** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -294,7 +294,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/TECHNICAL-OVERVIEW.md
+++ b/docs/TECHNICAL-OVERVIEW.md
@@ -1,6 +1,6 @@
 # MARM Technical Overview
 
-> Current implementation: MARM MCP Server v2.32.0
+> Current implementation: MARM MCP Server v2.33.0
 
 This document explains what MARM is, why it is built this way, and how information moves through the system from an agent writing something to that information being recalled later. It is intended as a technical product overview, not a source-code reference.
 

--- a/marm-console/pnpm-lock.yaml
+++ b/marm-console/pnpm-lock.yaml
@@ -60,6 +60,7 @@ catalogs:
 
 overrides:
   esbuild: 0.28.1
+  postcss: '>=8.5.18'
 
 importers:
 
@@ -1307,8 +1308,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1327,8 +1328,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.24:
+    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.29.7:
@@ -2530,7 +2531,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   node-releases@2.0.50: {}
 
@@ -2540,9 +2541,9 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.16:
+  postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2696,7 +2697,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.24
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/marm-console/pnpm-workspace.yaml
+++ b/marm-console/pnpm-workspace.yaml
@@ -6,6 +6,11 @@ packages:
 
 overrides:
   esbuild: 0.28.1
+  # Pulled in transitively by vite, so there is no dependency line to bump.
+  # <=8.5.17 auto-loads the .map file named by a sourceMappingURL comment and can
+  # be walked out of the intended directory (GHSA / Dependabot #11). A range, not
+  # a pin, so a later patch cannot silently drop back below the fix.
+  postcss: '>=8.5.18'
 
 catalog:
   '@radix-ui/react-dialog': ^1.1.7

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -73,7 +73,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.32.0"
+LABEL org.opencontainers.image.version="2.33.0"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -7,7 +7,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.32.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.0</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -130,6 +130,8 @@ marm-memory console                  # start or reuse the bundled local Console
 ```bash
 marm-memory http                     # run HTTP in the foreground
 marm-memory stdio                    # run the strict local MCP STDIO transport
+marm-memory init                     # install the MARM skill into detected agents (project scan)
+marm-memory init --g-claude          # install the skill into the home-folder claude directory
 marm-memory doctor                   # diagnose the local install
 marm-memory key init                 # create or reuse ~/.marm/.env without displaying the key
 marm-memory key path                 # print the managed key-file path
@@ -985,6 +987,7 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `FTS_EXTRA_STOPWORDS` | *(empty)* | Comma-separated extra words to ignore when building keyword queries, for terms so common in your store they carry no signal |
 | `HYBRID_SEARCH_TEXT_WEIGHT` | `0.05` | How much the keyword score influences ranking. Set from a benchmark sweep; accuracy peaks across `0.04`-`0.08` and falls off sharply above `0.10`. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
 | `FTS_LONE_HIT_SCORE` | `1.0` | Keyword score used when only one memory matches, or when every match ties. Lower it on small stores if a single keyword match should not count as a perfect one. |
+| `SEMANTIC_SEARCH_ENABLED` | `1` | Set to `0` to run without the embedding model: nothing is loaded, no embeddings are written, and recall falls back to keyword matching. Useful on low-memory hosts, or to see how recall behaves when the model is unavailable. `marm-memory doctor` reports when it is off. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |
@@ -1123,7 +1126,7 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 
 </details>
 
-For memory behavior, transports, supported clients, compaction, and backup questions, see the [FAQ](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/FAQ.md).
+For memory behavior, transports, supported clients, compaction, and backup questions, see the [FAQ](docs/FAQ.md).
 
 ## ⭐ Star the Project
 

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     # :latest is the all-in-one MCP image (memory + graph, one port).
     # Pin :memory-only instead if you need the pre-unification image shape.
-    image: lyellr88/marm-mcp-server:2.32.0
+    image: lyellr88/marm-mcp-server:2.33.0
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -18,7 +18,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.32.0
+      - SERVER_VERSION=2.33.0
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -19,7 +19,7 @@ Version: 2.32.0
 
 __version__ = "2.32.0"
 __author__ = "Ryan Lyell"
-__email__ = "lyell@marmsystems.com"
+__email__ = "ryanlyell@marmemory.com"
 
 __all__ = ["__version__", "create_server", "main"]
 

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,10 +14,10 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.32.0
+Version: 2.33.0
 """
 
-__version__ = "2.32.0"
+__version__ = "2.33.0"
 __author__ = "Ryan Lyell"
 __email__ = "ryanlyell@marmemory.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -77,13 +77,31 @@ def _csv_frozenset(env_key: str) -> frozenset[str]:
     return frozenset(part.strip().lower() for part in raw.split(",") if part.strip())
 
 
-SEMANTIC_SEARCH_AVAILABLE = importlib.util.find_spec("fastembed") is not None
-if not SEMANTIC_SEARCH_AVAILABLE:
-    print("WARNING: Semantic search not available. Install: pip install fastembed")
+# Setting this to 0 makes the server behave exactly as it does when fastembed is
+# not installed: no model load, no embeddings written, recall served by the
+# keyword/text lane. Two uses: exercising the degraded path without uninstalling
+# the dependency (there is no other way to benchmark or verify it), and letting a
+# low-memory host skip loading the model at all.
+SEMANTIC_SEARCH_ENABLED = os.environ.get("SEMANTIC_SEARCH_ENABLED", "1") == "1"
+_FASTEMBED_INSTALLED = importlib.util.find_spec("fastembed") is not None
+SEMANTIC_SEARCH_AVAILABLE = SEMANTIC_SEARCH_ENABLED and _FASTEMBED_INSTALLED
+if not _FASTEMBED_INSTALLED:
+    print(
+        "WARNING: Semantic search not available. Install: pip install fastembed",
+        file=sys.stderr,
+    )
+elif not SEMANTIC_SEARCH_ENABLED:
+    print(
+        "WARNING: Semantic search disabled by SEMANTIC_SEARCH_ENABLED=0",
+        file=sys.stderr,
+    )
 
 SCHEDULER_AVAILABLE = importlib.util.find_spec("apscheduler") is not None
 if not SCHEDULER_AVAILABLE:
-    print("WARNING: Scheduler not available. Install: pip install apscheduler")
+    print(
+        "WARNING: Scheduler not available. Install: pip install apscheduler",
+        file=sys.stderr,
+    )
 
 CONCEPT_MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "en_core_web_sm"
 # Same two files scripts/bundle-concept-model.py verifies after extraction, so a
@@ -161,7 +179,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.32.0"
+SERVER_VERSION = "2.33.0"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 
@@ -326,9 +344,11 @@ FTS_QUERY_MODE = _safe_choice("FTS_QUERY_MODE", "or_nostop", FTS_QUERY_MODES)
 # Additive only -- it cannot remove built-ins. Comma-separated, case-insensitive.
 FTS_EXTRA_STOPWORDS = _csv_frozenset("FTS_EXTRA_STOPWORDS")
 
-# Lexical score given to a degenerate semantic-lane candidate set (one row, or
-# every row tied on BM25), where per-query min-max has no spread to normalize
-# against. The exact lane always uses 1.0.
+# Lexical score given to a degenerate candidate set (one row, or every row tied on
+# BM25), where per-query min-max has no spread to normalize against. Applies to
+# both lanes that match on a wide OR: the semantic lane, and since v2.33.0 the
+# semantic-fallback lane. The exact lane always uses 1.0, because its strict AND
+# means a lone hit contained every query term.
 #
 # Stays at 1.0: swept over 0.0/0.3/0.5/1.0 in v2.32.0 with no measurable effect,
 # because on a corpus of any size the wide OR fills the candidate pool. An offline

--- a/marm-mcp-server/marm_mcp_server/core/memory_recall.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_recall.py
@@ -9,6 +9,7 @@ from ..config.settings import (
     TEMPORAL_WEIGHT,
     TEMPORAL_HALF_LIFE_DAYS,
     FTS_CANDIDATE_LIMIT,
+    FTS_LONE_HIT_SCORE,
     FTS_QUERY_MODE,
     HYBRID_SEARCH_TEXT_WEIGHT,
 )
@@ -348,8 +349,15 @@ async def _recall_text_search(
     because the exact lane (_recall_exact) must return lexical hits in BM25 order,
     unaffected by age; only the semantic-intent fallbacks turn it on so their
     ranking stays consistent with the main semantic lane.
+
+    It also selects the MATCH builder, since it is what distinguishes the two
+    lanes: the fallbacks get the wide builder, the exact lane strict AND.
     """
-    _recall_debug(f"text-search path: terms={len(query.split())}, session={session}")
+    _recall_debug(
+        f"text-search path: terms={len(query.split())}, session={session}, "
+        f"lane={'fallback' if apply_temporal else 'exact'}, "
+        f"builder={'wide' if apply_temporal else 'strict'}"
+    )
 
     def _blend_temporal(base_sim: float, timestamp: str) -> float:
         if not apply_temporal:
@@ -357,7 +365,16 @@ async def _recall_text_search(
         t_score = _temporal_score(timestamp, TEMPORAL_HALF_LIFE_DAYS)
         return (1 - TEMPORAL_WEIGHT) * base_sim + TEMPORAL_WEIGHT * t_score
 
-    fts_query = _safe_fts_query(query)
+    # apply_temporal is already this function's lane discriminator: True from the
+    # two semantic-fallback call sites, False from _recall_exact. The exact lane
+    # must never widen, so it stays on the strict builder.
+    #
+    # Under strict AND this lane was effectively dead: a natural-language question
+    # matched nothing, the LIKE fallback then searched for the whole question as a
+    # substring and also matched nothing. Measured at 0.1% any-hit on LoCoMo with
+    # the encoder disabled, against 55.4% using the wide builder. FTS_QUERY_MODE=and
+    # remains the escape hatch for anyone who wants strict matching everywhere.
+    fts_query = _wide_fts_query(query) if apply_temporal else _safe_fts_query(query)
     if fts_query is not None:
         # Temporal re-ranking must see beyond the top-`limit` BM25 rows, or a
         # newer result ranked just outside the cutoff could never be promoted.
@@ -372,6 +389,9 @@ async def _recall_text_search(
                 fetch_limit,
                 project,
                 platform,
+                # Same reason the semantic lane passes it: this lane's MATCH is a
+                # wide OR, so a degenerate set is weak evidence, not a perfect hit.
+                lone_hit_score=FTS_LONE_HIT_SCORE if apply_temporal else 1.0,
             )
             if fts_rows:
                 _recall_debug(f"FTS5 returned {len(fts_rows)} results")

--- a/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
@@ -197,6 +197,8 @@ def _fetch_and_score_fts_rows(
     limit: int,
     project: str | None = None,
     platform: str | None = None,
+    *,
+    lone_hit_score: float = 1.0,
 ) -> list[tuple]:
     conn = sqlite3.connect(db_path, timeout=30.0)
     try:
@@ -229,9 +231,13 @@ def _fetch_and_score_fts_rows(
     if not rows:
         return []
 
-    # Exact lane: keeps the 1.0 default because this path is only reached with a
-    # strict-AND MATCH, where a lone hit means every query term was present.
-    normalized = _normalize_bm25([row["score"] for row in rows])
+    # Two lanes share this fetcher. The exact lane leaves lone_hit_score at 1.0,
+    # because its strict-AND MATCH means a lone hit had every query term present.
+    # The semantic-fallback lane passes FTS_LONE_HIT_SCORE, because since v2.33.0 it
+    # matches on a wide OR, where a lone hit can mean one memory shared one word.
+    normalized = _normalize_bm25(
+        [row["score"] for row in rows], lone_hit_score=lone_hit_score
+    )
     return list(zip(rows, normalized))
 
 

--- a/marm-mcp-server/marm_mcp_server/core/memory_utils.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_utils.py
@@ -136,9 +136,10 @@ def _wide_fts_query(query: str) -> str | None:
     tokens instead so the lane produces a real candidate pool for semantic
     reranking to filter.
 
-    Only the semantic lane uses this. The exact/lexical lane keeps
-    `_safe_fts_query`, because its BM25 hits are returned to the caller without
-    any semantic rerank to clean up over-broad matches.
+    Used by the semantic lane and, since v2.33.0, by the semantic-fallback lane.
+    The exact/lexical lane keeps `_safe_fts_query`, because its BM25 hits are
+    returned to the caller without any semantic rerank to clean up over-broad
+    matches.
 
     Returns None when nothing searchable survives, matching `_safe_fts_query`'s
     contract so callers keep their existing fail-open path.

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.32.0</h1>
+# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.0
 
 ## Important Messages
 
@@ -19,6 +19,8 @@
 - [Knowledge Graphs: Code & Concepts](#knowledge-graphs-code--concepts)
 - [Architecture & Internals](#architecture--internals)
 - [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+- [Project Documentation](#project-documentation)
 
 ## Why MARM Memory
 
@@ -102,6 +104,8 @@ marm-memory console                  # start or reuse the bundled local Console
 ```bash
 marm-memory http                     # run HTTP in the foreground
 marm-memory stdio                    # run the strict local MCP STDIO transport
+marm-memory init                     # install the MARM skill into detected agents (project scan)
+marm-memory init --g-claude          # install the skill into the home-folder claude directory
 marm-memory doctor                   # diagnose the local install
 marm-memory key init                 # create or reuse ~/.marm/.env without displaying the key
 marm-memory key path                 # print the managed key-file path
@@ -951,6 +955,7 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `FTS_EXTRA_STOPWORDS` | *(empty)* | Comma-separated extra words to ignore when building keyword queries, for terms so common in your store they carry no signal |
 | `HYBRID_SEARCH_TEXT_WEIGHT` | `0.05` | How much the keyword score influences ranking. Set from a benchmark sweep; accuracy peaks across `0.04`-`0.08` and falls off sharply above `0.10`. At `0.0` keyword matching narrows which memories are considered but does not reorder them. |
 | `FTS_LONE_HIT_SCORE` | `1.0` | Keyword score used when only one memory matches, or when every match ties. Lower it on small stores if a single keyword match should not count as a perfect one. |
+| `SEMANTIC_SEARCH_ENABLED` | `1` | Set to `0` to run without the embedding model: nothing is loaded, no embeddings are written, and recall falls back to keyword matching. Useful on low-memory hosts, or to see how recall behaves when the model is unavailable. `marm-memory doctor` reports when it is off. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
 | `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |
@@ -1088,5 +1093,3 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `embedding model not found` | Semantic search model didn't download | First run takes time; be patient, check internet connection |
 
 </details>
-
-For memory behavior, transports, supported clients, compaction, and backup questions, see the [FAQ](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/FAQ.md).

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - marm-memory
-Version: 2.32.0
+Version: 2.33.0
 """
 
 import os

--- a/marm-mcp-server/marm_mcp_server/services/cli_output.py
+++ b/marm-mcp-server/marm_mcp_server/services/cli_output.py
@@ -92,6 +92,8 @@ def _print_doctor(payload: dict[str, Any]) -> None:
     if isinstance(retrieval, dict):
         print()
         print("Recall tuning")
+        if retrieval.get("semantic_search_available") is False:
+            print("  Meaning-based search: off (keyword matching only)")
         print(f"  Keyword match mode: {retrieval.get('fts_query_mode')}")
         print(f"  Keyword candidates: {retrieval.get('fts_candidate_limit')}")
         weight = retrieval.get("hybrid_search_text_weight")

--- a/marm-mcp-server/marm_mcp_server/services/runtime_status.py
+++ b/marm-mcp-server/marm_mcp_server/services/runtime_status.py
@@ -23,6 +23,7 @@ from ..config.settings import (
     FTS_QUERY_MODE,
     FTS_LONE_HIT_SCORE,
     HYBRID_SEARCH_TEXT_WEIGHT,
+    SEMANTIC_SEARCH_AVAILABLE,
     SERVER_HOST,
     SERVER_PORT,
     SERVER_VERSION,
@@ -228,6 +229,7 @@ def doctor_status() -> dict[str, Any]:
         # Surfaced because HYBRID_SEARCH_TEXT_WEIGHT and FTS_QUERY_MODE change
         # retrieval behavior in ways that are otherwise invisible when debugging.
         "retrieval": {
+            "semantic_search_available": SEMANTIC_SEARCH_AVAILABLE,
             "fts_query_mode": FTS_QUERY_MODE,
             "fts_candidate_limit": FTS_CANDIDATE_LIMIT,
             "hybrid_search_text_weight": HYBRID_SEARCH_TEXT_WEIGHT,

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -5,15 +5,15 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "marm-mcp-server"
 version = "2.32.0"
-description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indices & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
+description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "THIRD_PARTY_NOTICES.md"]
 authors = [
-    {name = "Ryan Lyell", email = "lyell@marmsystems.com"}
+    {name = "Ryan Lyell", email = "ryanlyell@marmemory.com"}
 ]
 maintainers = [
-    {name = "Ryan Lyell", email = "lyell@marmsystems.com"}
+    {name = "Ryan Lyell", email = "support@marmemory.com"}
 ]
 keywords = ["mcp", "ai", "memory", "claude", "assistant", "protocol"]
 classifiers = [

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.32.0"
+version = "2.33.0"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.32.0",
+      "identifier": "lyellr88/marm-mcp-server:2.33.0",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -1304,3 +1304,57 @@ async def test_fallback_lane_surfaces_the_configured_lone_hit_score(
     assert default[0]["similarity"] - lowered[0]["similarity"] > 0.5, (
         "FTS_LONE_HIT_SCORE did not reach the fallback lane"
     )
+
+
+def test_semantic_disabled_refuses_the_encoder_and_writes_no_embedding(tmp_path):
+    """The switch has to degrade the running server, not just the constant.
+
+    `test_semantic_search_enabled_zero_forces_the_degraded_path` proves the flag
+    reaches settings, which is a different claim from the one the release makes:
+    no model load, and no embeddings written. Both are decided by an import-time
+    constant read inside MARMMemory, so a fresh process is the only place to
+    observe them.
+    """
+    import subprocess
+
+    pytest.importorskip("fastembed")
+
+    db_path = tmp_path / "degraded.db"
+    script = """
+import asyncio, sqlite3, sys
+from marm_mcp_server.config.settings import SEMANTIC_SEARCH_AVAILABLE
+from marm_mcp_server.core.memory import MARMMemory
+
+db = sys.argv[1]
+assert SEMANTIC_SEARCH_AVAILABLE is False, "flag did not reach settings"
+
+mem = MARMMemory(db)
+assert mem._load_encoder_lazily() is False, "encoder loaded despite the switch"
+assert mem.encoder is None, "an encoder object was constructed"
+
+mem_id = asyncio.run(
+    mem.store_memory("a normal write with the model switched off", session="degraded")
+)
+assert mem_id, "write did not return an id"
+
+conn = sqlite3.connect(db)
+row = conn.execute("SELECT embedding FROM memories WHERE id = ?", (mem_id,)).fetchone()
+conn.close()
+assert row is not None, "the write did not land in the database"
+assert row[0] is None, "an embedding was written with the model switched off"
+print("OK")
+"""
+
+    env = dict(os.environ)
+    env["SEMANTIC_SEARCH_ENABLED"] = "0"
+    proc = subprocess.run(
+        [sys.executable, "-c", script, str(db_path)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(pathlib.Path(__file__).resolve().parent.parent),
+        timeout=120,
+    )
+
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert "OK" in proc.stdout

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -1123,3 +1123,184 @@ def test_wide_builder_respects_session_scope(tmp_path):
 
     assert scoped == {mine_id}
     assert len(unscoped) == 2
+
+
+# --- Phase 3: semantic-fallback lane (v2.33.0) ---
+
+
+def _fallback_corpus(tmp_path):
+    """A store whose memories share no single word with the question below.
+
+    Strict AND therefore matches nothing, which is the condition that made this
+    lane dead; the wide builder matches on individual content words.
+    """
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    # Exactly what _load_encoder_lazily() returning False produces at runtime.
+    memory._encoder_failed = True
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    with memory.get_connection() as conn:
+        target = _insert_with_embedding(
+            conn, "fb", "I adopted a golden retriever puppy last spring", vec
+        )
+        _insert_with_embedding(conn, "fb", "the quarterly budget was approved", vec)
+    return memory, target
+
+
+FALLBACK_QUESTION = "What kind of puppy did they adopt?"
+
+
+@pytest.mark.asyncio
+async def test_semantic_fallback_lane_uses_the_wide_builder(tmp_path):
+    """With no encoder, an NL question must still return the matching memory.
+
+    Before v2.33.0 this lane built a strict-AND MATCH, found nothing, fell through
+    to `content LIKE '%<whole question>%'` which also found nothing, and returned
+    an empty list for essentially every natural-language query.
+    """
+    memory, target = _fallback_corpus(tmp_path)
+
+    results = await memory.recall_similar(FALLBACK_QUESTION, session="fb", limit=5)
+
+    assert [r["id"] for r in results] == [target]
+    assert results[0]["retrieval_mode"] == "semantic_fallback_fts"
+
+
+@pytest.mark.asyncio
+async def test_strict_builder_would_have_returned_nothing_for_the_same_query(tmp_path):
+    """Pins the regression the wide builder fixes, so the test above cannot pass
+    for an unrelated reason (e.g. the LIKE fallback happening to match)."""
+    from marm_mcp_server.core.memory_scoring import _fetch_and_score_fts_rows
+
+    memory, _ = _fallback_corpus(tmp_path)
+
+    strict = _safe_fts_query(FALLBACK_QUESTION)
+    assert strict is not None, (
+        "the query is sanitizable; the AND semantics are the issue"
+    )
+    rows = _fetch_and_score_fts_rows(memory.db_path, "fb", strict, 200)
+
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_exact_lane_still_uses_strict_and_after_the_fallback_widened(tmp_path):
+    """The regression guard for the whole spec: widening the fallback must not
+    widen the exact lane, which returns rows with no semantic rerank."""
+    memory, _ = _fallback_corpus(tmp_path)
+
+    results = await memory.recall_similar(
+        FALLBACK_QUESTION, session="fb", limit=5, exact_mode="exact"
+    )
+
+    assert results == [], "exact lane widened; it must stay on strict AND"
+
+
+@pytest.mark.asyncio
+async def test_fallback_lane_stays_session_scoped_when_widened(tmp_path):
+    """Widening the MATCH is exactly where a scoping bug would surface, and this
+    lane bypasses the semantic reranker that would otherwise mask one."""
+    memory, target = _fallback_corpus(tmp_path)
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    with memory.get_connection() as conn:
+        _insert_with_embedding(conn, "other-session", "she adopted a puppy too", vec)
+
+    results = await memory.recall_similar(FALLBACK_QUESTION, session="fb", limit=5)
+
+    assert [r["id"] for r in results] == [target]
+
+
+def _import_settings_with_semantic_enabled(env_value: str) -> tuple[str, str]:
+    """Read SEMANTIC_SEARCH_AVAILABLE from a clean process.
+
+    Same constraint as the FTS_LONE_HIT_SCORE helper above: the value is decided at
+    import time, so only a fresh interpreter can observe a second setting of it.
+    """
+    import subprocess
+
+    env = dict(os.environ)
+    env["SEMANTIC_SEARCH_ENABLED"] = env_value
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from marm_mcp_server.config.settings import SEMANTIC_SEARCH_AVAILABLE as v;"
+            "print(repr(v))",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(pathlib.Path(__file__).resolve().parent.parent),
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip(), proc.stderr
+
+
+def test_semantic_search_enabled_zero_forces_the_degraded_path():
+    """The switch that makes the fallback lane reachable without uninstalling
+    fastembed. If this regresses, the Phase 3 measurement cannot be reproduced."""
+    pytest.importorskip("fastembed")
+
+    value, stderr = _import_settings_with_semantic_enabled("0")
+    assert value == "False"
+    assert "disabled by SEMANTIC_SEARCH_ENABLED=0" in stderr
+    assert "pip install fastembed" not in stderr, (
+        "reported a missing dependency when it is installed but switched off"
+    )
+
+    value, _ = _import_settings_with_semantic_enabled("1")
+    assert value == "True"
+
+
+def test_lone_hit_score_applies_to_fallback_lane_but_not_exact_lane(tmp_path):
+    """Both lanes share `_fetch_and_score_fts_rows`, so the parameter is the only
+    thing that can separate them on an identical degenerate result set.
+
+    The fallback lane matches on a wide OR, where a lone hit can mean one memory
+    shared one word, so it passes FTS_LONE_HIT_SCORE. The exact lane's strict AND
+    means a lone hit contained every term, so it keeps 1.0.
+    """
+    from marm_mcp_server.core.memory_scoring import _fetch_and_score_fts_rows
+
+    memory, target = _fallback_corpus(tmp_path)
+    wide = _wide(FALLBACK_QUESTION)
+
+    fallback = _fetch_and_score_fts_rows(
+        memory.db_path, "fb", wide, 200, lone_hit_score=0.25
+    )
+    exact = _fetch_and_score_fts_rows(memory.db_path, "fb", wide, 200)
+
+    assert [row["id"] for row, _ in fallback] == [target], "expected a degenerate set"
+    assert [score for _, score in fallback] == [0.25]
+    assert [score for _, score in exact] == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_fallback_lane_surfaces_the_configured_lone_hit_score(
+    tmp_path, monkeypatch
+):
+    """Proves the wiring reaches the real call site, not just the fetcher.
+
+    memory_recall reads the setting from its own namespace, so patching it here is
+    what a deployment setting the env var would produce.
+    """
+    from marm_mcp_server.core import memory_recall
+
+    memory, _ = _fallback_corpus(tmp_path)
+
+    default = await memory.recall_similar(FALLBACK_QUESTION, session="fb", limit=5)
+    assert len(default) == 1
+
+    monkeypatch.setattr(memory_recall, "FTS_LONE_HIT_SCORE", 0.25)
+    lowered = await memory.recall_similar(FALLBACK_QUESTION, session="fb", limit=5)
+
+    assert len(lowered) == 1
+    # A plain `<` would pass without the fix: recency decays between the two calls,
+    # so the later score is always fractionally lower. Only a gap this size can come
+    # from the 1.0 -> 0.25 change surviving the temporal blend.
+    assert default[0]["similarity"] - lowered[0]["similarity"] > 0.5, (
+        "FTS_LONE_HIT_SCORE did not reach the fallback lane"
+    )


### PR DESCRIPTION
## v2.33.0 - Keyword-Only Recall Works When the Embedding Model Is Unavailable

MARM falls back to keyword-only search when the embedding model cannot load or throws mid-recall. That fallback was unusable: it required every word of the query to appear in a single memory, so natural-language questions matched nothing and recall came back empty. This release makes the fallback actually work.

- The fallback lane now builds its keyword query the same broader way the main search lane has since v2.31.0. The exact-lookup lane is deliberately unchanged and still requires all terms, because its results are returned in raw keyword order with nothing reranking them. `FTS_QUERY_MODE=and` still forces strict matching everywhere for anyone who wants it.
- Measured on LoCoMo (1,977 questions, 5,882 ingested memories, top-5 recall,  embedding model disabled): any-hit **0.1% → 55.4%**, all-hit 0.1% → 46.7%,  evidence recall 0.1% → 50.5%. Every question category improved. Adversarial went from 0.0% → 51.8%, which mostly reflects that a lane returning nothing had no precision to lose. With the model loaded, the same corpus scored 62.5% any-hit, so the degraded path now reaches roughly 89% of full accuracy instead of being unusable.
- New setting `SEMANTIC_SEARCH_ENABLED` (default `1`). Set it to `0` to run as though fastembed were not installed: no model load, no embeddings written, keyword-only recall. It exists because the degraded path could not be measured any other way, and it also lets a low-memory host skip loading the model. `marm-memory doctor` reports when it is off.
- `FTS_LONE_HIT_SCORE` now applies to the fallback lane. That lane shares a row fetcher with the exact-lookup lane, so it always reported `1.0` correct under strict all-terms matching, wrong once the lane matched on a broad query, where a single match can mean one memory happened to share one word. The exact lane still always uses `1.0`. No change at the default.
- Fixed: the fastembed and apscheduler warnings in `settings.py` printed to stdout, which can corrupt JSON-RPC on the STDIO transport. Both now use stderr.

Behavior is unchanged for anyone whose embedding model loads normally, and there is no migration, schema change, or re-embed.

### Validation

Suite: 872 passed, 2 skipped. `tests/test_exact_retrieval_lane.py` passes unmodified, which is the guard that the widening did not leak into the exact lane. The 7 new tests were each re-run with their fix removed to confirm they fail one initially passed for the wrong reason, because recency decay between two successive recalls satisfied the assertion by about 4e-11 rather than by the setting under test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `SEMANTIC_SEARCH_ENABLED` to disable embedding/semantic behavior and force keyword matching only.
  * Added `marm-memory init` runtime setup commands, including a Claude integration option.
  * Improved diagnostics to surface whether semantic search is available (keyword-only mode).
* **Bug Fixes**
  * Improved embedding-unavailable recall fallback to use broader keyword matching (avoids empty recall).
  * Fixed “lone hit” FTS scoring for the fallback lane while keeping exact/lexical scoring unchanged.
* **Documentation**
  * Updated configuration references and all v2.33.0 version labels across installation and overview docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->