### PR TITLE
Release/v2.33.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,17 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+
+  # Track the Console UI. Directory is the pnpm workspace root, where the lockfile is.
+  - package-ecosystem: "npm"
+    directory: "/marm-console"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      console-dev:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      console-prod:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## Version 2 - MARM Protocol to Universal MCP Server Evolution
 
 <details>
+<summary><strong>July 30th, 2026: Recall and Consolidation Correctness Fixes (v2.33.1)</strong></summary>
+
+### Fixed: Duplicate Detection Compared the Wrong Score
+
+- `CONSOLIDATION_THRESHOLD` (default `0.92`) is documented as the meaning-similarity a memory needs before it is merged into an existing one. The check was comparing it against the final ranking score instead, which also folds in keyword relevance and a recency boost. A memory could therefore be merged away when its actual meaning-similarity was below the threshold, because keyword overlap and freshness had pushed its ranking score above it.
+- Duplicate detection now compares the raw meaning-similarity, as documented. It also asks for the meaning-based search lane explicitly: syntax-heavy content such as config keys, file paths and commands is normally routed to exact keyword lookup, which produces no meaning-similarity at all, so duplicate detection could not have worked for it either way. And it looks at a handful of candidates rather than only the top-ranked one, because the closest memory by meaning is not always the one that ranks first. If no meaning-similarity is available, nothing is merged.
+- This only affects installs that have turned consolidation on; it is off by default (`CONSOLIDATION_ENABLED=0`), so no existing default behavior changes. Fixes #113.
+
+### Fixed: Recency Scoring Was Not Reproducible Within a Single Recall
+
+- The recency boost read the clock separately for every candidate in a recall, so memories saved at the same moment received slightly different recency scores. Whenever two memories were otherwise equally relevant, which one ranked higher came down to which was processed first rather than anything about the memories.
+- All candidates in a recall are now scored against a single reference time, so identical timestamps produce identical recency scores. Applies to meaning-based search and to the keyword-only fallback; exact keyword lookup does not use recency scoring and is unchanged.
+- Note this addresses ordering *within* one recall. Recency scores still move as time passes between separate recalls, which is what the feature is for.
+
+</details>
+
+<details>
 <summary><strong>July 29th, 2026: Recall Keeps Working When the Embedding Model Does Not (v2.33.0)</strong></summary>
 
 ### Fixed: Recall Returned Nothing When the Embedding Model Was Unavailable

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.1</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -177,55 +177,65 @@ MARM is tuned for fast recall first, even as memory grows and long memories are 
 
 These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. All numbers below come from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal.
 
+Re-measured for v2.33.0. Latency rose and the hybrid speedup in section 4 fell substantially, both because `FTS_CANDIDATE_LIMIT` was raised from `50` to `200` in v2.32.0 to recover multi-hop accuracy. That was a deliberate trade of speed for correctness, and the older figures below were published before it.
+
 ### 1. Retrieval Latency Scaling
 
 End-to-end `recall_similar` latency (includes query encoding).
 
 | Session Size ($N$) | Min Latency | Median Latency | p95 Latency |
 | :--- | :--- | :--- | :--- |
-| **N = 100** | 6.3 ms | 6.5 ms | 8.1 ms |
-| **N = 500** | 7.2 ms | 7.4 ms | 8.0 ms |
-| **N = 1,000** | 8.0 ms | 8.2 ms | 9.9 ms |
-| **N = 2,000** | 9.2 ms | 9.7 ms | 10.8 ms |
-| **N = 4,000** | 11.4 ms | 12.0 ms | 14.8 ms |
+| **N = 100** | 7.4 ms | 7.9 ms | 9.4 ms |
+| **N = 250** | 11.9 ms | 13.5 ms | 15.4 ms |
+| **N = 500** | 10.9 ms | 11.8 ms | 13.4 ms |
+| **N = 1,000** | 13.3 ms | 13.5 ms | 15.6 ms |
+| **N = 2,000** | 17.5 ms | 18.2 ms | 19.6 ms |
+| **N = 4,000** | 23.8 ms | 25.9 ms | 30.9 ms |
+
+Run-to-run variance at small $N$ is larger than the gap between adjacent sizes, which is why N = 250 reads slower than N = 500 here. Treat the trend from N = 1,000 upward as the real signal.
 
 ### 2. Encoder + Concurrency
 
-- **Cold model load:** `934ms`
-- **Warm encode:** median `4.2ms`, p95 `4.8ms`
-- **Concurrent recall:** 10 gathered recalls completed in `609.5ms` vs `411.3ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so gathering calls does not create parallel speedup.
+- **Cold model load:** `893ms`
+- **Warm encode:** median `3.8ms`, p95 `4.3ms`
+- **Concurrent recall:** 10 gathered recalls completed in `151.5ms` vs `176.0ms` serial (`gather/serial = 0.86`). Do not read that as parallelism: repeated runs of this same benchmark land anywhere from `0.63` to `0.86`, so the ratio is not stable enough to claim a speedup. The path is serialized around shared encoder and SQLite work by design, and any apparent gain is measurement noise.
 
 ### 3. Write-Time Ingestion Cost
 
-- **Consolidation off:** median `5.9ms`, p95 `7.5ms`
-- **Consolidation on:** median `61.2ms`, p95 `105.3ms`
-- **Tradeoff:** write-time dedupe/clustering adds `10.3x` median cost so recall stays fast and cleaner over time.
+- **Consolidation off:** median `6.5ms`, p95 `7.6ms`
+- **Consolidation on:** median `58.1ms`, p95 `106.5ms`
+- **Tradeoff:** write-time dedupe/clustering adds `9.0x` median cost so recall stays fast and the store stays cleaner over time. Consolidation is off by default.
 
 ### 4. Recall Scaling: Full Scan vs Production Hybrid
 
 Why recall stays roughly flat as memory grows: instead of scoring every stored vector, production recall uses an FTS keyword pre-filter to a bounded candidate set, then re-ranks that set by semantic + BM25 + temporal score. Both columns are real code paths (`_fetch_and_score_embedding_rows` for the full scan, `recall_similar` for hybrid), dispatched through the same async path and timed with the query vector precomputed so the constant encode cost from section 1 is excluded from both. Each iteration alternates which path runs first so neither one consistently benefits from the other's warmed cache.
 
-| Session Size ($N$) | Full Semantic Scan | Production Hybrid | Speedup |
-| :--- | :--- | :--- | :--- |
-| **N = 100** | 3.5 ms | 3.8 ms | 0.9x |
-| **N = 500** | 15.9 ms | 4.2 ms | 3.8x |
-| **N = 1,000** | 34.4 ms | 4.9 ms | 7.0x |
-| **N = 2,000** | 67.6 ms | 5.7 ms | 11.9x |
-| **N = 4,000** | 132.5 ms | 7.3 ms | 18.0x |
-| **N = 10,000** | 330.4 ms | 8.4 ms | 39.4x |
+| Session Size ($N$) | Full Semantic Scan | Production Hybrid | Speedup | FTS candidates |
+| :--- | :--- | :--- | :--- | :--- |
+| **N = 100** | 3.3 ms | 6.6 ms | 0.5x | 85 / 200 |
+| **N = 500** | 16.3 ms | 11.6 ms | 1.4x | 200 / 200 |
+| **N = 1,000** | 31.1 ms | 14.7 ms | 2.1x | 200 / 200 |
+| **N = 2,000** | 63.5 ms | 19.0 ms | 3.3x | 200 / 200 |
+| **N = 4,000** | 127.2 ms | 29.1 ms | 4.4x | 200 / 200 |
+| **N = 10,000** | 316.7 ms | 53.8 ms | 5.9x | 200 / 200 |
 
-The full scan grows roughly linearly with $N$ while hybrid recall stays near-flat, so the advantage widens with session size. At very small $N$ the pre-filter overhead is not yet worth it (hybrid is marginally slower at N = 100); the win appears once there is enough to skip. Reproduce with [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py).
+The full scan grows roughly linearly with $N$ while hybrid recall grows far more slowly, so the advantage still widens with session size. At very small $N$ the pre-filter is not worth its overhead and hybrid is slower.
+
+**These speedups are much lower than the figures published before v2.32.0** (which claimed up to `39.4x` at N = 10,000). Nothing regressed. `FTS_CANDIDATE_LIMIT` was raised from `50` to `200` to recover multi-hop retrieval accuracy, so the rerank step now scores four times as many candidates. The `FTS candidates` column shows the pool saturating at 200 from N = 500 upward, which is where the extra cost comes from. Lowering the setting restores the old speed and gives back the accuracy. Reproduce with [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py).
 
 ### 5. LoCoMo Retrieval Accuracy
 
-A fresh Jina v2 Small run ingested all 10 LoCoMo conversations through `marm_log_entry`, then scored top-5 `marm_smart_recall` results against 1,977 evidence-annotated questions. No answer-generation model or LLM judge was used.
+All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is used.
 
-| Encoder | Any evidence hit | All evidence hit | Mean evidence recall |
+| Configuration | Any evidence hit | All evidence hit | Mean evidence recall |
 | :--- | :--- | :--- | :--- |
-| **MiniLM baseline** | 37.5% | 29.5% | not previously published |
-| **Jina v2 Small** | 53.0% | 43.4% | 47.6% |
+| MiniLM baseline | 37.5% | 29.5% | not published |
+| Jina v2 Small (v2.29.0) | 53.0% | 43.4% | 47.6% |
+| **Current (v2.33.0)** | **62.9 - 63.5%** | **53.1 - 53.5%** | **57.4 - 57.9%** |
 
-The Jina run improved both hit metrics in this benchmark. This comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce it with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+The v2.33.0 row is a range, not a point, because it is two identically-configured runs. Repeat runs of this harness disagree by up to **0.56pp** (19 of 1,977 questions), so differences smaller than that are not meaningful. The cause is understood: the corpus is written minutes before the benchmark, so `TEMPORAL_WEIGHT` reorders near-ties as the store ages between runs. Quote the range rather than the better run.
+
+The gain over v2.29.0 came from making the keyword lane actually produce candidates for natural-language questions (v2.31.0), then tuning what that lane contributes (v2.32.0) and fixing the encoder-off fallback (v2.33.0). The earlier MiniLM comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
 
 ### 6. vs Competitors: Architecture
 
@@ -924,7 +934,7 @@ Everything above runs on a small number of deliberate mechanisms. This section i
 - **Write-time consolidation** (opt-in, `CONSOLIDATION_ENABLED=1`) runs two layers before a memory lands:
   - **Layer 1, exact dedup**: a SHA-256 hash of normalized content is checked within the session; hash hits are verified against the actual content before deduplicating, so a hash collision stores a new row instead of silently merging different content.
   - **Layer 2, semantic merge**: near-duplicates above `CONSOLIDATION_THRESHOLD` cosine similarity are merged rather than accumulated. This never blocks a write; if the encoder isn't available, the write proceeds unconsolidated.
-  - The tradeoff is measured and published: roughly 4x median write cost (still ~42ms) in exchange for a store that stays clean, because reads dominate memory workloads.
+  - The tradeoff is measured and published: roughly 9x median write cost (58ms vs 6.5ms) in exchange for a store that stays clean, because reads dominate memory workloads. See section 3 of the benchmarks above.
 - **Compaction** (opt-in, `COMPACTION_ENABLED=1`) is Layer 3: after enough writes in a session, a background pass detects clusters of related memories using cosine similarity plus union-find connected components, gated by minimum cluster size, minimum age, and an active-session grace period so it never compacts work in flight. MARM then injects a bounded request asking the connected agent to summarize each cluster: `candidates` → `stage` → `review` → `apply` or `discard`. Source memory IDs are preserved on apply, so compacted summaries stay traceable to their originals. Staged summaries expire (`COMPACTION_STAGING_TTL_HOURS`), nudges are capped and cooldown-limited, and the injection has a byte budget. The design is honest about what LLMs are for: MARM detects, the agent summarizes, and a human-reviewable stage/apply/discard loop gates the destructive step.
 
 ### Recall path
@@ -988,7 +998,7 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `SEMANTIC_SEARCH_ENABLED` | `1` | Set to `0` to run without the embedding model: nothing is loaded, no embeddings are written, and recall falls back to keyword matching. Useful on low-memory hosts, or to see how recall behaves when the model is unavailable. `marm-memory doctor` reports when it is off. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
-| `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |
+| `CONSOLIDATION_THRESHOLD` | `0.92` | Cosine similarity needed to merge near-duplicates. Compared against meaning-similarity alone, not the blended ranking score |
 | `COMPACTION_ENABLED` | `0` | Background cluster detection + agent-assisted compaction |
 | `COMPACTION_TRIGGER_COUNT` | `5` | Writes per session before a compaction pass |
 | `COMPACTION_SIMILARITY_THRESHOLD` / `COMPACTION_MIN_CLUSTER_SIZE` / `COMPACTION_MIN_AGE_HOURS` | `0.88` / `3` / `24` | Cluster detection gates |

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.33.0** - Memory Accurate Response Mode
+**MARM v2.33.1** - Memory Accurate Response Mode
 *Docker deployment guide for Windows, Mac, and Linux*
 
 ---

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.33.0** - Memory Accurate Response Mode
+**MARM v2.33.1** - Memory Accurate Response Mode
 *Complete Linux installation guide*
 
 ---
@@ -320,7 +320,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-PLATFORMS.md
+++ b/docs/INSTALL-PLATFORMS.md
@@ -1,4 +1,4 @@
-# MARM v2.33.0 MCP Server - Platform Integration Guide
+# MARM v2.33.1 MCP Server - Platform Integration Guide
 
 ## Table of Contents
 

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -2,7 +2,7 @@
 
 ## Universal Memory Intelligence Platform for AI Agents
 
-**MARM v2.33.0** - Memory Accurate Response Mode
+**MARM v2.33.1** - Memory Accurate Response Mode
 *Complete Windows installation guide*
 
 ---
@@ -294,7 +294,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/TECHNICAL-OVERVIEW.md
+++ b/docs/TECHNICAL-OVERVIEW.md
@@ -1,6 +1,6 @@
 # MARM Technical Overview
 
-> Current implementation: MARM MCP Server v2.33.0
+> Current implementation: MARM MCP Server v2.33.1
 
 This document explains what MARM is, why it is built this way, and how information moves through the system from an agent writing something to that information being recalled later. It is intended as a technical product overview, not a source-code reference.
 

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -73,7 +73,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.33.0"
+LABEL org.opencontainers.image.version="2.33.1"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -7,7 +7,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="900"
      height="250">
 </picture>
-<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.0</h1>
+<h1 align="center">MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.1</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -179,55 +179,65 @@ MARM is tuned for fast recall first, even as memory grows and long memories are 
 
 These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. All numbers below come from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal.
 
+Re-measured for v2.33.0. Latency rose and the hybrid speedup in section 4 fell substantially, both because `FTS_CANDIDATE_LIMIT` was raised from `50` to `200` in v2.32.0 to recover multi-hop accuracy. That was a deliberate trade of speed for correctness, and the older figures below were published before it.
+
 ### 1. Retrieval Latency Scaling
 
 End-to-end `recall_similar` latency (includes query encoding).
 
 | Session Size ($N$) | Min Latency | Median Latency | p95 Latency |
 | :--- | :--- | :--- | :--- |
-| **N = 100** | 6.3 ms | 6.5 ms | 8.1 ms |
-| **N = 500** | 7.2 ms | 7.4 ms | 8.0 ms |
-| **N = 1,000** | 8.0 ms | 8.2 ms | 9.9 ms |
-| **N = 2,000** | 9.2 ms | 9.7 ms | 10.8 ms |
-| **N = 4,000** | 11.4 ms | 12.0 ms | 14.8 ms |
+| **N = 100** | 7.4 ms | 7.9 ms | 9.4 ms |
+| **N = 250** | 11.9 ms | 13.5 ms | 15.4 ms |
+| **N = 500** | 10.9 ms | 11.8 ms | 13.4 ms |
+| **N = 1,000** | 13.3 ms | 13.5 ms | 15.6 ms |
+| **N = 2,000** | 17.5 ms | 18.2 ms | 19.6 ms |
+| **N = 4,000** | 23.8 ms | 25.9 ms | 30.9 ms |
+
+Run-to-run variance at small $N$ is larger than the gap between adjacent sizes, which is why N = 250 reads slower than N = 500 here. Treat the trend from N = 1,000 upward as the real signal.
 
 ### 2. Encoder + Concurrency
 
-- **Cold model load:** `934ms`
-- **Warm encode:** median `4.2ms`, p95 `4.8ms`
-- **Concurrent recall:** 10 gathered recalls completed in `609.5ms` vs `411.3ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so gathering calls does not create parallel speedup.
+- **Cold model load:** `893ms`
+- **Warm encode:** median `3.8ms`, p95 `4.3ms`
+- **Concurrent recall:** 10 gathered recalls completed in `151.5ms` vs `176.0ms` serial (`gather/serial = 0.86`). Do not read that as parallelism: repeated runs of this same benchmark land anywhere from `0.63` to `0.86`, so the ratio is not stable enough to claim a speedup. The path is serialized around shared encoder and SQLite work by design, and any apparent gain is measurement noise.
 
 ### 3. Write-Time Ingestion Cost
 
-- **Consolidation off:** median `5.9ms`, p95 `7.5ms`
-- **Consolidation on:** median `61.2ms`, p95 `105.3ms`
-- **Tradeoff:** write-time dedupe/clustering adds `10.3x` median cost so recall stays fast and cleaner over time.
+- **Consolidation off:** median `6.5ms`, p95 `7.6ms`
+- **Consolidation on:** median `58.1ms`, p95 `106.5ms`
+- **Tradeoff:** write-time dedupe/clustering adds `9.0x` median cost so recall stays fast and the store stays cleaner over time. Consolidation is off by default.
 
 ### 4. Recall Scaling: Full Scan vs Production Hybrid
 
 Why recall stays roughly flat as memory grows: instead of scoring every stored vector, production recall uses an FTS keyword pre-filter to a bounded candidate set, then re-ranks that set by semantic + BM25 + temporal score. Both columns are real code paths (`_fetch_and_score_embedding_rows` for the full scan, `recall_similar` for hybrid), dispatched through the same async path and timed with the query vector precomputed so the constant encode cost from section 1 is excluded from both. Each iteration alternates which path runs first so neither one consistently benefits from the other's warmed cache.
 
-| Session Size ($N$) | Full Semantic Scan | Production Hybrid | Speedup |
-| :--- | :--- | :--- | :--- |
-| **N = 100** | 3.5 ms | 3.8 ms | 0.9x |
-| **N = 500** | 15.9 ms | 4.2 ms | 3.8x |
-| **N = 1,000** | 34.4 ms | 4.9 ms | 7.0x |
-| **N = 2,000** | 67.6 ms | 5.7 ms | 11.9x |
-| **N = 4,000** | 132.5 ms | 7.3 ms | 18.0x |
-| **N = 10,000** | 330.4 ms | 8.4 ms | 39.4x |
+| Session Size ($N$) | Full Semantic Scan | Production Hybrid | Speedup | FTS candidates |
+| :--- | :--- | :--- | :--- | :--- |
+| **N = 100** | 3.3 ms | 6.6 ms | 0.5x | 85 / 200 |
+| **N = 500** | 16.3 ms | 11.6 ms | 1.4x | 200 / 200 |
+| **N = 1,000** | 31.1 ms | 14.7 ms | 2.1x | 200 / 200 |
+| **N = 2,000** | 63.5 ms | 19.0 ms | 3.3x | 200 / 200 |
+| **N = 4,000** | 127.2 ms | 29.1 ms | 4.4x | 200 / 200 |
+| **N = 10,000** | 316.7 ms | 53.8 ms | 5.9x | 200 / 200 |
 
-The full scan grows roughly linearly with $N$ while hybrid recall stays near-flat, so the advantage widens with session size. At very small $N$ the pre-filter overhead is not yet worth it (hybrid is marginally slower at N = 100); the win appears once there is enough to skip. Reproduce with [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py).
+The full scan grows roughly linearly with $N$ while hybrid recall grows far more slowly, so the advantage still widens with session size. At very small $N$ the pre-filter is not worth its overhead and hybrid is slower.
+
+**These speedups are much lower than the figures published before v2.32.0** (which claimed up to `39.4x` at N = 10,000). Nothing regressed. `FTS_CANDIDATE_LIMIT` was raised from `50` to `200` to recover multi-hop retrieval accuracy, so the rerank step now scores four times as many candidates. The `FTS candidates` column shows the pool saturating at 200 from N = 500 upward, which is where the extra cost comes from. Lowering the setting restores the old speed and gives back the accuracy. Reproduce with [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py).
 
 ### 5. LoCoMo Retrieval Accuracy
 
-A fresh Jina v2 Small run ingested all 10 LoCoMo conversations through `marm_log_entry`, then scored top-5 `marm_smart_recall` results against 1,977 evidence-annotated questions. No answer-generation model or LLM judge was used.
+All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is used.
 
-| Encoder | Any evidence hit | All evidence hit | Mean evidence recall |
+| Configuration | Any evidence hit | All evidence hit | Mean evidence recall |
 | :--- | :--- | :--- | :--- |
-| **MiniLM baseline** | 37.5% | 29.5% | not previously published |
-| **Jina v2 Small** | 53.0% | 43.4% | 47.6% |
+| MiniLM baseline | 37.5% | 29.5% | not published |
+| Jina v2 Small (v2.29.0) | 53.0% | 43.4% | 47.6% |
+| **Current (v2.33.0)** | **62.9 - 63.5%** | **53.1 - 53.5%** | **57.4 - 57.9%** |
 
-The Jina run improved both hit metrics in this benchmark. This comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce it with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+The v2.33.0 row is a range, not a point, because it is two identically-configured runs. Repeat runs of this harness disagree by up to **0.56pp** (19 of 1,977 questions), so differences smaller than that are not meaningful. The cause is understood: the corpus is written minutes before the benchmark, so `TEMPORAL_WEIGHT` reorders near-ties as the store ages between runs. Quote the range rather than the better run.
+
+The gain over v2.29.0 came from making the keyword lane actually produce candidates for natural-language questions (v2.31.0), then tuning what that lane contributes (v2.32.0) and fixing the encoder-off fallback (v2.33.0). The earlier MiniLM comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
 
 ### 6. vs Competitors: Architecture
 
@@ -926,7 +936,7 @@ Everything above runs on a small number of deliberate mechanisms. This section i
 - **Write-time consolidation** (opt-in, `CONSOLIDATION_ENABLED=1`) runs two layers before a memory lands:
   - **Layer 1, exact dedup**: a SHA-256 hash of normalized content is checked within the session; hash hits are verified against the actual content before deduplicating, so a hash collision stores a new row instead of silently merging different content.
   - **Layer 2, semantic merge**: near-duplicates above `CONSOLIDATION_THRESHOLD` cosine similarity are merged rather than accumulated. This never blocks a write; if the encoder isn't available, the write proceeds unconsolidated.
-  - The tradeoff is measured and published: roughly 4x median write cost (still ~42ms) in exchange for a store that stays clean, because reads dominate memory workloads.
+  - The tradeoff is measured and published: roughly 9x median write cost (58ms vs 6.5ms) in exchange for a store that stays clean, because reads dominate memory workloads. See section 3 of the benchmarks above.
 - **Compaction** (opt-in, `COMPACTION_ENABLED=1`) is Layer 3: after enough writes in a session, a background pass detects clusters of related memories using cosine similarity plus union-find connected components, gated by minimum cluster size, minimum age, and an active-session grace period so it never compacts work in flight. MARM then injects a bounded request asking the connected agent to summarize each cluster: `candidates` → `stage` → `review` → `apply` or `discard`. Source memory IDs are preserved on apply, so compacted summaries stay traceable to their originals. Staged summaries expire (`COMPACTION_STAGING_TTL_HOURS`), nudges are capped and cooldown-limited, and the injection has a byte budget. The design is honest about what LLMs are for: MARM detects, the agent summarizes, and a human-reviewable stage/apply/discard loop gates the destructive step.
 
 ### Recall path
@@ -990,7 +1000,7 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `SEMANTIC_SEARCH_ENABLED` | `1` | Set to `0` to run without the embedding model: nothing is loaded, no embeddings are written, and recall falls back to keyword matching. Useful on low-memory hosts, or to see how recall behaves when the model is unavailable. `marm-memory doctor` reports when it is off. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
-| `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |
+| `CONSOLIDATION_THRESHOLD` | `0.92` | Cosine similarity needed to merge near-duplicates. Compared against meaning-similarity alone, not the blended ranking score |
 | `COMPACTION_ENABLED` | `0` | Background cluster detection + agent-assisted compaction |
 | `COMPACTION_TRIGGER_COUNT` | `5` | Writes per session before a compaction pass |
 | `COMPACTION_SIMILARITY_THRESHOLD` / `COMPACTION_MIN_CLUSTER_SIZE` / `COMPACTION_MIN_AGE_HOURS` | `0.88` / `3` / `24` | Cluster detection gates |

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     # :latest is the all-in-one MCP image (memory + graph, one port).
     # Pin :memory-only instead if you need the pre-unification image shape.
-    image: lyellr88/marm-mcp-server:2.33.0
+    image: lyellr88/marm-mcp-server:2.33.1
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -18,7 +18,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.33.0
+      - SERVER_VERSION=2.33.1
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,10 +14,10 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.33.0
+Version: 2.33.1
 """
 
-__version__ = "2.33.0"
+__version__ = "2.33.1"
 __author__ = "Ryan Lyell"
 __email__ = "ryanlyell@marmemory.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -179,7 +179,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.33.0"
+SERVER_VERSION = "2.33.1"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 

--- a/marm-mcp-server/marm_mcp_server/core/consolidation.py
+++ b/marm-mcp-server/marm_mcp_server/core/consolidation.py
@@ -9,6 +9,9 @@ from ..config.settings import MARM_PROJECT, MARM_PLATFORM
 logger = logging.getLogger(__name__)
 _UNSET = object()
 
+# Enough rows to absorb reordering by the lexical and recency signals.
+_DUPLICATE_CANDIDATES = 5
+
 
 def normalize_content(content: str) -> str:
     return content.lower().strip()
@@ -54,26 +57,36 @@ async def find_semantic_duplicate(
     project: object = _UNSET,
     platform: object = _UNSET,
 ) -> Optional[str]:
-    """Return memory_id of nearest semantic match at or above threshold in session, or None.
+    """Return memory_id of a semantic match at or above threshold in session, or None.
 
     Falls back to None if encoder unavailable — never blocks a write.
     Accepts a pre-computed query_vec to avoid re-encoding already-embedded content.
+
+    threshold is a cosine threshold, so this compares raw cosine and not
+    "similarity", which is blended with the lexical and recency signals. A row
+    with no cosine is never a duplicate.
     """
     try:
         if query_vec is None and not memory._load_encoder_lazily():
             return None
         scoped_project = MARM_PROJECT or None if project is _UNSET else project
         scoped_platform = MARM_PLATFORM or None if platform is _UNSET else platform
+        # exact_mode="semantic" because the exact lane produces no cosine.
         results = await memory.recall_similar(
             content,
             session=session_name,
-            limit=1,
+            limit=_DUPLICATE_CANDIDATES,
             query_vec=query_vec,
             project=scoped_project,
             platform=scoped_platform,
+            exact_mode="semantic",
+            with_cosine=True,
         )
-        if results and results[0]["similarity"] >= threshold:
-            return results[0]["id"]
+        scored = [r for r in results if "cosine" in r]
+        if scored:
+            nearest = max(scored, key=lambda r: r["cosine"])
+            if nearest["cosine"] >= threshold:
+                return nearest["id"]
     except Exception:
         logger.exception("Semantic dedup check failed")
     return None

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -409,6 +409,8 @@ class MARMMemory:
         exact_mode: str = "auto",
         project: str = None,
         platform: str = None,
+        *,
+        with_cosine: bool = False,
     ):
         return await _recall_similar(
             self,
@@ -420,6 +422,7 @@ class MARMMemory:
             exact_mode,
             project,
             platform,
+            with_cosine=with_cosine,
         )
 
     async def recall_text_search(

--- a/marm-mcp-server/marm_mcp_server/core/memory_recall.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_recall.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from datetime import datetime, timezone
 from typing import Dict, List
 
 from ..config.settings import (
@@ -142,6 +143,8 @@ async def _recall_similar(
     exact_mode: str = "auto",
     project: str = None,
     platform: str = None,
+    *,
+    with_cosine: bool = False,
 ):
     """Find semantically similar memories.
 
@@ -157,6 +160,12 @@ async def _recall_similar(
     When include_scan_metadata=True, returns (List[Dict], dict) where the second
     element contains recall_scan_truncated and recall_scan_limit. All other callers
     receive List[Dict] as before.
+
+    with_cosine adds a "cosine" key carrying the unfused cosine score. Internal
+    only: "similarity" is a ranking score blended with the lexical and recency
+    signals, so a caller comparing against a cosine threshold needs the raw value.
+    The key is present only on the lanes that compute a cosine at all, so a caller
+    that requires it also gets a reliable signal that none was available.
     """
     scan_limit = RECALL_SCAN_LIMIT
 
@@ -280,9 +289,14 @@ async def _recall_similar(
         # signal, so it keeps the pure semantic+temporal blend.
         apply_bm25 = not use_semantic_fallback and bool(bm25_by_id)
 
+        # One instant for the whole set, so equal timestamps score equally.
+        scored_at = datetime.now(timezone.utc)
+
         combined: dict[str, tuple] = {}
         for mem_row, vec_score in similarities:
-            t_score = _temporal_score(mem_row["timestamp"], TEMPORAL_HALF_LIFE_DAYS)
+            t_score = _temporal_score(
+                mem_row["timestamp"], TEMPORAL_HALF_LIFE_DAYS, scored_at
+            )
             if apply_bm25:
                 bm25_score = bm25_by_id.get(mem_row["id"], 0.0)
                 relevance = (
@@ -293,27 +307,29 @@ async def _recall_similar(
             combined[mem_row["id"]] = (
                 mem_row,
                 (1 - TEMPORAL_WEIGHT) * relevance + TEMPORAL_WEIGHT * t_score,
+                vec_score,
             )
 
         ranked = sorted(combined.values(), key=lambda x: x[1], reverse=True)[:limit]
 
         results = []
-        for memory, similarity in ranked:
-            results.append(
-                {
-                    "id": memory["id"],
-                    "session_name": memory["session_name"],
-                    "content": memory["content"],
-                    "timestamp": memory["timestamp"],
-                    "context_type": memory["context_type"],
-                    "metadata": json.loads(memory["metadata"])
-                    if memory["metadata"]
-                    else {},
-                    "similarity": float(similarity),
-                    "project": memory["project"],
-                    "platform": memory["platform"],
-                }
-            )
+        for memory, similarity, cosine in ranked:
+            result = {
+                "id": memory["id"],
+                "session_name": memory["session_name"],
+                "content": memory["content"],
+                "timestamp": memory["timestamp"],
+                "context_type": memory["context_type"],
+                "metadata": json.loads(memory["metadata"])
+                if memory["metadata"]
+                else {},
+                "similarity": float(similarity),
+                "project": memory["project"],
+                "platform": memory["platform"],
+            }
+            if with_cosine:
+                result["cosine"] = float(cosine)
+            results.append(result)
 
         return _wrap(results, scan_truncated)
 
@@ -359,10 +375,13 @@ async def _recall_text_search(
         f"builder={'wide' if apply_temporal else 'strict'}"
     )
 
+    # None on the exact lane, which never reaches _temporal_score.
+    scored_at = datetime.now(timezone.utc) if apply_temporal else None
+
     def _blend_temporal(base_sim: float, timestamp: str) -> float:
         if not apply_temporal:
             return base_sim
-        t_score = _temporal_score(timestamp, TEMPORAL_HALF_LIFE_DAYS)
+        t_score = _temporal_score(timestamp, TEMPORAL_HALF_LIFE_DAYS, scored_at)
         return (1 - TEMPORAL_WEIGHT) * base_sim + TEMPORAL_WEIGHT * t_score
 
     # apply_temporal is already this function's lane discriminator: True from the
@@ -389,8 +408,6 @@ async def _recall_text_search(
                 fetch_limit,
                 project,
                 platform,
-                # Same reason the semantic lane passes it: this lane's MATCH is a
-                # wide OR, so a degenerate set is weak evidence, not a perfect hit.
                 lone_hit_score=FTS_LONE_HIT_SCORE if apply_temporal else 1.0,
             )
             if fts_rows:

--- a/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
@@ -11,14 +11,10 @@ def _normalize_bm25(
 ) -> list[float]:
     """Map raw BM25 scores (more-negative = better) to [0, 1] with 1.0 best.
 
-    Per-query min-max needs a spread to normalize against, so single-row and
-    all-equal result sets are degenerate and get `lone_hit_score` instead.
-
-    How much evidence a degenerate set represents depends on how the MATCH was
-    built, so the caller decides. Under strict AND a lone hit means every query
-    term was present, which justifies the default 1.0. Under the semantic lane's
-    wide OR it can mean one memory contained one non-stopword, so that caller
-    passes FTS_LONE_HIT_SCORE.
+    Min-max needs a spread, so single-row and all-equal sets get lone_hit_score.
+    The caller sets it because the evidence a lone hit represents depends on how
+    its MATCH was built: strict AND means every term was present, a wide OR can
+    mean one shared word.
     """
     if not raw_scores:
         return []
@@ -231,10 +227,6 @@ def _fetch_and_score_fts_rows(
     if not rows:
         return []
 
-    # Two lanes share this fetcher. The exact lane leaves lone_hit_score at 1.0,
-    # because its strict-AND MATCH means a lone hit had every query term present.
-    # The semantic-fallback lane passes FTS_LONE_HIT_SCORE, because since v2.33.0 it
-    # matches on a wide OR, where a lone hit can mean one memory shared one word.
     normalized = _normalize_bm25(
         [row["score"] for row in rows], lone_hit_score=lone_hit_score
     )

--- a/marm-mcp-server/marm_mcp_server/core/memory_utils.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_utils.py
@@ -73,13 +73,24 @@ def _strip_script_tags(text: str) -> str:
     return "".join(result)
 
 
-def _temporal_score(timestamp: str, half_life_days: float) -> float:
-    """Return a recency score in [0, 1]: 1.0 for brand-new, 0.5 at half_life_days."""
+def _temporal_score(
+    timestamp: str, half_life_days: float, now: datetime | None = None
+) -> float:
+    """Return a recency score in [0, 1]: 1.0 for brand-new, 0.5 at half_life_days.
+
+    Pass `now` to score a whole candidate set against one reference instant.
+    Reading the clock per candidate instead makes two rows with the same stored
+    timestamp score fractionally apart, which is enough to decide their order
+    whenever the relevance scores are tied, so recall would rank them by
+    microsecond timing rather than by anything reproducible. Defaults to the
+    current time so existing callers are unaffected.
+    """
     try:
         ts = datetime.fromisoformat(timestamp)
         if ts.tzinfo is None:
             ts = ts.replace(tzinfo=timezone.utc)
-        age_days = (datetime.now(timezone.utc) - ts).total_seconds() / 86400
+        reference = now if now is not None else datetime.now(timezone.utc)
+        age_days = (reference - ts).total_seconds() / 86400
         return min(1.0, math.exp(-age_days * math.log(2) / half_life_days))
     except Exception:
         return 0.5

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.0
+# MARM: Local-First Persistent Multi-Agent Memory Layer for MCP Clients v2.33.1
 
 ## Important Messages
 
@@ -153,55 +153,65 @@ MARM is tuned for fast recall first, even as memory grows and long memories are 
 
 These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. All numbers below come from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal.
 
+Re-measured for v2.33.0. Latency rose and the hybrid speedup in section 4 fell substantially, both because `FTS_CANDIDATE_LIMIT` was raised from `50` to `200` in v2.32.0 to recover multi-hop accuracy. That was a deliberate trade of speed for correctness, and the older figures below were published before it.
+
 ### 1. Retrieval Latency Scaling
 
 End-to-end `recall_similar` latency (includes query encoding).
 
 | Session Size ($N$) | Min Latency | Median Latency | p95 Latency |
 | :--- | :--- | :--- | :--- |
-| **N = 100** | 6.3 ms | 6.5 ms | 8.1 ms |
-| **N = 500** | 7.2 ms | 7.4 ms | 8.0 ms |
-| **N = 1,000** | 8.0 ms | 8.2 ms | 9.9 ms |
-| **N = 2,000** | 9.2 ms | 9.7 ms | 10.8 ms |
-| **N = 4,000** | 11.4 ms | 12.0 ms | 14.8 ms |
+| **N = 100** | 7.4 ms | 7.9 ms | 9.4 ms |
+| **N = 250** | 11.9 ms | 13.5 ms | 15.4 ms |
+| **N = 500** | 10.9 ms | 11.8 ms | 13.4 ms |
+| **N = 1,000** | 13.3 ms | 13.5 ms | 15.6 ms |
+| **N = 2,000** | 17.5 ms | 18.2 ms | 19.6 ms |
+| **N = 4,000** | 23.8 ms | 25.9 ms | 30.9 ms |
+
+Run-to-run variance at small $N$ is larger than the gap between adjacent sizes, which is why N = 250 reads slower than N = 500 here. Treat the trend from N = 1,000 upward as the real signal.
 
 ### 2. Encoder + Concurrency
 
-- **Cold model load:** `934ms`
-- **Warm encode:** median `4.2ms`, p95 `4.8ms`
-- **Concurrent recall:** 10 gathered recalls completed in `609.5ms` vs `411.3ms` serial. The current path is intentionally serialized around shared encoder/SQLite work, so gathering calls does not create parallel speedup.
+- **Cold model load:** `893ms`
+- **Warm encode:** median `3.8ms`, p95 `4.3ms`
+- **Concurrent recall:** 10 gathered recalls completed in `151.5ms` vs `176.0ms` serial (`gather/serial = 0.86`). Do not read that as parallelism: repeated runs of this same benchmark land anywhere from `0.63` to `0.86`, so the ratio is not stable enough to claim a speedup. The path is serialized around shared encoder and SQLite work by design, and any apparent gain is measurement noise.
 
 ### 3. Write-Time Ingestion Cost
 
-- **Consolidation off:** median `5.9ms`, p95 `7.5ms`
-- **Consolidation on:** median `61.2ms`, p95 `105.3ms`
-- **Tradeoff:** write-time dedupe/clustering adds `10.3x` median cost so recall stays fast and cleaner over time.
+- **Consolidation off:** median `6.5ms`, p95 `7.6ms`
+- **Consolidation on:** median `58.1ms`, p95 `106.5ms`
+- **Tradeoff:** write-time dedupe/clustering adds `9.0x` median cost so recall stays fast and the store stays cleaner over time. Consolidation is off by default.
 
 ### 4. Recall Scaling: Full Scan vs Production Hybrid
 
 Why recall stays roughly flat as memory grows: instead of scoring every stored vector, production recall uses an FTS keyword pre-filter to a bounded candidate set, then re-ranks that set by semantic + BM25 + temporal score. Both columns are real code paths (`_fetch_and_score_embedding_rows` for the full scan, `recall_similar` for hybrid), dispatched through the same async path and timed with the query vector precomputed so the constant encode cost from section 1 is excluded from both. Each iteration alternates which path runs first so neither one consistently benefits from the other's warmed cache.
 
-| Session Size ($N$) | Full Semantic Scan | Production Hybrid | Speedup |
-| :--- | :--- | :--- | :--- |
-| **N = 100** | 3.5 ms | 3.8 ms | 0.9x |
-| **N = 500** | 15.9 ms | 4.2 ms | 3.8x |
-| **N = 1,000** | 34.4 ms | 4.9 ms | 7.0x |
-| **N = 2,000** | 67.6 ms | 5.7 ms | 11.9x |
-| **N = 4,000** | 132.5 ms | 7.3 ms | 18.0x |
-| **N = 10,000** | 330.4 ms | 8.4 ms | 39.4x |
+| Session Size ($N$) | Full Semantic Scan | Production Hybrid | Speedup | FTS candidates |
+| :--- | :--- | :--- | :--- | :--- |
+| **N = 100** | 3.3 ms | 6.6 ms | 0.5x | 85 / 200 |
+| **N = 500** | 16.3 ms | 11.6 ms | 1.4x | 200 / 200 |
+| **N = 1,000** | 31.1 ms | 14.7 ms | 2.1x | 200 / 200 |
+| **N = 2,000** | 63.5 ms | 19.0 ms | 3.3x | 200 / 200 |
+| **N = 4,000** | 127.2 ms | 29.1 ms | 4.4x | 200 / 200 |
+| **N = 10,000** | 316.7 ms | 53.8 ms | 5.9x | 200 / 200 |
 
-The full scan grows roughly linearly with $N$ while hybrid recall stays near-flat, so the advantage widens with session size. At very small $N$ the pre-filter overhead is not yet worth it (hybrid is marginally slower at N = 100); the win appears once there is enough to skip. Reproduce with [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py).
+The full scan grows roughly linearly with $N$ while hybrid recall grows far more slowly, so the advantage still widens with session size. At very small $N$ the pre-filter is not worth its overhead and hybrid is slower.
+
+**These speedups are much lower than the figures published before v2.32.0** (which claimed up to `39.4x` at N = 10,000). Nothing regressed. `FTS_CANDIDATE_LIMIT` was raised from `50` to `200` to recover multi-hop retrieval accuracy, so the rerank step now scores four times as many candidates. The `FTS candidates` column shows the pool saturating at 200 from N = 500 upward, which is where the extra cost comes from. Lowering the setting restores the old speed and gives back the accuracy. Reproduce with [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py).
 
 ### 5. LoCoMo Retrieval Accuracy
 
-A fresh Jina v2 Small run ingested all 10 LoCoMo conversations through `marm_log_entry`, then scored top-5 `marm_smart_recall` results against 1,977 evidence-annotated questions. No answer-generation model or LLM judge was used.
+All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is used.
 
-| Encoder | Any evidence hit | All evidence hit | Mean evidence recall |
+| Configuration | Any evidence hit | All evidence hit | Mean evidence recall |
 | :--- | :--- | :--- | :--- |
-| **MiniLM baseline** | 37.5% | 29.5% | not previously published |
-| **Jina v2 Small** | 53.0% | 43.4% | 47.6% |
+| MiniLM baseline | 37.5% | 29.5% | not published |
+| Jina v2 Small (v2.29.0) | 53.0% | 43.4% | 47.6% |
+| **Current (v2.33.0)** | **62.9 - 63.5%** | **53.1 - 53.5%** | **57.4 - 57.9%** |
 
-The Jina run improved both hit metrics in this benchmark. This comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce it with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+The v2.33.0 row is a range, not a point, because it is two identically-configured runs. Repeat runs of this harness disagree by up to **0.56pp** (19 of 1,977 questions), so differences smaller than that are not meaningful. The cause is understood: the corpus is written minutes before the benchmark, so `TEMPORAL_WEIGHT` reorders near-ties as the store ages between runs. Quote the range rather than the better run.
+
+The gain over v2.29.0 came from making the keyword lane actually produce candidates for natural-language questions (v2.31.0), then tuning what that lane contributes (v2.32.0) and fixing the encoder-off fallback (v2.33.0). The earlier MiniLM comparison does not isolate context length as the sole cause; model quality, 512-dimensional vectors, and reranking behavior changed together. Reproduce with [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
 
 ### 6. vs Competitors: Architecture
 
@@ -894,7 +904,7 @@ Everything above runs on a small number of deliberate mechanisms. This section i
 - **Write-time consolidation** (opt-in, `CONSOLIDATION_ENABLED=1`) runs two layers before a memory lands:
   - **Layer 1, exact dedup**: a SHA-256 hash of normalized content is checked within the session; hash hits are verified against the actual content before deduplicating, so a hash collision stores a new row instead of silently merging different content.
   - **Layer 2, semantic merge**: near-duplicates above `CONSOLIDATION_THRESHOLD` cosine similarity are merged rather than accumulated. This never blocks a write; if the encoder isn't available, the write proceeds unconsolidated.
-  - The tradeoff is measured and published: roughly 4x median write cost (still ~42ms) in exchange for a store that stays clean, because reads dominate memory workloads.
+  - The tradeoff is measured and published: roughly 9x median write cost (58ms vs 6.5ms) in exchange for a store that stays clean, because reads dominate memory workloads. See section 3 of the benchmarks above.
 - **Compaction** (opt-in, `COMPACTION_ENABLED=1`) is Layer 3: after enough writes in a session, a background pass detects clusters of related memories using cosine similarity plus union-find connected components, gated by minimum cluster size, minimum age, and an active-session grace period so it never compacts work in flight. MARM then injects a bounded request asking the connected agent to summarize each cluster: `candidates` → `stage` → `review` → `apply` or `discard`. Source memory IDs are preserved on apply, so compacted summaries stay traceable to their originals. Staged summaries expire (`COMPACTION_STAGING_TTL_HOURS`), nudges are capped and cooldown-limited, and the injection has a byte budget. The design is honest about what LLMs are for: MARM detects, the agent summarizes, and a human-reviewable stage/apply/discard loop gates the destructive step.
 
 ### Recall path
@@ -958,7 +968,7 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `SEMANTIC_SEARCH_ENABLED` | `1` | Set to `0` to run without the embedding model: nothing is loaded, no embeddings are written, and recall falls back to keyword matching. Useful on low-memory hosts, or to see how recall behaves when the model is unavailable. `marm-memory doctor` reports when it is off. |
 | `TEMPORAL_WEIGHT` / `TEMPORAL_HALF_LIFE_DAYS` | `0.1` / `30` | Strength and decay of the recency boost |
 | `CONSOLIDATION_ENABLED` | `0` | Write-time dedup + semantic merge |
-| `CONSOLIDATION_THRESHOLD` | `0.92` | Similarity needed to merge near-duplicates |
+| `CONSOLIDATION_THRESHOLD` | `0.92` | Cosine similarity needed to merge near-duplicates. Compared against meaning-similarity alone, not the blended ranking score |
 | `COMPACTION_ENABLED` | `0` | Background cluster detection + agent-assisted compaction |
 | `COMPACTION_TRIGGER_COUNT` | `5` | Writes per session before a compaction pass |
 | `COMPACTION_SIMILARITY_THRESHOLD` / `COMPACTION_MIN_CLUSTER_SIZE` / `COMPACTION_MIN_AGE_HOURS` | `0.88` / `3` / `24` | Cluster detection gates |

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
@@ -19,8 +19,6 @@
 - [Knowledge Graphs: Code & Concepts](#knowledge-graphs-code--concepts)
 - [Architecture & Internals](#architecture--internals)
 - [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [Project Documentation](#project-documentation)
 
 ## Why MARM Memory
 

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - marm-memory
-Version: 2.33.0
+Version: 2.33.1
 """
 
 import os

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.33.0"
+version = "2.33.1"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.33.0",
+      "version": "2.33.1",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.33.0",
+      "identifier": "lyellr88/marm-mcp-server:2.33.1",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_consolidation_write_time.py
+++ b/marm-mcp-server/tests/test_consolidation_write_time.py
@@ -129,10 +129,19 @@ async def test_find_semantic_duplicate_returns_id_when_similarity_above_threshol
     mem = MARMMemory(str(tmp_path / "memory.db"))
 
     monkeypatched_recall_called = []
+    recall_kwargs = {}
 
     async def mock_recall(query, session=None, limit=5, query_vec=None, **kwargs):
         monkeypatched_recall_called.append(query)
-        return [{"id": "existing-id", "similarity": 0.95, "content": "similar content"}]
+        recall_kwargs.update(kwargs)
+        return [
+            {
+                "id": "existing-id",
+                "similarity": 0.95,
+                "cosine": 0.95,
+                "content": "similar content",
+            }
+        ]
 
     mem._load_encoder_lazily = lambda: True
     mem.recall_similar = mock_recall
@@ -143,6 +152,8 @@ async def test_find_semantic_duplicate_returns_id_when_similarity_above_threshol
 
     assert result == "existing-id"
     assert len(monkeypatched_recall_called) == 1
+    # The threshold is a cosine threshold, so the raw value has to be requested.
+    assert recall_kwargs.get("with_cosine") is True
 
 
 @pytest.mark.asyncio
@@ -152,7 +163,17 @@ async def test_find_semantic_duplicate_returns_none_when_similarity_below_thresh
     mem = MARMMemory(str(tmp_path / "memory.db"))
 
     async def mock_recall(query, session=None, limit=5, query_vec=None, **kwargs):
-        return [{"id": "existing-id", "similarity": 0.85, "content": "similar content"}]
+        # High fused score, low cosine: the row ranks first but is not a
+        # duplicate. Only the cosine may decide, or an unrelated memory gets
+        # merged away.
+        return [
+            {
+                "id": "existing-id",
+                "similarity": 0.99,
+                "cosine": 0.85,
+                "content": "similar content",
+            }
+        ]
 
     mem._load_encoder_lazily = lambda: True
     mem.recall_similar = mock_recall

--- a/marm-mcp-server/tests/test_hybrid_search.py
+++ b/marm-mcp-server/tests/test_hybrid_search.py
@@ -1358,3 +1358,443 @@ print("OK")
 
     assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     assert "OK" in proc.stdout
+
+
+# --- temporal scoring uses one reference instant per recall ---
+
+
+def _stub_tied_cosines(monkeypatch, module, id_order):
+    """Force exactly equal cosine scores, returned in a chosen fetch order.
+
+    Storing the same embedding twice is not enough: float32 matmul accumulates in
+    SIMD blocks, so two copies of one vector differ by ~1e-6. Only the score is
+    synthesized; the rows come from the real query.
+    """
+    original = module._fetch_and_score_by_ids
+
+    def tied(db_path, memory_ids, query_embedding):
+        results, skipped = original(db_path, memory_ids, query_embedding)
+        by_id = {row["id"]: row for row, _ in results}
+        return [(by_id[mid], 1.0) for mid in id_order if mid in by_id], skipped
+
+    monkeypatch.setattr(module, "_fetch_and_score_by_ids", tied)
+
+
+def test_temporal_score_accepts_a_reference_time_and_stays_backward_compatible():
+    """The parameter is optional, so every existing caller keeps working."""
+    from datetime import timedelta
+
+    from marm_mcp_server.core.memory_utils import _temporal_score
+
+    aged = (datetime.now(_timezone.utc) - timedelta(days=30)).isoformat()
+
+    # Omitted: still the documented half-life behavior.
+    assert _temporal_score(aged, 30) == pytest.approx(0.5, abs=1e-4)
+
+    # Supplied: repeated scoring against one instant is bit-identical, which is
+    # the property the recall paths depend on.
+    now = datetime.now(_timezone.utc)
+    assert _temporal_score(aged, 30, now) == _temporal_score(aged, 30, now)
+
+    # Closed form, not a second live clock read: at a 30-day half-life the score
+    # moves ~1.3e-7 per second, so that comparison would be a stopwatch race.
+    fixed = datetime.fromisoformat("2026-01-31T00:00:00+00:00")
+    sixty_days_before = datetime.fromisoformat("2025-12-02T00:00:00+00:00")
+    assert _temporal_score(sixty_days_before.isoformat(), 30, fixed) == pytest.approx(
+        0.25, abs=1e-9
+    )
+
+    # Unparseable input keeps its neutral score with or without a reference.
+    assert _temporal_score("not a timestamp", 30) == 0.5
+    assert _temporal_score("not a timestamp", 30, now) == 0.5
+
+
+def _shared_timestamp_pool(memory, session, count, content="shared keyword row"):
+    """Insert `count` rows that share one timestamp and identical content.
+
+    Identical content makes BM25 tie exactly, so the lexical term cannot separate
+    the rows and the temporal term is the only remaining variable.
+    """
+    from datetime import timedelta
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    shared = (datetime.now(_timezone.utc) - timedelta(days=7)).isoformat()
+
+    ids = []
+    with memory.get_connection() as conn:
+        for _ in range(count):
+            mem_id = str(_uuid_module.uuid4())
+            conn.execute(
+                "INSERT INTO memories"
+                " (id, session_name, content, embedding, content_hash, timestamp,"
+                "  context_type, metadata)"
+                " VALUES (?, ?, ?, ?, ?, ?, 'general', '{}')",
+                (
+                    mem_id,
+                    session,
+                    content,
+                    vec.tobytes(),
+                    f"hash-{mem_id}",
+                    shared,
+                ),
+            )
+            ids.append(mem_id)
+    return ids, vec
+
+
+@pytest.mark.asyncio
+async def test_semantic_lane_scores_equal_timestamps_against_one_reference(
+    monkeypatch, tmp_path
+):
+    """Rows sharing a timestamp, with cosine and BM25 tied, must score identically.
+
+    Eight rows rather than two: a single sub-microsecond clock tick anywhere in
+    the loop is enough to break the assertion.
+    """
+    from marm_mcp_server.core import memory_recall as memory_recall_module
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+    ids, vec = _shared_timestamp_pool(memory, "tsnap", 8)
+
+    # Temporal must stay on: it is the term under test.
+    assert memory_recall_module.TEMPORAL_WEIGHT > 0
+
+    _stub_tied_cosines(monkeypatch, memory_recall_module, sorted(ids))
+    monkeypatch.setattr(
+        memory_recall_module,
+        "_fetch_fts_candidate_ids",
+        lambda *_: [(mid, 1.0) for mid in sorted(ids)],
+    )
+
+    results = await memory.recall_similar(
+        "shared", session="tsnap", limit=len(ids), query_vec=vec.copy()
+    )
+
+    assert len(results) == len(ids)
+    scores = {r["similarity"] for r in results}
+    assert len(scores) == 1, (
+        f"equal timestamps produced {len(scores)} distinct scores: {sorted(scores)}"
+    )
+    # A real recency score, not a degenerate 0.0 or 1.0 that would tie anyway.
+    assert 0.0 < results[0]["similarity"] < 1.0
+
+
+@pytest.mark.asyncio
+async def test_keyword_fallback_scores_equal_timestamps_against_one_reference(
+    tmp_path,
+):
+    """The encoder-off lane blends temporal too, so it needs the same snapshot."""
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    # Exactly what _load_encoder_lazily() returning False produces at runtime.
+    memory._encoder_failed = True
+    ids, _vec = _shared_timestamp_pool(memory, "tsnapfb", 8)
+
+    results = await memory.recall_similar(
+        "shared keyword", session="tsnapfb", limit=len(ids)
+    )
+
+    assert len(results) == len(ids)
+    assert all(r["retrieval_mode"] == "semantic_fallback_fts" for r in results)
+    scores = {r["similarity"] for r in results}
+    assert len(scores) == 1, (
+        f"equal timestamps produced {len(scores)} distinct scores: {sorted(scores)}"
+    )
+    assert 0.0 < results[0]["similarity"] < 1.0
+
+
+@pytest.mark.asyncio
+async def test_exact_lane_still_skips_temporal_scoring_entirely(tmp_path):
+    """The snapshot must not pull temporal into the exact lane, which returns raw
+    BM25 order by design."""
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    with memory.get_connection() as conn:
+        _insert_with_embedding(conn, "ex", "FTS_CANDIDATE_LIMIT=200 note", vec)
+        _insert_with_embedding(conn, "ex", "unrelated weather prose", vec)
+
+    results = await memory.recall_similar(
+        "FTS_CANDIDATE_LIMIT", session="ex", limit=5, exact_mode="exact"
+    )
+
+    assert results
+    assert all(r["retrieval_mode"].startswith("exact_") for r in results)
+    # Un-blended BM25: the sole match of a degenerate set keeps FTS_LONE_HIT_SCORE
+    # rather than being pulled below 1.0 by a recency term.
+    assert results[0]["similarity"] == pytest.approx(1.0)
+
+
+# --- consolidation thresholds on raw cosine, not the fused ranking score ---
+
+
+def _vector_with_cosine(query_vec, target_cos, dim=384):
+    """Build a unit vector whose cosine to query_vec is target_cos."""
+    orthogonal = np.zeros(dim, dtype=np.float32)
+    half = dim // 2
+    orthogonal[:half] = 1.0
+    orthogonal[half:] = -1.0
+    orthogonal -= np.dot(orthogonal, query_vec) * query_vec
+    orthogonal /= np.linalg.norm(orthogonal)
+    out = target_cos * query_vec + np.sqrt(1.0 - target_cos**2) * orthogonal
+    return (out / np.linalg.norm(out)).astype(np.float32)
+
+
+# Fused score lands ~0.927, over the 0.92 threshold, while the true cosine is
+# under it. Usable window is cos in [0.910, 0.920).
+_TRAP_COSINE = 0.915
+
+
+def _near_miss_store(tmp_path, session="dedup"):
+    """A store holding one memory that is close but not a duplicate."""
+    from marm_mcp_server.core import memory_recall as memory_recall_module
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    query = np.ones(384, dtype=np.float32)
+    query /= np.linalg.norm(query)
+    near_miss = _vector_with_cosine(query, _TRAP_COSINE)
+
+    with memory.get_connection() as conn:
+        lone = _insert_with_embedding(
+            conn, session, "a nearby but distinct memory", near_miss
+        )
+    return memory, memory_recall_module, query, lone
+
+
+@pytest.mark.asyncio
+async def test_consolidation_thresholds_on_cosine_not_the_fused_score(
+    monkeypatch, tmp_path
+):
+    """Issue #113: a memory whose real cosine is under the threshold can still
+    report a blended score above it, and must not be merged."""
+    from marm_mcp_server.core.consolidation import find_semantic_duplicate
+
+    memory, module, query, lone = _near_miss_store(tmp_path)
+    # Top lexical score, which is what a real single-row match produces via
+    # FTS_LONE_HIT_SCORE. Temporal is left at its shipped weight: the trap
+    # depends on it, and pinning it to 0 would test a config nobody runs.
+    monkeypatch.setattr(module, "_fetch_fts_candidate_ids", lambda *_: [(lone, 1.0)])
+
+    ranked = await memory.recall_similar(
+        "anything", session="dedup", limit=5, query_vec=query.copy(), with_cosine=True
+    )
+    # Arm the trap, so this test cannot pass on a harmless fixture.
+    assert ranked[0]["similarity"] >= 0.92, (
+        f"fused score {ranked[0]['similarity']:.5f} does not clear the threshold, "
+        "so the old code would not have merged and there is nothing to catch"
+    )
+    assert ranked[0]["cosine"] < 0.92, "fixture is a genuine duplicate"
+
+    found = await find_semantic_duplicate(
+        memory,
+        "anything",
+        "dedup",
+        0.92,
+        query_vec=query.copy(),
+        project=None,
+        platform=None,
+    )
+    assert found is None, (
+        "merged a non-duplicate by thresholding the fused ranking score"
+    )
+
+
+@pytest.mark.asyncio
+async def test_consolidation_still_merges_a_genuine_near_duplicate(
+    monkeypatch, tmp_path
+):
+    """The other direction: reading cosine must not break real dedup."""
+    from marm_mcp_server.core import memory_recall as memory_recall_module
+    from marm_mcp_server.core.consolidation import find_semantic_duplicate
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    with memory.get_connection() as conn:
+        twin = _insert_with_embedding(conn, "dedup", "the deploy step is manual", vec)
+
+    monkeypatch.setattr(
+        memory_recall_module, "_fetch_fts_candidate_ids", lambda *_: [(twin, 1.0)]
+    )
+
+    found = await find_semantic_duplicate(
+        memory,
+        "the deploy step is manual",
+        "dedup",
+        0.92,
+        query_vec=vec.copy(),
+        project=None,
+        platform=None,
+    )
+    assert found == twin
+
+
+@pytest.mark.asyncio
+async def test_with_cosine_is_opt_in_and_reports_the_unfused_score(
+    monkeypatch, tmp_path
+):
+    """Consolidation's channel for the raw value. Off by default so MCP responses
+    keep their shape, and carrying cosine rather than the blend when asked."""
+    memory, module, query, lone = _near_miss_store(tmp_path, session="cos")
+    monkeypatch.setattr(module, "_fetch_fts_candidate_ids", lambda *_: [(lone, 1.0)])
+
+    default = await memory.recall_similar(
+        "anything", session="cos", limit=5, query_vec=query.copy()
+    )
+    assert "cosine" not in default[0], "raw cosine leaked into a normal response"
+
+    opted_in = await memory.recall_similar(
+        "anything", session="cos", limit=5, query_vec=query.copy(), with_cosine=True
+    )
+    assert opted_in[0]["cosine"] == pytest.approx(_TRAP_COSINE, abs=1e-4)
+    # The two must not be the same number, or the key is reporting the blend.
+    assert opted_in[0]["cosine"] != pytest.approx(opted_in[0]["similarity"], abs=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_consolidation_declines_when_no_cosine_is_available(
+    monkeypatch, tmp_path
+):
+    """When scoring fails, recall degrades to the keyword-only path, which reports
+    no cosine. An absent cosine must mean "not a duplicate"."""
+    from marm_mcp_server.core import memory_recall as memory_recall_module
+    from marm_mcp_server.core.consolidation import find_semantic_duplicate
+
+    memory, target = _fallback_corpus(tmp_path)
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("embedding scoring unavailable")
+
+    monkeypatch.setattr(memory_recall_module, "_fetch_and_score_by_ids", boom)
+    monkeypatch.setattr(memory_recall_module, "_fetch_and_score_embedding_rows", boom)
+
+    # Arm the trap: the degraded path really does return the row, with a score
+    # that would clear the threshold if "similarity" were trusted.
+    degraded = await memory.recall_similar(
+        "I adopted a golden retriever puppy last spring",
+        session="fb",
+        limit=5,
+        query_vec=vec.copy(),
+        exact_mode="semantic",
+        with_cosine=True,
+    )
+    assert degraded and degraded[0]["id"] == target
+    assert degraded[0]["similarity"] >= 0.92
+    assert "cosine" not in degraded[0]
+
+    found = await find_semantic_duplicate(
+        memory,
+        "I adopted a golden retriever puppy last spring",
+        "fb",
+        0.92,
+        query_vec=vec.copy(),
+        project=None,
+        platform=None,
+    )
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_consolidation_reaches_cosine_for_syntax_heavy_content(tmp_path):
+    """Syntax-heavy content satisfies _is_exact_query, and the exact lane returns
+    no cosine, so on "auto" dedup would decline every such write."""
+    from marm_mcp_server.core.consolidation import find_semantic_duplicate
+    from marm_mcp_server.core.memory_utils import _is_exact_query
+
+    content = "export FTS_CANDIDATE_LIMIT=200"
+    assert _is_exact_query(content), "fixture no longer routes to the exact lane"
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    vec = np.ones(384, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    with memory.get_connection() as conn:
+        twin = _insert_with_embedding(conn, "syntax", content, vec)
+
+    # Prove the premise: under "auto" this content bypasses cosine entirely.
+    routed = await memory.recall_similar(
+        content, session="syntax", limit=5, query_vec=vec.copy(), with_cosine=True
+    )
+    assert routed[0]["retrieval_mode"].startswith("exact_")
+    assert "cosine" not in routed[0]
+
+    found = await find_semantic_duplicate(
+        memory,
+        content,
+        "syntax",
+        0.92,
+        query_vec=vec.copy(),
+        project=None,
+        platform=None,
+    )
+    assert found == twin, "syntax-heavy duplicate was not consolidated"
+
+
+@pytest.mark.asyncio
+async def test_consolidation_looks_past_the_top_fused_row(monkeypatch, tmp_path):
+    """The row that ranks first is not always the closest by cosine.
+
+    near_miss  cos 0.910  bm25 1.0  -> fused 0.92305   ranks first
+    duplicate  cos 0.950  bm25 0.0  -> fused 0.91225   ranks second
+    """
+    from marm_mcp_server.core import memory_recall as memory_recall_module
+    from marm_mcp_server.core.consolidation import find_semantic_duplicate
+
+    memory = MARMMemory(str(tmp_path / "memory.db"))
+    memory._encoder_failed = True
+
+    query = np.ones(384, dtype=np.float32)
+    query /= np.linalg.norm(query)
+    near_miss_vec = _vector_with_cosine(query, 0.910)
+    duplicate_vec = _vector_with_cosine(query, 0.950)
+
+    with memory.get_connection() as conn:
+        near_miss = _insert_with_embedding(
+            conn, "past-top", "strong keyword overlap, wrong meaning", near_miss_vec
+        )
+        duplicate = _insert_with_embedding(
+            conn, "past-top", "the actual near duplicate", duplicate_vec
+        )
+
+    monkeypatch.setattr(
+        memory_recall_module,
+        "_fetch_fts_candidate_ids",
+        lambda *_: [(near_miss, 1.0), (duplicate, 0.0)],
+    )
+
+    # Arm the trap: confirm the near-miss really does outrank the duplicate, and
+    # that it alone would not clear the threshold.
+    ranked = await memory.recall_similar(
+        "anything",
+        session="past-top",
+        limit=5,
+        query_vec=query.copy(),
+        with_cosine=True,
+    )
+    assert ranked[0]["id"] == near_miss, "fixture no longer ranks the near-miss first"
+    assert ranked[0]["cosine"] < 0.92
+    assert any(r["id"] == duplicate and r["cosine"] >= 0.92 for r in ranked)
+
+    found = await find_semantic_duplicate(
+        memory,
+        "anything",
+        "past-top",
+        0.92,
+        query_vec=query.copy(),
+        project=None,
+        platform=None,
+    )
+    assert found == duplicate, (
+        "inspected only the top-ranked row and missed the real duplicate behind it"
+    )


### PR DESCRIPTION
v2.33.1 - Recall and Consolidation Correctness Fixes

This patch carries forward two independent correctness fixes found during the Phase 4 fusion bake-off. RRF itself was not merged; min-max remains the shipped fusion method.

- Recall now scores every candidate in one request against the same reference time, preventing equal timestamps from being reordered by per-row clock drift.
- Write-time consolidation now compares `CONSOLIDATION_THRESHOLD` against raw cosine similarity not the blended keyword/semantic/temporal ranking score. It explicitly uses the semantic lane, checks multiple candidates, and declines to merge when cosine is unavailable. Fixes #113.
- Added regression coverage for temporal stability, raw-cosine thresholding, syntax-heavy content, missing-cosine safety, and candidates displaced by fusion ranking.
- Updated v2.33.1 version surfaces, changelog, benchmark documentation, packaged docs, and Console Dependabot coverage.

Validation completed: 899 passed, 2 skipped; Ruff, MCP schema validation, version audit, and wheel/sdist build all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved semantic duplicate detection by evaluating multiple candidates and using raw meaning similarity.
  - Corrected recency scoring so results share a consistent reference time.
  - Preserved exact keyword search behavior while improving hybrid retrieval accuracy.

- **Documentation**
  - Updated installation guides, technical documentation, benchmarks, and performance figures for v2.33.1.
  - Clarified consolidation thresholds and revised estimated consolidation costs.

- **Release**
  - Updated the MARM version to v2.33.1 across published packages and deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->