### PR TITLE
Release/v2.38.0

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -56,7 +56,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r marm-mcp-server/requirements.txt
           pip install -e './marm-mcp-server' --no-deps
-          pip install pytest pytest-asyncio pytest-cov jsonschema requests black isort flake8 mypy ruff
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy ruff
 
       - name: Validate server.json
         run: |

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -24,8 +24,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Pinned so a ruff release cannot turn a green PR red on its own. Unpinned,
+      # 0.16.2 promoted RUF036 out of preview and failed a PR whose code had not
+      # changed, while the developer's 0.15.16 reported the file clean.
+      # Keep local ruff on this version.
       - name: Install Ruff
-        run: pip install ruff
+        run: pip install ruff==0.16.2
 
       - name: Run Ruff Check
         run: ruff check --output-format=github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Semver: MAJOR = breaking (schema renames, parameter removals), MINOR = new tools
 - Dev setup: `cd marm-mcp-server && pip install -e ".[dev]" && python scripts/bundle-concept-model.py`
 - Benchmarks live in `scripts/benchmarking/`: `preformance/bench_hotpath.py` for hot-path performance, `accuracy/locomo/run_eval.py` for LoCoMo retrieval accuracy. Do not publish performance claims neither script can back.
 
-## Current Stats (v2.37.0)
+## Current Stats (v2.38.0)
 
 - 14 MCP tools over HTTP + STDIO
 - 3 isolated SQLite databases (memory + concept graph + analytics), no shared pools. The code graph engine owns its own store outside all three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 <details>
+<summary><strong>August 10th, 2026: Type-Safe Core and Unified Validation (v2.38.0)</strong></summary>
+
+### Changed: MARM's Entire Server Package Is Now Type-Checked
+
+- Mypy previously checked only `core/`, which left endpoint, transport, Console, service, and utility code free to accumulate errors unnoticed. It now checks all 110 server modules and records a strict baseline, so a new type error fails the local gate instead of becoming another item in a hidden backlog.
+- The work tightened the contracts at the real boundaries: SQLite connections, memory ownership, serialized writes, recall return shapes, embeddings, compaction, graph gates, FastAPI middleware, CLI paths, and injected test doubles. These are internal contracts only; MCP tools, parameters, HTTP/STDIO behavior, and stored data are unchanged.
+- The encoder adapter now states its two actual shapes: encoding one string returns one NumPy vector, while encoding a list returns one vector per input. Migration and rechunking use a structural encoder contract, so their test doubles remain supported without pretending every encoder is FastEmbed.
+- The pass also exposed two latent type mismatches in real code, including a recall SQL parameter list that mixed text and a numeric limit. Both are corrected without changing the intended query or result behavior.
+
+### Changed: One Formatter and Linter Own the Python Style Contract
+
+- Ruff now owns formatting and linting. Black, isort, and Flake8 were removed from development and CI because their formatting and line-length rules conflicted with the project’s Ruff configuration. CI installs and checks the same tools developers run locally.
+- The bundled `marm-init` installer skill was refreshed alongside its source copy, so installed agents receive the current setup flow and both copies remain identical.
+
+### Developer Note
+
+- The typecheck gate ends at two deliberately visible graph-shutdown race findings. They are documented in `docs/current/graph-client-none-guard.md` rather than suppressed: resolving them requires a supervisor lifecycle change, not an annotation workaround.
+
+</details>
+
+<details>
 <summary><strong>August 4th, 2026: Automatic Code Graph Indexing (v2.37.0)</strong></summary>
 
 ### Added: Indexed Repositories Refresh Themselves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed: MARM's Entire Server Package Is Now Type-Checked
 
-- Mypy previously checked only `core/`, which left endpoint, transport, Console, service, and utility code free to accumulate errors unnoticed. It now checks all 110 server modules and records a strict baseline, so a new type error fails the local gate instead of becoming another item in a hidden backlog.
+- Mypy previously checked only `core/`, which left endpoint, transport, Console, service, and utility code free to accumulate errors unnoticed. It now checks all 110 server modules against a recorded error count, so a new type error raises that count and fails the local gate instead of becoming another item in a hidden backlog.
 - The work tightened the contracts at the real boundaries: SQLite connections, memory ownership, serialized writes, recall return shapes, embeddings, compaction, graph gates, FastAPI middleware, CLI paths, and injected test doubles. These are internal contracts only; MCP tools, parameters, HTTP/STDIO behavior, and stored data are unchanged.
 - The encoder adapter now states its two actual shapes: encoding one string returns one NumPy vector, while encoding a list returns one vector per input. Migration and rechunking use a structural encoder contract, so their test doubles remain supported without pretending every encoder is FastEmbed.
 - The pass also exposed two latent type mismatches in real code, including a recall SQL parameter list that mixed text and a numeric limit. Both are corrected without changing the intended query or result behavior.
@@ -14,6 +14,13 @@
 
 - Ruff now owns formatting and linting. Black, isort, and Flake8 were removed from development and CI because their formatting and line-length rules conflicted with the project’s Ruff configuration. CI installs and checks the same tools developers run locally.
 - The bundled `marm-init` installer skill was refreshed alongside its source copy, so installed agents receive the current setup flow and both copies remain identical.
+- Ruff is pinned in CI. An unpinned install let a new Ruff release fail a pull request whose code had not changed: 0.16.2 promoted a rule out of preview and flagged four annotations that the previous version reported clean. Keep local Ruff on the pinned version so a local pass predicts CI.
+
+### Fixed: A Doc Save No Longer Fails Or Duplicates Its Memory Mirror
+
+- Saving a doc commits the docs row first, then links it to a memories mirror in a second write. If that link failed, the save reported an error even though the doc was already stored durably, and the mirror row was left behind pointing at nothing.
+- The link failure is now reported as `mirror_status: "pending"` on an otherwise successful save, matching how a failed mirror write already behaved.
+- A later save repairs the link rather than creating a second mirror. The mirror write resolves a doc's existing mirror by its `doc_id`, so a doc keeps exactly one mirror row however many times the link has to be retried. Installs that already accumulated duplicate mirrors keep them; the fix stops new ones.
 
 ### Developer Note
 

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -313,7 +313,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -287,7 +287,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -73,7 +73,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.37.0"
+LABEL org.opencontainers.image.version="2.38.0"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     # :latest is the all-in-one MCP image (memory + graph, one port).
     # Pin :memory-only instead if you need the pre-unification image shape.
-    image: lyellr88/marm-mcp-server:2.37.0
+    image: lyellr88/marm-mcp-server:2.38.0
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -18,7 +18,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.37.0
+      - SERVER_VERSION=2.38.0
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,17 +14,19 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.37.0
+Version: 2.38.0
 """
 
-__version__ = "2.37.0"
+from typing import Any
+
+__version__ = "2.38.0"
 __author__ = "Ryan Lyell"
 __email__ = "ryanlyell@marmemory.com"
 
 __all__ = ["__version__", "create_server", "main"]
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     """Lazy-load HTTP server exports without side effects during STDIO imports."""
     if name == "create_server":
         from .server import create_server

--- a/marm-mcp-server/marm_mcp_server/cli.py
+++ b/marm-mcp-server/marm_mcp_server/cli.py
@@ -10,10 +10,13 @@ import urllib.error
 import urllib.request
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import structlog
 import uvicorn
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
 from .config import settings
 from .config.settings import (
@@ -83,7 +86,7 @@ async def run_server_with_shutdown() -> None:
         logger.info("Server shutdown complete")
 
 
-def create_server():
+def create_server() -> "FastAPI":
     """Return the FastAPI app instance for external use."""
     from .server import app
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -159,7 +159,7 @@ def _file_link(path: Path) -> str:
         return str(path)
 
 
-def get_marm_db_path():
+def get_marm_db_path() -> str:
     """Get the official MARM database path, respecting environment variable if set"""
     env_db_path = os.environ.get("MARM_DB_PATH")
     if env_db_path:
@@ -178,7 +178,7 @@ DEFAULT_DB_PATH = get_marm_db_path()
 MAX_DB_CONNECTIONS = 5
 
 
-def get_analytics_db_path():
+def get_analytics_db_path() -> str:
     """Get the analytics database path, respecting environment variable if set"""
     env_analytics_db_path = os.environ.get("MARM_ANALYTICS_DB_PATH")
     if env_analytics_db_path:

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -206,7 +206,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.37.0"
+SERVER_VERSION = "2.38.0"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 

--- a/marm-mcp-server/marm_mcp_server/console/app.py
+++ b/marm-mcp-server/marm_mcp_server/console/app.py
@@ -11,15 +11,17 @@ import logging
 import os
 import secrets
 import threading
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+from starlette.middleware.base import RequestResponseEndpoint
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from . import auth, mcp_client
@@ -70,7 +72,7 @@ def _warm_project_cache() -> None:
 
 
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if not (STATIC_DIR / "index.html").exists():
         logger.warning(
             "MARM Console frontend assets are missing; API remains available."
@@ -92,7 +94,9 @@ class _ConsoleBootstrapRequest(BaseModel):
 
 
 @app.middleware("http")
-async def console_api_auth(request: Request, call_next):
+async def console_api_auth(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
     """Apply MARM's auth policy to Console data APIs, not static SPA assets."""
     if request.method == "OPTIONS" or not request.url.path.startswith("/api/"):
         return await call_next(request)
@@ -174,7 +178,7 @@ if (STATIC_DIR / "assets").is_dir():
 
 
 @app.get("/", include_in_schema=False)
-def console_index():
+def console_index() -> Response:
     index = STATIC_DIR / "index.html"
     if index.exists():
         return FileResponse(index)
@@ -185,7 +189,7 @@ def console_index():
 
 
 @app.get("/{path:path}", include_in_schema=False)
-def console_spa_fallback(path: str):
+def console_spa_fallback(path: str) -> Response:
     if path == "api" or path.startswith("api/"):
         raise HTTPException(status_code=404, detail="Not Found")
     root_asset = ROOT_STATIC_ASSETS.get(path)

--- a/marm-mcp-server/marm_mcp_server/console/app.py
+++ b/marm-mcp-server/marm_mcp_server/console/app.py
@@ -150,7 +150,7 @@ app.include_router(projects.router)
 
 
 @app.post("/api/auth/bootstrap", include_in_schema=False)
-def bootstrap_console_session(payload: _ConsoleBootstrapRequest):
+def bootstrap_console_session(payload: _ConsoleBootstrapRequest) -> JSONResponse:
     """Exchange a local one-time handoff for an HttpOnly browser session."""
     from ..core.runtime_manager import runtime_dir
 

--- a/marm-mcp-server/marm_mcp_server/console/cli.py
+++ b/marm-mcp-server/marm_mcp_server/console/cli.py
@@ -12,6 +12,7 @@ import time
 import urllib.error
 import urllib.request
 import webbrowser
+from typing import Any
 
 import psutil
 import uvicorn
@@ -94,7 +95,7 @@ def run_console(
         log_path = runtime_dir() / "console.log"
         bound_log_file(log_path)
         flags = 0
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if os.name == "nt":
             flags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
         else:

--- a/marm-mcp-server/marm_mcp_server/console/cli.py
+++ b/marm-mcp-server/marm_mcp_server/console/cli.py
@@ -42,7 +42,7 @@ def _healthy(timeout: float = 0.75) -> bool:
             f"http://{host}:{_port()}/health", timeout=timeout
         ) as response:
             payload = json.load(response)
-            return payload.get("service") == "marm-console"
+            return bool(payload.get("service") == "marm-console")
     except (urllib.error.URLError, OSError, ValueError):
         return False
 

--- a/marm-mcp-server/marm_mcp_server/console/endpoints/concepts.py
+++ b/marm-mcp-server/marm_mcp_server/console/endpoints/concepts.py
@@ -123,7 +123,7 @@ def get_concept_neighborhood(
 
 
 @router.post("/api/concepts/build")
-def build_concepts(payload: ConceptBuildPayload) -> dict:
+def build_concepts(payload: ConceptBuildPayload) -> JSONResponse:
     if not (payload.session_name or payload.project or payload.search_all):
         raise HTTPException(
             status_code=422, detail="Choose a session, project, or all memory scope."

--- a/marm-mcp-server/marm_mcp_server/core/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/core/compaction.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+import sqlite3
 import uuid
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -182,7 +183,7 @@ def _compute_candidate_hash(source_memory_ids: list) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
-def _get_source_snapshot(conn, source_ids: list) -> dict:
+def _get_source_snapshot(conn: sqlite3.Connection, source_ids: list) -> dict:
     """Return {memory_id: content_hash} for the given source IDs (staleness fingerprint)."""
     placeholders = ",".join("?" * len(source_ids))
     rows = conn.execute(

--- a/marm-mcp-server/marm_mcp_server/core/compaction_scheduler.py
+++ b/marm-mcp-server/marm_mcp_server/core/compaction_scheduler.py
@@ -1,5 +1,7 @@
 """Starts the compaction maintenance APScheduler job."""
 
+from typing import TYPE_CHECKING
+
 import structlog
 
 from ..config.settings import (
@@ -10,10 +12,13 @@ from ..config.settings import (
 )
 from .memory import memory
 
+if TYPE_CHECKING:
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
 logger = structlog.get_logger()
 
 
-def _maybe_start_compaction_scheduler():
+def _maybe_start_compaction_scheduler() -> "AsyncIOScheduler | None":
     """Start the compaction maintenance APScheduler job.
 
     Runs whenever COMPACTION_ENABLED is true — auto-apply is optional on top.

--- a/marm-mcp-server/marm_mcp_server/core/compaction_scheduler.py
+++ b/marm-mcp-server/marm_mcp_server/core/compaction_scheduler.py
@@ -28,12 +28,12 @@ def _maybe_start_compaction_scheduler():
     if COMPACTION_AUTO_APPLY_ENABLED:
         from ..endpoints.compaction import auto_apply_staged_summaries
 
-        async def _job():
+        async def _job() -> None:
             await process_nudge_exhausted_candidates(memory)
             await auto_apply_staged_summaries()
     else:
 
-        async def _job():
+        async def _job() -> None:
             await process_nudge_exhausted_candidates(memory)
 
     scheduler = AsyncIOScheduler()

--- a/marm-mcp-server/marm_mcp_server/core/concept_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/concept_db.py
@@ -333,7 +333,9 @@ class ConceptDB:
             (run_id, scope_type, scope_value, created_at),
         )
 
-    def update_build_run(self, conn: sqlite3.Connection, run_id: str, **fields) -> None:
+    def update_build_run(
+        self, conn: sqlite3.Connection, run_id: str, **fields: object
+    ) -> None:
         allowed = {
             "status",
             "memories_processed",

--- a/marm-mcp-server/marm_mcp_server/core/concept_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/concept_db.py
@@ -311,7 +311,7 @@ class ConceptDB:
             self.db_path, max_connections=MAX_CONCEPT_DB_CONNECTIONS
         )
 
-    def get_connection(self):
+    def get_connection(self) -> ConnectionContext:
         return ConnectionContext(self.connection_pool)
 
     def close(self) -> None:
@@ -319,7 +319,7 @@ class ConceptDB:
 
     def create_build_run(
         self,
-        conn,
+        conn: sqlite3.Connection,
         *,
         run_id: str,
         scope_type: str,
@@ -333,7 +333,7 @@ class ConceptDB:
             (run_id, scope_type, scope_value, created_at),
         )
 
-    def update_build_run(self, conn, run_id: str, **fields) -> None:
+    def update_build_run(self, conn: sqlite3.Connection, run_id: str, **fields) -> None:
         allowed = {
             "status",
             "memories_processed",
@@ -357,7 +357,7 @@ class ConceptDB:
 
     def get_or_create_entity(
         self,
-        conn,
+        conn: sqlite3.Connection,
         name: str,
         entity_type: str,
         session_name: Optional[str],
@@ -423,7 +423,7 @@ class ConceptDB:
 
     def find_similar_entities(
         self,
-        conn,
+        conn: sqlite3.Connection,
         name_embedding: bytes,
         session_name: Optional[str],
         project: Optional[str],
@@ -499,7 +499,7 @@ class ConceptDB:
 
     def store_relationship(
         self,
-        conn,
+        conn: sqlite3.Connection,
         source_id: int,
         target_id: int,
         predicate: str,
@@ -524,7 +524,7 @@ class ConceptDB:
 
     def store_code_link(
         self,
-        conn,
+        conn: sqlite3.Connection,
         entity_id: int,
         graph_qualified_name: str,
         project: str,

--- a/marm-mcp-server/marm_mcp_server/core/concept_extraction.py
+++ b/marm-mcp-server/marm_mcp_server/core/concept_extraction.py
@@ -1,7 +1,7 @@
 """spaCy-based entity/relationship extraction for the concept graph."""
 
 import threading
-from typing import TYPE_CHECKING, NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple
 
 from ..config.settings import CONCEPT_MODEL_PATH, CONCEPTS_AVAILABLE
 
@@ -87,7 +87,7 @@ def _load_nlp_lazily():
     return _nlp
 
 
-def _classify_chunk(chunk_text: str, sentence_text: str) -> Optional[str]:
+def _classify_chunk(chunk_text: str, sentence_text: str) -> str:
     """Rule layer: classify a noun chunk as concept/decision/pattern/error/tool
     based on keyword triggers in its sentence, defaulting to 'concept'."""
     lowered_sentence = sentence_text.lower()

--- a/marm-mcp-server/marm_mcp_server/core/concept_extraction.py
+++ b/marm-mcp-server/marm_mcp_server/core/concept_extraction.py
@@ -1,11 +1,12 @@
 """spaCy-based entity/relationship extraction for the concept graph."""
 
 import threading
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 from ..config.settings import CONCEPT_MODEL_PATH, CONCEPTS_AVAILABLE
 
 if TYPE_CHECKING:
+    from spacy.language import Language
     from spacy.tokens import Span, Token
 
 # spaCy's raw NER labels we keep as-is (lowercased) rather than remapping —
@@ -65,7 +66,7 @@ _nlp_lock = threading.Lock()
 _nlp_failed = False
 
 
-def _load_nlp_lazily():
+def _load_nlp_lazily() -> Optional["Language"]:
     """Lazy singleton load, mirroring memory.py's _load_encoder_lazily pattern."""
     global _nlp, _nlp_failed
     if _nlp is not None:
@@ -97,7 +98,7 @@ def _classify_chunk(chunk_text: str, sentence_text: str) -> str:
     return "concept"
 
 
-def _ancestor_chain(token: "Token") -> list:
+def _ancestor_chain(token: "Token") -> list["Token"]:
     """token, its head, its head's head, ... up to the sentence root (where
     token.head == token, spaCy's self-loop convention). Always terminates —
     every parsed token has exactly one path to its sentence root."""
@@ -109,7 +110,7 @@ def _ancestor_chain(token: "Token") -> list:
     return chain
 
 
-def _lowest_common_ancestor(token_a: "Token", token_b: "Token"):
+def _lowest_common_ancestor(token_a: "Token", token_b: "Token") -> Optional["Token"]:
     """First token in token_a's ancestor chain that also appears in
     token_b's — the syntactic point where the two entities' dependency
     paths converge. None only if token_a/token_b aren't in the same
@@ -123,7 +124,7 @@ def _lowest_common_ancestor(token_a: "Token", token_b: "Token"):
     return None
 
 
-def _nearest_verb_ancestor(token: "Token"):
+def _nearest_verb_ancestor(token: "Token") -> Optional["Token"]:
     """token itself if already VERB/AUX, else the nearest VERB/AUX walking
     up its own head chain, else None if the sentence root has no verb
     (e.g. a bare noun-phrase list with no verb at all)."""

--- a/marm-mcp-server/marm_mcp_server/core/consolidation.py
+++ b/marm-mcp-server/marm_mcp_server/core/consolidation.py
@@ -42,8 +42,8 @@ def find_exact_duplicate(
     content_hash: str,
     session_name: str,
     normalized_content: str,
-    project: str | None | _Unset = _UNSET,
-    platform: str | None | _Unset = _UNSET,
+    project: str | _Unset | None = _UNSET,
+    platform: str | _Unset | None = _UNSET,
 ) -> Optional[str]:
     """Return memory_id of an existing exact match within the session, or None.
 
@@ -70,8 +70,8 @@ async def find_semantic_duplicate(
     session_name: str,
     threshold: float,
     query_vec: np.ndarray | None = None,
-    project: str | None | _Unset = _UNSET,
-    platform: str | None | _Unset = _UNSET,
+    project: str | _Unset | None = _UNSET,
+    platform: str | _Unset | None = _UNSET,
 ) -> Optional[str]:
     """Return memory_id of a semantic match at or above threshold in session, or None.
 

--- a/marm-mcp-server/marm_mcp_server/core/consolidation.py
+++ b/marm-mcp-server/marm_mcp_server/core/consolidation.py
@@ -3,12 +3,25 @@
 import hashlib
 import logging
 import sqlite3
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .memory import MARMMemory
 
 from ..config.settings import MARM_PROJECT, MARM_PLATFORM
 
 logger = logging.getLogger(__name__)
-_UNSET = object()
+
+
+class _Unset:
+    """Own type so a scope parameter can be `str | None` and still tell "not
+    passed" apart from an explicit None. A bare object() sentinel forced the
+    parameters to `object`, which no identity check can narrow back down."""
+
+
+_UNSET = _Unset()
 
 # Enough rows to absorb reordering by the lexical and recency signals.
 _DUPLICATE_CANDIDATES = 5
@@ -29,34 +42,36 @@ def find_exact_duplicate(
     content_hash: str,
     session_name: str,
     normalized_content: str,
-    project: object = _UNSET,
-    platform: object = _UNSET,
+    project: str | None | _Unset = _UNSET,
+    platform: str | None | _Unset = _UNSET,
 ) -> Optional[str]:
     """Return memory_id of an existing exact match within the session, or None.
 
     Verifies content equality after the hash match so SHA-256 collisions store
     as a new row rather than silently deduplicating different content.
     """
-    scoped_project = MARM_PROJECT or None if project is _UNSET else project
-    scoped_platform = MARM_PLATFORM or None if platform is _UNSET else platform
+    scoped_project = MARM_PROJECT or None if isinstance(project, _Unset) else project
+    scoped_platform = (
+        MARM_PLATFORM or None if isinstance(platform, _Unset) else platform
+    )
     rows = conn.execute(
         "SELECT id, content FROM memories WHERE content_hash = ? AND session_name = ? AND project IS ? AND platform IS ?",
         (content_hash, session_name, scoped_project, scoped_platform),
     ).fetchall()
     for row_id, row_content in rows:
         if normalize_content(row_content) == normalized_content:
-            return row_id
+            return str(row_id)
     return None
 
 
 async def find_semantic_duplicate(
-    memory,
+    memory: "MARMMemory",
     content: str,
     session_name: str,
     threshold: float,
-    query_vec=None,
-    project: object = _UNSET,
-    platform: object = _UNSET,
+    query_vec: np.ndarray | None = None,
+    project: str | None | _Unset = _UNSET,
+    platform: str | None | _Unset = _UNSET,
 ) -> Optional[str]:
     """Return memory_id of a semantic match at or above threshold in session, or None.
 
@@ -70,8 +85,12 @@ async def find_semantic_duplicate(
     try:
         if query_vec is None and not memory._load_encoder_lazily():
             return None
-        scoped_project = MARM_PROJECT or None if project is _UNSET else project
-        scoped_platform = MARM_PLATFORM or None if platform is _UNSET else platform
+        scoped_project = (
+            MARM_PROJECT or None if isinstance(project, _Unset) else project
+        )
+        scoped_platform = (
+            MARM_PLATFORM or None if isinstance(platform, _Unset) else platform
+        )
         # exact_mode="semantic" because the exact lane produces no cosine.
         results = await memory.recall_similar(
             content,
@@ -87,7 +106,7 @@ async def find_semantic_duplicate(
         if scored:
             nearest = max(scored, key=lambda r: r["cosine"])
             if nearest["cosine"] >= threshold:
-                return nearest["id"]
+                return str(nearest["id"])
     except Exception:
         logger.exception("Semantic dedup check failed")
     return None

--- a/marm-mcp-server/marm_mcp_server/core/consolidation.py
+++ b/marm-mcp-server/marm_mcp_server/core/consolidation.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+import sqlite3
 from typing import Optional
 
 from ..config.settings import MARM_PROJECT, MARM_PLATFORM
@@ -24,7 +25,7 @@ def compute_content_hash(content: str) -> str:
 
 
 def find_exact_duplicate(
-    conn,
+    conn: sqlite3.Connection,
     content_hash: str,
     session_name: str,
     normalized_content: str,

--- a/marm-mcp-server/marm_mcp_server/core/docs_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/docs_db.py
@@ -85,12 +85,12 @@ class DocsDB:
             self.db_path, max_connections=MAX_DOCS_DB_CONNECTIONS
         )
 
-    def get_connection(self):
+    def get_connection(self) -> ConnectionContext:
         return ConnectionContext(self.connection_pool)
 
     def save_doc(
         self,
-        conn,
+        conn: sqlite3.Connection,
         *,
         name: str,
         content: str,
@@ -161,5 +161,7 @@ class DocsDB:
             raise
         return DocRow(*row), was_created
 
-    def set_memory_id(self, conn, doc_id: int, memory_id: str) -> None:
+    def set_memory_id(
+        self, conn: sqlite3.Connection, doc_id: int, memory_id: str
+    ) -> None:
         conn.execute("UPDATE docs SET memory_id = ? WHERE id = ?", (memory_id, doc_id))

--- a/marm-mcp-server/marm_mcp_server/core/events.py
+++ b/marm-mcp-server/marm_mcp_server/core/events.py
@@ -13,7 +13,7 @@ class MARMEvents:
         self.failed_callbacks: Dict[str, int] = {}
         self.logger = logging.getLogger(__name__)
 
-    def on(self, event_type: str, callback) -> None:
+    def on(self, event_type: str, callback: Callable) -> None:
         """Register event listener"""
         if event_type not in self.listeners:
             self.listeners[event_type] = []

--- a/marm-mcp-server/marm_mcp_server/core/events.py
+++ b/marm-mcp-server/marm_mcp_server/core/events.py
@@ -8,18 +8,18 @@ from typing import Dict, List, Callable
 class MARMEvents:
     """Built-in automation system with full error isolation"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.listeners: Dict[str, List[Callable]] = {}
         self.failed_callbacks: Dict[str, int] = {}
         self.logger = logging.getLogger(__name__)
 
-    def on(self, event_type: str, callback):
+    def on(self, event_type: str, callback) -> None:
         """Register event listener"""
         if event_type not in self.listeners:
             self.listeners[event_type] = []
         self.listeners[event_type].append(callback)
 
-    async def emit(self, event_type: str, data: dict):
+    async def emit(self, event_type: str, data: dict) -> None:
         """Trigger automatic actions with full error isolation"""
         if event_type not in self.listeners:
             return
@@ -57,7 +57,9 @@ class MARMEvents:
                 f"Event '{event_type}' completed successfully: {successful_callbacks} callbacks"
             )
 
-    def _log_callback_error(self, callback_id: str, error_msg: str, event_type: str):
+    def _log_callback_error(
+        self, callback_id: str, error_msg: str, event_type: str
+    ) -> None:
         """Log callback errors with failure tracking"""
         self.failed_callbacks[callback_id] = (
             self.failed_callbacks.get(callback_id, 0) + 1

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_lock.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_lock.py
@@ -36,7 +36,7 @@ import os
 import threading
 import uuid
 from contextlib import contextmanager
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, TypeVar
 
 import structlog
 
@@ -44,6 +44,8 @@ from ..config import settings
 from . import lease_lock
 
 logger = structlog.get_logger(__name__)
+
+T = TypeVar("T")
 
 _TABLE = "graph_index_lock"
 
@@ -126,10 +128,10 @@ def gate_sync(purpose: str, ttl_seconds: Optional[int] = None) -> Any:
 def _gated_call(
     purpose: str,
     ttl_seconds: int,
-    fn: Callable[..., Any],
+    fn: Callable[..., T],
     args: tuple,
     kwargs: dict,
-) -> Any:
+) -> T:
     with gate_sync(purpose, ttl_seconds):
         return fn(*args, **kwargs)
 
@@ -137,10 +139,10 @@ def _gated_call(
 async def _owned_call(
     purpose: str,
     ttl_seconds: int,
-    fn: Callable[..., Any],
+    fn: Callable[..., T],
     args: tuple,
     kwargs: dict,
-) -> Any:
+) -> T:
     """Acquire, call, and release, all inside one thread.
 
     The acquire and the release have to sit on the same side of the thread
@@ -163,11 +165,11 @@ def _forget(task: asyncio.Task) -> None:
 
 async def run_exclusive(
     purpose: str,
-    fn: Callable[..., Any],
+    fn: Callable[..., T],
     *args: Any,
     ttl_seconds: Optional[int] = None,
     **kwargs: Any,
-) -> Any:
+) -> T:
     """Run one engine store mutation under the gate. Raises GraphIndexBusy if refused.
 
     Indexing is the common case, but a project delete mutates the same per-project

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
@@ -22,7 +22,10 @@ import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from marm_graph.core.cbm_client import CbmClient
 
 import structlog
 from marm_graph.core import tool_router as R
@@ -117,7 +120,7 @@ def git_signature(root: str) -> Optional[tuple[str, bool]]:
     return (head, bool(status))
 
 
-def index_repository(client, req: GraphIndexRequest) -> dict:
+def index_repository(client: "CbmClient", req: GraphIndexRequest) -> dict:
     """The callable every index path hands to the gate: index, then settle the
     durable block state before the lease is released.
 

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -190,7 +190,7 @@ class MARMMemory:
             entry for entry in entries if entry.get("name") != name
         ]
 
-    def get_connection(self):
+    def get_connection(self) -> ConnectionContext:
         return ConnectionContext(self.connection_pool)
 
     def _encode_sync(self, text: str):

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -91,14 +91,13 @@ class MARMMemory:
             db_path, max_connections=MAX_DB_CONNECTIONS
         )
 
-        self.encoder = None
+        self.encoder: _FastEmbedEncoder | None = None
         self._encoder_loading = False
         self._encoder_failed = False
         self._encoder_lock = threading.Lock()
 
         init_database(self.db_path)
 
-        self.active_sessions = {}
         self.active_notebook_entries_by_session: dict[str, list[dict]] = {}
         self.active_log_session: str = "main"
         self._write_queue: WriteQueue | None = None
@@ -197,7 +196,9 @@ class MARMMemory:
     def _encode_sync(self, text: str):
         """Encode text with the shared encoder, serialized to prevent concurrent-use hangs."""
         with self._encoder_lock:
-            return self.encoder.encode(text)
+            # Every caller gates on _load_encoder_lazily(), which returns
+            # `self.encoder is not None`. mypy cannot carry that through a bool.
+            return self.encoder.encode(text)  # type: ignore[union-attr]
 
     def _load_encoder_lazily(self) -> bool:
         """Lazy load the semantic search model only when needed"""
@@ -268,7 +269,7 @@ class MARMMemory:
         content: str,
         session: str,
         context_type: str = "general",
-        metadata: Dict = None,
+        metadata: Dict | None = None,
     ) -> str:
         return await _store_memory(self, content, session, context_type, metadata)
 
@@ -277,7 +278,7 @@ class MARMMemory:
         content: str,
         session: str,
         context_type: str = "general",
-        metadata: Dict = None,
+        metadata: Dict | None = None,
         queue_enabled: Optional[bool] = None,
     ) -> str:
         """Store memory through the write queue unless explicitly disabled."""
@@ -406,13 +407,13 @@ class MARMMemory:
     async def recall_similar(
         self,
         query: str,
-        session: str = None,
+        session: str | None = None,
         limit: int = 5,
         query_vec=None,
         include_scan_metadata: bool = False,
         exact_mode: str = "auto",
-        project: str = None,
-        platform: str = None,
+        project: str | None = None,
+        platform: str | None = None,
         *,
         with_cosine: bool = False,
     ):
@@ -432,10 +433,10 @@ class MARMMemory:
     async def recall_text_search(
         self,
         query: str,
-        session: str = None,
+        session: str | None = None,
         limit: int = 5,
-        project: str = None,
-        platform: str = None,
+        project: str | None = None,
+        platform: str | None = None,
     ) -> List[Dict]:
         return await _recall_text_search(
             self, query, session, limit, project=project, platform=platform

--- a/marm-mcp-server/marm_mcp_server/core/memory.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory.py
@@ -3,7 +3,9 @@
 import importlib.util
 import json
 import threading
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional, Tuple, overload
+
+import numpy as np
 
 from ..config.settings import (
     COMPACTION_ENABLED,
@@ -35,7 +37,7 @@ from .memory_ops import (
     _store_memory,
     _update_memory,
 )
-from .memory_recall import _recall_similar, _recall_text_search
+from .memory_recall import RecallResult, _recall_similar, _recall_text_search
 from .memory_scoring import _score_chunk_aware  # noqa: F401
 from .memory_utils import (  # noqa: F401
     DOC_CHUNK_OVERLAP_WORDS,
@@ -74,7 +76,13 @@ class _FastEmbedEncoder:
         )
         self._model = TextEmbedding(model_name=resolved_name)
 
-    def encode(self, text):
+    @overload
+    def encode(self, text: str) -> np.ndarray: ...
+
+    @overload
+    def encode(self, text: list[str]) -> list[np.ndarray]: ...
+
+    def encode(self, text: str | list[str]) -> np.ndarray | list[np.ndarray]:
         if isinstance(text, str):
             return next(iter(self._model.embed([text])))
         return list(self._model.embed(text))
@@ -193,12 +201,13 @@ class MARMMemory:
     def get_connection(self) -> ConnectionContext:
         return ConnectionContext(self.connection_pool)
 
-    def _encode_sync(self, text: str):
+    def _encode_sync(self, text: str) -> np.ndarray:
         """Encode text with the shared encoder, serialized to prevent concurrent-use hangs."""
         with self._encoder_lock:
             # Every caller gates on _load_encoder_lazily(), which returns
             # `self.encoder is not None`. mypy cannot carry that through a bool.
-            return self.encoder.encode(text)  # type: ignore[union-attr]
+            assert self.encoder is not None
+            return self.encoder.encode(text)
 
     def _load_encoder_lazily(self) -> bool:
         """Lazy load the semantic search model only when needed"""
@@ -404,19 +413,49 @@ class MARMMemory:
             "chunk_count": row[11],
         }
 
+    @overload
     async def recall_similar(
         self,
         query: str,
         session: str | None = None,
         limit: int = 5,
-        query_vec=None,
+        query_vec: np.ndarray | None = None,
+        include_scan_metadata: Literal[False] = False,
+        exact_mode: str = "auto",
+        project: str | None = None,
+        platform: str | None = None,
+        *,
+        with_cosine: bool = False,
+    ) -> List[Dict]: ...
+
+    @overload
+    async def recall_similar(
+        self,
+        query: str,
+        session: str | None = None,
+        limit: int = 5,
+        query_vec: np.ndarray | None = None,
+        *,
+        include_scan_metadata: Literal[True],
+        exact_mode: str = "auto",
+        project: str | None = None,
+        platform: str | None = None,
+        with_cosine: bool = False,
+    ) -> Tuple[List[Dict], dict]: ...
+
+    async def recall_similar(
+        self,
+        query: str,
+        session: str | None = None,
+        limit: int = 5,
+        query_vec: np.ndarray | None = None,
         include_scan_metadata: bool = False,
         exact_mode: str = "auto",
         project: str | None = None,
         platform: str | None = None,
         *,
         with_cosine: bool = False,
-    ):
+    ) -> RecallResult:
         return await _recall_similar(
             self,
             query,

--- a/marm-mcp-server/marm_mcp_server/core/memory_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_db.py
@@ -12,7 +12,9 @@ class SQLiteConnectionPool:
     def __init__(self, db_path: str, max_connections: int = 5):
         self.db_path = db_path
         self.max_connections = max_connections
-        self.pool = queue.Queue(maxsize=max_connections)
+        self.pool: queue.Queue[sqlite3.Connection] = queue.Queue(
+            maxsize=max_connections
+        )
         self.created_connections = 0
         self.lock = threading.Lock()
 

--- a/marm-mcp-server/marm_mcp_server/core/memory_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_db.py
@@ -4,6 +4,7 @@ import queue
 import sqlite3
 import threading
 from datetime import datetime, timezone
+from types import TracebackType
 
 
 class SQLiteConnectionPool:
@@ -20,12 +21,12 @@ class SQLiteConnectionPool:
 
         self._create_initial_connections()
 
-    def _create_initial_connections(self):
+    def _create_initial_connections(self) -> None:
         """Create initial pool of connections"""
         for _ in range(min(2, self.max_connections)):
             self.pool.put(self._create_connection())
 
-    def _create_connection(self):
+    def _create_connection(self) -> sqlite3.Connection:
         """Create and return a new SQLite connection with optimal settings."""
         conn = sqlite3.connect(
             self.db_path,
@@ -41,7 +42,7 @@ class SQLiteConnectionPool:
         self.created_connections += 1
         return conn
 
-    def get_connection(self):
+    def get_connection(self) -> sqlite3.Connection:
         """Get a connection from the pool"""
         try:
             return self.pool.get(block=False)
@@ -54,14 +55,14 @@ class SQLiteConnectionPool:
 
             return self.pool.get(block=True, timeout=10)
 
-    def return_connection(self, conn):
+    def return_connection(self, conn: sqlite3.Connection) -> None:
         """Return connection to pool"""
         try:
             self.pool.put(conn, block=False)
         except queue.Full:
             conn.close()
 
-    def close_all(self):
+    def close_all(self) -> None:
         """Close all connections in the pool"""
         while not self.pool.empty():
             try:
@@ -78,15 +79,20 @@ class ConnectionContext:
     connection to the pool.
     """
 
-    def __init__(self, pool):
+    def __init__(self, pool: SQLiteConnectionPool) -> None:
         self.pool = pool
-        self.conn = None
+        self.conn: sqlite3.Connection | None = None
 
-    def __enter__(self):
+    def __enter__(self) -> sqlite3.Connection:
         self.conn = self.pool.get_connection()
         return self.conn
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         if self.conn:
             if exc_type is None:
                 self.conn.commit()

--- a/marm-mcp-server/marm_mcp_server/core/memory_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_db.py
@@ -5,6 +5,10 @@ import sqlite3
 import threading
 from datetime import datetime, timezone
 from types import TracebackType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .memory import MARMMemory
 
 
 class SQLiteConnectionPool:
@@ -461,7 +465,7 @@ def init_database(db_path: str) -> None:
         conn.commit()
 
 
-def _get_compaction_write_count(mem, session: str) -> int:
+def _get_compaction_write_count(mem: "MARMMemory", session: str) -> int:
     with mem.get_connection() as conn:
         row = conn.execute(
             "SELECT write_count FROM compaction_session_state WHERE session_name = ?",
@@ -472,7 +476,7 @@ def _get_compaction_write_count(mem, session: str) -> int:
     return count
 
 
-def _set_compaction_write_count(mem, session: str, count: int) -> None:
+def _set_compaction_write_count(mem: "MARMMemory", session: str, count: int) -> None:
     now = datetime.now(timezone.utc).isoformat()
     with mem.get_connection() as conn:
         conn.execute(
@@ -489,7 +493,7 @@ def _set_compaction_write_count(mem, session: str, count: int) -> None:
     mem._session_write_counts[session] = count
 
 
-def _increment_compaction_write_count(mem, session: str) -> int:
+def _increment_compaction_write_count(mem: "MARMMemory", session: str) -> int:
     now = datetime.now(timezone.utc).isoformat()
     with mem.get_connection() as conn:
         conn.execute("BEGIN IMMEDIATE")

--- a/marm-mcp-server/marm_mcp_server/core/memory_delete.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_delete.py
@@ -3,11 +3,15 @@
 import json
 import sqlite3
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from .concept_queue import dequeue as dequeue_concept_index
 
+if TYPE_CHECKING:
+    from .memory import MARMMemory
 
-async def _delete_memory(mem, memory_id: str) -> bool:
+
+async def _delete_memory(mem: "MARMMemory", memory_id: str) -> bool:
     result = await _delete_memories(mem, [memory_id])
     return bool(result["deleted_ids"])
 
@@ -97,7 +101,7 @@ def _restore_sources_from_deleted_summary(
     return restored
 
 
-async def _delete_memories(mem, memory_ids: list[str]) -> dict:
+async def _delete_memories(mem: "MARMMemory", memory_ids: list[str]) -> dict:
     unique_ids = list(dict.fromkeys(str(memory_id) for memory_id in memory_ids))
     if not unique_ids:
         return {

--- a/marm-mcp-server/marm_mcp_server/core/memory_delete.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_delete.py
@@ -1,6 +1,7 @@
 """Memory deletion and compaction-lineage cleanup for the MARM memory system."""
 
 import json
+import sqlite3
 from datetime import datetime, timezone
 
 from .concept_queue import dequeue as dequeue_concept_index
@@ -11,7 +12,7 @@ async def _delete_memory(mem, memory_id: str) -> bool:
     return bool(result["deleted_ids"])
 
 
-def _delete_impact(conn, memory_id: str) -> dict:
+def _delete_impact(conn: sqlite3.Connection, memory_id: str) -> dict:
     row = conn.execute(
         "SELECT id, compaction_role, compacted_into, metadata FROM memories WHERE id = ?",
         (memory_id,),
@@ -44,7 +45,7 @@ def _delete_impact(conn, memory_id: str) -> dict:
 
 
 def _remove_deleted_sources_from_summary(
-    conn, summary_id: str, deleted_source_ids: set[str], now: str
+    conn: sqlite3.Connection, summary_id: str, deleted_source_ids: set[str], now: str
 ) -> int:
     row = conn.execute(
         "SELECT metadata FROM memories WHERE id = ? AND compaction_role = 'summary'",
@@ -73,7 +74,7 @@ def _remove_deleted_sources_from_summary(
 
 
 def _restore_sources_from_deleted_summary(
-    conn, summary_id: str, deleted_ids: set[str], now: str
+    conn: sqlite3.Connection, summary_id: str, deleted_ids: set[str], now: str
 ) -> int:
     rows = conn.execute(
         "SELECT id, metadata FROM memories WHERE compacted_into = ?",

--- a/marm-mcp-server/marm_mcp_server/core/memory_delete.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_delete.py
@@ -133,12 +133,12 @@ async def _delete_memories(mem, memory_ids: list[str]) -> dict:
             }
 
         source_summary_ids = {
-            item.get("compacted_into")
+            compacted_into
             for item in impacts
             if item.get("exists")
             and item.get("compaction_role") == "source"
-            and item.get("compacted_into")
-            and item.get("compacted_into") not in existing_ids
+            and (compacted_into := item.get("compacted_into"))
+            and compacted_into not in existing_ids
         }
         summaries_updated = sum(
             _remove_deleted_sources_from_summary(conn, summary_id, existing_ids, now)

--- a/marm-mcp-server/marm_mcp_server/core/memory_ops.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_ops.py
@@ -149,7 +149,7 @@ async def _store_memory(
     content: str,
     session: str,
     context_type: str = "general",
-    metadata: Dict = None,
+    metadata: Dict | None = None,
     project: str | None = None,
     platform: str | None = None,
     explicit_scope: bool = False,

--- a/marm-mcp-server/marm_mcp_server/core/memory_ops.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_ops.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 from ..config.settings import (
     CONSOLIDATION_ENABLED,
@@ -33,8 +33,11 @@ from .memory_utils import (
     sanitize_content,
 )
 
+if TYPE_CHECKING:
+    from .memory import MARMMemory
 
-async def _update_memory(mem, memory_id: str, new_content: str) -> bool:
+
+async def _update_memory(mem: "MARMMemory", memory_id: str, new_content: str) -> bool:
     """Append new_content into an existing memory and record the merge in metadata.
 
     Recomputes content_hash and embedding so Layer 1 dedup and semantic recall
@@ -145,7 +148,7 @@ async def _update_memory(mem, memory_id: str, new_content: str) -> bool:
 
 
 async def _store_memory(
-    mem,
+    mem: "MARMMemory",
     content: str,
     session: str,
     context_type: str = "general",
@@ -296,7 +299,7 @@ async def _store_memory(
 
 
 async def _replace_memory(
-    mem,
+    mem: "MARMMemory",
     memory_id: str,
     content: str,
     session: str,
@@ -374,7 +377,7 @@ async def _replace_memory(
 
 
 async def _store_doc_mirror(
-    mem,
+    mem: "MARMMemory",
     content: str,
     session: str,
     project: str | None,

--- a/marm-mcp-server/marm_mcp_server/core/memory_ops.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_ops.py
@@ -394,10 +394,12 @@ async def _store_doc_mirror(
     mirror into an unrelated memory. Uses the doc chunk profile instead
     of the memory profile. If existing_memory_id is provided and its row
     still exists, the row is replaced in place (keeps its id stable, so
-    a routine resave never needs to touch docs.memory_id); otherwise a
-    fresh row is created with a new id -- this also doubles as the repair
-    path for a doc whose prior mirror was deleted out from under it (e.g.
-    via a direct Console memory delete).
+    a routine resave never needs to touch docs.memory_id). Without a usable
+    id, the doc's existing mirror is resolved by metadata.doc_id, so the
+    write is idempotent per doc even when the caller lost the id. Only when
+    neither locates a row is a fresh one created with a new id -- that is
+    the repair path for a doc whose prior mirror was deleted out from under
+    it (e.g. via a direct Console memory delete).
     """
     sanitized_content = sanitize_content(content)
     content_hash = compute_content_hash(sanitized_content)
@@ -415,6 +417,25 @@ async def _store_doc_mirror(
     with mem.get_connection() as conn:
         conn.execute("BEGIN IMMEDIATE")
         try:
+            # A caller with no id may still have a mirror: docs.memory_id is set
+            # in a second, separate write, so a failure between the two leaves
+            # this row orphaned rather than absent. Resolving it by the doc_id
+            # already in metadata makes the write idempotent per doc; creating a
+            # fresh row instead would duplicate the mirror on every later save.
+            # Inside the transaction so the resolve cannot race the write.
+            if not existing_memory_id and metadata.get("doc_id") is not None:
+                orphan = conn.execute(
+                    """
+                    SELECT id FROM memories
+                    WHERE context_type = 'doc'
+                      AND json_extract(metadata, '$.doc_id') = ?
+                    ORDER BY timestamp LIMIT 1
+                    """,
+                    (metadata["doc_id"],),
+                ).fetchone()
+                if orphan is not None:
+                    existing_memory_id = orphan[0]
+
             replaced = False
             if existing_memory_id:
                 cursor = conn.execute(

--- a/marm-mcp-server/marm_mcp_server/core/memory_recall.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_recall.py
@@ -3,7 +3,9 @@
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+
+import numpy as np
 
 from ..config.settings import (
     RECALL_SCAN_LIMIT,
@@ -29,14 +31,20 @@ from .memory_scoring import (
     _fetch_and_score_fts_rows,
 )
 
+if TYPE_CHECKING:
+    from .memory import MARMMemory
+
+# include_scan_metadata=True swaps the plain list for a (list, metadata) pair.
+RecallResult = Union[List[Dict], Tuple[List[Dict], dict]]
+
 
 async def _recall_exact(
-    mem,
-    query,
-    session=None,
-    limit=5,
-    project=None,
-    platform=None,
+    mem: "MARMMemory",
+    query: str,
+    session: str | None = None,
+    limit: int = 5,
+    project: str | None = None,
+    platform: str | None = None,
 ) -> List[Dict]:
     """Deterministic exact/lexical recall via FTS5 BM25, with LIKE fallback.
 
@@ -92,7 +100,7 @@ async def _recall_exact(
                   AND (compaction_role IS NULL OR compaction_role != 'source')
             """
 
-            params = [f"%{query}%"]
+            params: list[str | int] = [f"%{query}%"]
 
             if session is not None:
                 base += " AND session_name = ?"
@@ -134,18 +142,18 @@ async def _recall_exact(
 
 
 async def _recall_similar(
-    mem,
+    mem: "MARMMemory",
     query: str,
     session: str | None = None,
     limit: int = 5,
-    query_vec=None,
+    query_vec: np.ndarray | None = None,
     include_scan_metadata: bool = False,
     exact_mode: str = "auto",
     project: str | None = None,
     platform: str | None = None,
     *,
     with_cosine: bool = False,
-):
+) -> RecallResult:
     """Find semantically similar memories.
 
     exact_mode controls which retrieval lane is used:
@@ -169,7 +177,7 @@ async def _recall_similar(
     """
     scan_limit = RECALL_SCAN_LIMIT
 
-    def _wrap(results, truncated):
+    def _wrap(results: List[Dict], truncated: bool) -> RecallResult:
         if include_scan_metadata:
             return results, {
                 "recall_scan_truncated": truncated,
@@ -351,7 +359,7 @@ async def _recall_similar(
 
 
 async def _recall_text_search(
-    mem,
+    mem: "MARMMemory",
     query: str,
     session: str | None = None,
     limit: int = 5,

--- a/marm-mcp-server/marm_mcp_server/core/memory_recall.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_recall.py
@@ -136,13 +136,13 @@ async def _recall_exact(
 async def _recall_similar(
     mem,
     query: str,
-    session: str = None,
+    session: str | None = None,
     limit: int = 5,
     query_vec=None,
     include_scan_metadata: bool = False,
     exact_mode: str = "auto",
-    project: str = None,
-    platform: str = None,
+    project: str | None = None,
+    platform: str | None = None,
     *,
     with_cosine: bool = False,
 ):
@@ -353,10 +353,10 @@ async def _recall_similar(
 async def _recall_text_search(
     mem,
     query: str,
-    session: str = None,
+    session: str | None = None,
     limit: int = 5,
-    project: str = None,
-    platform: str = None,
+    project: str | None = None,
+    platform: str | None = None,
     apply_temporal: bool = False,
 ) -> List[Dict]:
     """Text search via FTS5 BM25 ranking, with LIKE fallback for unsanitizable queries.

--- a/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_scoring.py
@@ -1,9 +1,19 @@
 """Vector scoring and DB fetch-and-score operations for the MARM memory system."""
 
 import sqlite3
+from typing import Any, Protocol, Sequence
+
 import numpy as np
 
 from ..config.settings import FTS_LONE_HIT_SCORE
+
+
+class _Row(Protocol):
+    """The row shape the scorers index into. Not sqlite3.Row: the chunk-scoring
+    tests pass plain dicts carrying the same keys, and pinning the concrete class
+    would make those call sites type errors."""
+
+    def __getitem__(self, key: str, /) -> Any: ...
 
 
 def _normalize_bm25(
@@ -25,7 +35,9 @@ def _normalize_bm25(
     return [(max_s - s) / span for s in raw_scores]
 
 
-def _score_embedding_rows(rows, query_embedding, limit: int):
+def _score_embedding_rows(
+    rows: Sequence[sqlite3.Row], query_embedding: np.ndarray, limit: int
+) -> tuple[list[tuple[sqlite3.Row, float]], int]:
     """Score embedding rows in one NumPy batch instead of a Python cosine loop."""
     if limit <= 0:
         return [], 0
@@ -72,10 +84,10 @@ def _score_embedding_rows(rows, query_embedding, limit: int):
 
 
 def _score_chunk_aware(
-    memories,
-    chunks_by_id: dict,
-    query_embedding,
-) -> tuple[list[tuple], int]:
+    memories: Sequence[_Row],
+    chunks_by_id: dict[str, list],
+    query_embedding: np.ndarray,
+) -> tuple[list[tuple[_Row, float]], int]:
     """Score memories using chunk embeddings where available, parent embedding otherwise.
 
     Deduplicates to one (memory_row, best_score) per memory_id before returning.
@@ -137,11 +149,11 @@ def _fetch_and_score_embedding_rows(
     db_path: str,
     session: str | None,
     scan_limit: int,
-    query_embedding,
+    query_embedding: np.ndarray,
     limit: int,
     project: str | None = None,
     platform: str | None = None,
-):
+) -> tuple[list[tuple[_Row, float]], int, bool]:
     conn = sqlite3.connect(db_path, timeout=30.0)
     try:
         conn.row_factory = sqlite3.Row
@@ -285,7 +297,7 @@ def _fetch_fts_candidate_ids(
 def _fetch_and_score_by_ids(
     db_path: str,
     memory_ids: list[str],
-    query_embedding,
+    query_embedding: np.ndarray,
 ) -> tuple[list[tuple], int]:
     """Fetch specific memories by ID and score their embeddings.
 

--- a/marm-mcp-server/marm_mcp_server/core/memory_utils.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_utils.py
@@ -8,11 +8,14 @@ import re
 import sqlite3
 import sys
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 
 from ..config.settings import FTS_EXTRA_STOPWORDS, FTS_QUERY_MODE
+
+if TYPE_CHECKING:
+    from .memory import MARMMemory
 
 
 def _safe_print(msg: str) -> None:
@@ -191,7 +194,7 @@ DOC_CHUNK_TARGET_WORDS = 800
 DOC_CHUNK_OVERLAP_WORDS = 100
 
 
-def _embedding_to_bytes(vector) -> bytes:
+def _embedding_to_bytes(vector: np.ndarray) -> bytes:
     """Store embeddings in the float32 layout expected by recall scoring."""
     return np.asarray(vector, dtype=np.float32).tobytes()
 
@@ -282,7 +285,7 @@ async def drain_chunk_writes(
 
 
 async def _write_chunks(
-    mem_instance,
+    mem_instance: "MARMMemory",
     db_path: str,
     memory_id: str,
     chunks: list[str],

--- a/marm-mcp-server/marm_mcp_server/core/models.py
+++ b/marm-mcp-server/marm_mcp_server/core/models.py
@@ -153,7 +153,7 @@ class CompactionRequest(BaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_action_requirements(self):
+    def validate_action_requirements(self) -> "CompactionRequest":
         if self.action == "stage" and not self.summaries:
             raise ValueError("summaries is required for action='stage'")
         if self.action in ("apply", "discard") and not self.candidate_id:
@@ -179,7 +179,7 @@ class ConceptBuildRequest(BaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_scope_requirements(self):
+    def validate_scope_requirements(self) -> "ConceptBuildRequest":
         if not (self.session_name or self.project or self.search_all):
             raise ValueError(
                 "session_name, project, or search_all=True is required to scope the build"

--- a/marm-mcp-server/marm_mcp_server/core/rate_limiter.py
+++ b/marm-mcp-server/marm_mcp_server/core/rate_limiter.py
@@ -14,7 +14,7 @@ from ..config.settings import (
 class IPRateLimiter:
     """Simple IP-based rate limiter for preventing abuse without authentication"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.request_buckets: Dict[str, deque] = defaultdict(lambda: deque())
         self.blocked_ips: Dict[str, float] = {}  # IP -> unblock_timestamp
 
@@ -83,7 +83,7 @@ class IPRateLimiter:
                 f"Rate limit exceeded: {config['requests']} requests per {config['window']}s. Blocked for {config['block_duration']}s.",
             )
 
-    def _cleanup_if_needed(self, current_time: float):
+    def _cleanup_if_needed(self, current_time: float) -> None:
         """Clean up old data to prevent memory leaks"""
         if current_time - self.last_cleanup < 300:
             return

--- a/marm-mcp-server/marm_mcp_server/core/response_limiter.py
+++ b/marm-mcp-server/marm_mcp_server/core/response_limiter.py
@@ -85,7 +85,7 @@ class MCPResponseLimiter:
         if available_space <= 0:
             return [], True
 
-        limited_memories = []
+        limited_memories: List[Dict[str, Any]] = []
         was_truncated = False
 
         estimated_content_per_memory = available_space // len(memories)
@@ -114,7 +114,10 @@ class MCPResponseLimiter:
 
     @classmethod
     def add_truncation_notice(
-        cls, response: Dict[str, Any], was_truncated: bool, total_available: int = None
+        cls,
+        response: Dict[str, Any],
+        was_truncated: bool,
+        total_available: int | None = None,
     ) -> Dict[str, Any]:
         """Add truncation notice to response if content was limited."""
         if was_truncated:

--- a/marm-mcp-server/marm_mcp_server/core/runtime_manager.py
+++ b/marm-mcp-server/marm_mcp_server/core/runtime_manager.py
@@ -370,7 +370,9 @@ def stop_runtime(
             if os.name == "nt":
                 psutil.Process(int(state["pid"])).kill()
             else:
-                os.kill(int(state["pid"]), signal.SIGKILL)
+                # Unreachable on Windows, where signal.SIGKILL does not exist and
+                # mypy resolves the stdlib against.
+                os.kill(int(state["pid"]), signal.SIGKILL)  # type: ignore[attr-defined]
     clear_state(runtime_id)
     return True
 

--- a/marm-mcp-server/marm_mcp_server/core/shutdown_manager.py
+++ b/marm-mcp-server/marm_mcp_server/core/shutdown_manager.py
@@ -32,7 +32,7 @@ class ShutdownManager:
             logger.info("Signal handlers not available on this platform")
             pass
 
-    def _signal_handler(self, sig) -> None:
+    def _signal_handler(self, sig: signal.Signals) -> None:
         """Handle shutdown signals"""
         logger.info("Shutdown signal received", signal=sig.name)
 

--- a/marm-mcp-server/marm_mcp_server/core/shutdown_manager.py
+++ b/marm-mcp-server/marm_mcp_server/core/shutdown_manager.py
@@ -13,12 +13,12 @@ logger = structlog.get_logger()
 
 
 class ShutdownManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self.shutdown_event = asyncio.Event()
         self.shutdown_initiated = False
         self._cleanup_complete = False
 
-    async def setup_signal_handlers(self):
+    async def setup_signal_handlers(self) -> None:
         """Setup signal handlers for graceful shutdown"""
         try:
             loop = asyncio.get_event_loop()
@@ -32,7 +32,7 @@ class ShutdownManager:
             logger.info("Signal handlers not available on this platform")
             pass
 
-    def _signal_handler(self, sig):
+    def _signal_handler(self, sig) -> None:
         """Handle shutdown signals"""
         logger.info("Shutdown signal received", signal=sig.name)
 
@@ -46,11 +46,11 @@ class ShutdownManager:
             self.shutdown_initiated = True
             self.shutdown_event.set()
 
-    async def wait_for_shutdown(self):
+    async def wait_for_shutdown(self) -> None:
         """Wait for shutdown signal"""
         await self.shutdown_event.wait()
 
-    async def graceful_shutdown(self):
+    async def graceful_shutdown(self) -> None:
         """Perform graceful shutdown of all connections and services"""
         if self._cleanup_complete:
             return

--- a/marm-mcp-server/marm_mcp_server/core/stdio_tool_lifecycle.py
+++ b/marm-mcp-server/marm_mcp_server/core/stdio_tool_lifecycle.py
@@ -4,6 +4,7 @@ init, protocol/compaction injection."""
 import asyncio
 import functools
 import json
+from typing import Any, Awaitable, Callable
 
 from .compaction import claim_pending_compaction_prompt
 from .memory import memory
@@ -18,9 +19,13 @@ _STDIO_LITE_INTERVAL = 30
 _protocol_delivery_lock = asyncio.Lock()
 
 
-def _log_tool_call(fn):
+# Deliberately signature-erasing: the wrapper introspects kwargs by name
+# (session_name, query, limit), which a ParamSpec types as object.
+def _log_tool_call(
+    fn: Callable[..., Awaitable[Any]],
+) -> Callable[..., Awaitable[Any]]:
     @functools.wraps(fn)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
         name = fn.__name__
         if _debug:
             safe = []

--- a/marm-mcp-server/marm_mcp_server/core/write_queue.py
+++ b/marm-mcp-server/marm_mcp_server/core/write_queue.py
@@ -3,7 +3,12 @@
 import asyncio
 import inspect
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, TypeVar, overload
+
+if TYPE_CHECKING:
+    from .memory import MARMMemory
+
+T = TypeVar("T")
 
 
 @dataclass
@@ -28,7 +33,7 @@ class CallableWriteRequest:
 class WriteQueue:
     """Serialize memory writes through one async worker."""
 
-    def __init__(self, memory, max_size: int = 100) -> None:
+    def __init__(self, memory: "MARMMemory", max_size: int = 100) -> None:
         self.memory = memory
         self.queue: asyncio.Queue = asyncio.Queue(maxsize=max_size)
         self._worker_task: asyncio.Task | None = None
@@ -61,20 +66,32 @@ class WriteQueue:
         if self._stopping:
             raise RuntimeError("write queue is shutting down")
         loop = asyncio.get_running_loop()
-        future: asyncio.Future = loop.create_future()
+        future: asyncio.Future[str] = loop.create_future()
         await self.queue.put(
             MemoryWriteRequest(content, session, context_type, metadata, future)
         )
         return await future
 
+    # Split by awaitability rather than one `Awaitable[T] | T` parameter: that
+    # union left T ambiguous and mypy solved it as Never at the call sites.
+    @overload
     async def put_callable(
-        self, func: Callable[..., Awaitable[Any] | Any], *args: Any, **kwargs: Any
-    ) -> Any:
+        self, func: Callable[..., Awaitable[T]], *args: Any, **kwargs: Any
+    ) -> T: ...
+
+    @overload
+    async def put_callable(
+        self, func: Callable[..., T], *args: Any, **kwargs: Any
+    ) -> T: ...
+
+    async def put_callable(
+        self, func: Callable[..., Awaitable[T] | T], *args: Any, **kwargs: Any
+    ) -> T:
         """Enqueue any async callable to be executed in write-queue order."""
         if self._stopping:
             raise RuntimeError("write queue is shutting down")
         loop = asyncio.get_running_loop()
-        future: asyncio.Future = loop.create_future()
+        future: asyncio.Future[T] = loop.create_future()
         await self.queue.put(CallableWriteRequest(func, args, kwargs, future))
         return await future
 

--- a/marm-mcp-server/marm_mcp_server/core/write_queue.py
+++ b/marm-mcp-server/marm_mcp_server/core/write_queue.py
@@ -28,7 +28,7 @@ class CallableWriteRequest:
 class WriteQueue:
     """Serialize memory writes through one async worker."""
 
-    def __init__(self, memory, max_size: int = 100):
+    def __init__(self, memory, max_size: int = 100) -> None:
         self.memory = memory
         self.queue: asyncio.Queue = asyncio.Queue(maxsize=max_size)
         self._worker_task: asyncio.Task | None = None

--- a/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
@@ -532,7 +532,7 @@ def _compaction_status() -> dict:
 
 
 @router.post("/marm_compaction", operation_id="marm_compaction")
-async def marm_compaction(request: CompactionRequest):
+async def marm_compaction(request: CompactionRequest) -> dict:
     """Compact related memories into a single summary to reduce context bloat.
 
     Workflow: status/candidates → stage → review → apply/discard

--- a/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/compaction.py
@@ -33,7 +33,7 @@ router = APIRouter(prefix="", tags=["Compaction"])
     operation_id="marm_get_compaction_candidates",
     include_in_schema=False,
 )
-async def marm_get_compaction_candidates():
+async def marm_get_compaction_candidates() -> dict:
     """
     Return pending_summary compaction candidates with an embedded prompt template.
 
@@ -90,7 +90,9 @@ async def marm_get_compaction_candidates():
     operation_id="marm_stage_compaction_summaries",
     include_in_schema=False,
 )
-async def marm_stage_compaction_summaries(request: StageCompactionSummariesRequest):
+async def marm_stage_compaction_summaries(
+    request: StageCompactionSummariesRequest,
+) -> dict:
     """
     Submit agent-generated summaries for pending compaction candidates.
 
@@ -252,7 +254,7 @@ async def marm_stage_compaction_summaries(request: StageCompactionSummariesReque
     operation_id="marm_get_staged_summaries",
     include_in_schema=False,
 )
-async def marm_get_staged_summaries(limit: int = 20):
+async def marm_get_staged_summaries(limit: int = 20) -> dict:
     """
     Return all summary_staged compaction proposals awaiting main agent review.
 
@@ -305,7 +307,7 @@ async def marm_get_staged_summaries(limit: int = 20):
     operation_id="marm_apply_compaction",
     include_in_schema=False,
 )
-async def marm_apply_compaction(request: ApplyCompactionRequest):
+async def marm_apply_compaction(request: ApplyCompactionRequest) -> dict:
     """
     Apply or discard a staged compaction proposal.
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
@@ -10,6 +10,7 @@ related-to intent from query shape.
 
 import asyncio
 import itertools
+import sqlite3
 import threading
 import time
 import uuid
@@ -422,7 +423,11 @@ def _prepare_build_schema(req: ConceptBuildRequest) -> bool:
 
 
 def _traverse(
-    conn, seed_ids: list[int], depth: int, direction: str, limit: int
+    conn: sqlite3.Connection,
+    seed_ids: list[int],
+    depth: int,
+    direction: str,
+    limit: int,
 ) -> list[dict]:
     results, _, _ = traverse_graph(
         conn,

--- a/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
@@ -323,8 +323,8 @@ def _run_build(
 
                 if graph_available:
                     for entity in result.entities:
-                        entity_id = name_to_id.get(entity.name)
-                        if entity_id is None:
+                        linked_entity_id = name_to_id.get(entity.name)
+                        if linked_entity_id is None:
                             continue
                         try:
                             match = find_code_match(entity.name, mem_project)
@@ -335,7 +335,7 @@ def _run_build(
                             try:
                                 if concept_db.store_code_link(
                                     conn,
-                                    entity_id,
+                                    linked_entity_id,
                                     match["qualified_name"],
                                     mem_project or "",
                                     label=match.get("label"),
@@ -507,7 +507,7 @@ async def _marm_concept_build(
         except Exception as e:
             logger.warning("concepts.build_run_create_error", error=str(e))
             return {"status": "error", "message": "Concept build failed."}
-        result = {
+        degraded = {
             "status": "degraded",
             "error_code": "concepts_unavailable",
             "message": _CONCEPTS_UNAVAILABLE_MESSAGE,
@@ -525,8 +525,8 @@ async def _marm_concept_build(
             finished_at=datetime.now(timezone.utc).isoformat(),
             duration_ms=0,
         )
-        result["build_run_id"] = run_id
-        return result
+        degraded["build_run_id"] = run_id
+        return degraded
     try:
         graph_rebuilt = await asyncio.to_thread(_prepare_build_schema, req)
     except ValueError:

--- a/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/concepts.py
@@ -396,7 +396,7 @@ def _create_build_run(req: ConceptBuildRequest, run_id: str, created_at: str) ->
         )
 
 
-def _finish_build_run(run_id: str, **fields) -> None:
+def _finish_build_run(run_id: str, **fields: object) -> None:
     concept_db = _get_concept_db()
     with concept_db.get_connection() as conn:
         concept_db.update_build_run(conn, run_id, **fields)

--- a/marm-mcp-server/marm_mcp_server/endpoints/logging.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/logging.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="", tags=["Logging"])
 
 
 @router.post("/marm_log_entry", operation_id="marm_log_entry")
-async def marm_log_entry(request: LogEntryRequest):
+async def marm_log_entry(request: LogEntryRequest) -> dict:
     """
     📝 Add structured log entry for milestones or decisions
 
@@ -31,7 +31,7 @@ async def marm_log_show(
     session_name: Optional[str] = Query(
         None, description="Session to show logs for. If omitted, lists all sessions."
     ),
-):
+) -> dict:
     """
     📋 Display all entries and sessions logged
 
@@ -41,7 +41,7 @@ async def marm_log_show(
 
 
 @router.post("/marm_delete", operation_id="marm_delete")
-async def marm_delete(request: DeleteRequest):
+async def marm_delete(request: DeleteRequest) -> dict:
     """
     🗑️ Delete a log session, log entry, or notebook entry
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -21,7 +21,7 @@ logger = structlog.get_logger(__name__)
 
 def track_endpoint_usage(
     endpoint: str, request: Request, extra_data: dict | None = None
-):
+) -> None:
     """Track MCP endpoint usage"""
     try:
         import sqlite3

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -212,7 +212,7 @@ def _inject_log_results(response: dict, log_results: list) -> None:
 
 
 @router.post("/marm_smart_recall", operation_id="marm_smart_recall")
-async def marm_smart_recall(request: SmartRecallRequest, http_request: Request):
+async def marm_smart_recall(request: SmartRecallRequest, http_request: Request) -> dict:
     """
     🧠 Intelligent memory recall based on semantic similarity
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -19,7 +19,9 @@ from ..services.graph_context import attach_graph_context, get_graph_context
 logger = structlog.get_logger(__name__)
 
 
-def track_endpoint_usage(endpoint: str, request: Request, extra_data: dict = None):
+def track_endpoint_usage(
+    endpoint: str, request: Request, extra_data: dict | None = None
+):
     """Track MCP endpoint usage"""
     try:
         import sqlite3

--- a/marm-mcp-server/marm_mcp_server/endpoints/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/notebook.py
@@ -9,7 +9,7 @@ router = APIRouter(prefix="", tags=["Notebook"])
 
 
 @router.post("/marm_notebook", operation_id="marm_notebook")
-async def marm_notebook(request: NotebookRequest):
+async def marm_notebook(request: NotebookRequest) -> dict:
     """
     📔 Unified notebook — add, use, show, status, clear, or save
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/reasoning.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/reasoning.py
@@ -10,7 +10,7 @@ router = APIRouter(prefix="", tags=["Reasoning"])
 @router.get("/marm_summary", operation_id="marm_summary")
 async def marm_summary(
     session_name: str = Query(..., description="The name of the session to summarize."),
-):
+) -> dict:
     """
     📊 Generate paste-ready context block for new chats
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/session.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/session.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="", tags=["MARM Protocol"])
 
 
 @router.post("/marm_start", operation_id="marm_start", include_in_schema=False)
-async def marm_start(request: SessionRequest):
+async def marm_start(request: SessionRequest) -> dict:
     """
     🚀 Activates MARM memory and accuracy layers
 
@@ -65,7 +65,7 @@ async def marm_start(request: SessionRequest):
 
 
 @router.post("/marm_refresh", operation_id="marm_refresh", include_in_schema=False)
-async def marm_refresh(request: SessionRequest):
+async def marm_refresh(request: SessionRequest) -> dict:
     """
     🔄 Refreshes active session state and reaffirms protocol adherence
 

--- a/marm-mcp-server/marm_mcp_server/endpoints/system.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/system.py
@@ -21,7 +21,7 @@ router = APIRouter(prefix="", tags=["System"])
 
 
 @router.get("/health", include_in_schema=False)
-async def health_check():
+async def health_check() -> dict:
     """Health check endpoint for Docker and monitoring"""
     try:
         with memory.get_connection() as conn:
@@ -51,7 +51,7 @@ async def health_check():
 
 
 @router.get("/ready", include_in_schema=False)
-async def readiness_check():
+async def readiness_check() -> dict:
     """Readiness check endpoint - service ready to handle requests"""
     try:
         with memory.get_connection() as conn:
@@ -112,7 +112,7 @@ async def runtime_shutdown() -> dict:
 @router.post(
     "/marm_reload_docs", operation_id="marm_reload_docs", include_in_schema=False
 )
-async def marm_reload_docs():
+async def marm_reload_docs() -> dict:
     """
     📚 Reload MARM documentation into memory system
 

--- a/marm-mcp-server/marm_mcp_server/middleware/auth.py
+++ b/marm-mcp-server/marm_mcp_server/middleware/auth.py
@@ -1,14 +1,18 @@
 """Authentication middleware for MARM MCP Server."""
 
 from fastapi import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
+from starlette.middleware.base import RequestResponseEndpoint
+
 from ..config.settings import MARM_API_KEY
 
 PUBLIC_PATHS = {"/health", "/ready", "/ping", "/", "/docs", "/redoc", "/openapi.json"}
 PUBLIC_PREFIXES = ("/openapi",)
 
 
-async def auth_middleware(request: Request, call_next):
+async def auth_middleware(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
     """
     Two-mode auth gate:
       - No MARM_API_KEY set: loopback-only (127.0.0.1 / ::1). Safe default for local deployments.

--- a/marm-mcp-server/marm_mcp_server/middleware/protocol_injection.py
+++ b/marm-mcp-server/marm_mcp_server/middleware/protocol_injection.py
@@ -5,7 +5,8 @@ import json
 
 import structlog
 from fastapi import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
+from starlette.middleware.base import RequestResponseEndpoint
 
 from ..config import settings
 from ..core.compaction import claim_pending_compaction_prompt
@@ -28,7 +29,9 @@ from ..utils.helpers import read_protocol_file, read_protocol_lite_file
 logger = structlog.get_logger()
 
 
-async def _mcp_tool_call_tracker(request: Request, call_next):
+async def _mcp_tool_call_tracker(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
     """Lazy doc-load and auto-refresh for MCP tool calls.
 
     Registered first so LIFO puts it last — only runs after rate_limit and auth pass.
@@ -119,7 +122,9 @@ async def _mcp_tool_call_tracker(request: Request, call_next):
 
         body_bytes = b""
         try:
-            async for chunk in response.body_iterator:
+            # BaseHTTPMiddleware hands back a private _StreamingResponse, which
+            # carries body_iterator while the declared Response type does not.
+            async for chunk in response.body_iterator:  # type: ignore[attr-defined]
                 body_bytes += chunk
             data = json.loads(body_bytes)
             result = data.get("result", {})

--- a/marm-mcp-server/marm_mcp_server/middleware/rate_limiting.py
+++ b/marm-mcp-server/marm_mcp_server/middleware/rate_limiting.py
@@ -1,7 +1,8 @@
 """Rate limiting middleware for FastAPI."""
 
 from fastapi import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
+from starlette.middleware.base import RequestResponseEndpoint
 import time
 from ..core.rate_limiter import rate_limiter
 from ..config.settings import RATE_LIMIT_BLOCK_SECONDS
@@ -40,7 +41,9 @@ def determine_endpoint_type(path: str) -> str:
         return "default"
 
 
-async def rate_limit_middleware(request: Request, call_next):
+async def rate_limit_middleware(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
     """Rate limiting middleware - prevents abuse while keeping service free"""
 
     if request.url.path in [

--- a/marm-mcp-server/marm_mcp_server/resources/skills/marm-init/SKILL.md
+++ b/marm-mcp-server/marm_mcp_server/resources/skills/marm-init/SKILL.md
@@ -13,21 +13,13 @@ metadata:
 === MARM INIT PROTOCOL - YOU ARE THE INSTALLER ===
 
 RULE ZERO (highest priority):
-This file is not documentation to summarize. It is a setup program and you are
-the runtime. Execute it top to bottom. Run the steps, ask the questions, write
-the files, and start the server. Do not paste this content back to the user as
-text. Do not narrate what the skill "would" do. You do it.
+This file is not documentation to summarize. It is a setup program and you are the runtime. Execute it top to bottom. Run the steps, ask the questions, write the files, and start the server. Do not paste this content back to the user as text. Do not narrate what the skill "would" do. You do it.
 
-You are MARM's installer for this agent. Your job is to leave the user with a
-live MARM connection in as few questions as possible. One question at a time,
-wait for the answer, then act on it before moving on.
+You are MARM's installer for this agent. Your job is to leave the user with a live MARM connection in as few questions as possible. One question at a time, wait for the answer, then act on it before moving on.
 
-Scope: this protocol governs only the setup conversation below. Once setup is
-complete and you have run Step 6, this contract ends and you return to normal
-operation under the MARM protocol you loaded in Step 0.
+Scope: this protocol governs only the setup conversation below. Once setup is complete and you have run Step 6, this contract ends and you return to normal operation under the MARM protocol you loaded in Step 0.
 
-Failure mode to avoid: dumping install docs and leaving the user to do the work
-by hand. That is the exact outcome this skill exists to prevent.
+Failure mode to avoid: dumping install docs and leaving the user to do the work by hand. That is the exact outcome this skill exists to prevent.
 
 </MARM_INIT_EXECUTOR_ACTIVE>
 
@@ -35,34 +27,26 @@ by hand. That is the exact outcome this skill exists to prevent.
 
 ## Step 00 - Engine pre-flight 
 
-Run this first, before anything else. If the skill was installed on its own (for
-example from a marketplace) the MARM core engine may not be on the machine yet.
-Confirm it is present, or install it, before continuing.
+Run this first, before anything else. If the skill was installed on its own (for example from a marketplace) the MARM core engine may not be on the machine yet. Confirm it is present, or install it, before continuing.
 
 1. Scan the host for the core engine:
-   - CLI entry points on PATH. Unix: `command -v marm-memory || command -v marm-mcp-server || command -v marm-mcp-stdio`. PowerShell: `Get-Command marm-memory, marm-mcp-server, marm-mcp-stdio -ErrorAction SilentlyContinue`.
-   - Docker image present locally: `docker images -q lyellr88/marm-mcp-server`.
+  - CLI entry points on PATH. Unix: `command -v marm-memory || command -v marm-mcp-server || command -v marm-mcp-stdio`. PowerShell: `Get-Command marm-memory, marm-mcp-server, marm-mcp-stdio -ErrorAction SilentlyContinue`.
+  - Docker image present locally: `docker images -q lyellr88/marm-mcp-server`.
 
 2. Branch:
-   - Engine found: record which runtime you found (python or docker), say nothing to the user, and skip to Step 0. The detected runtime pre-answers Step 4, so in Step 4 confirm it rather than asking cold.
-   - Nothing found: stop and run the install prompt below.
+  - Engine found: record which runtime you found (python or docker), say nothing to the user, and skip to Step 0. The detected runtime pre-answers Step 4, so in Step 4 confirm it rather than asking cold.
+  - Nothing found: stop and run the install prompt below.
 
 3. Install prompt (only when nothing was found):
-   Ask: "I could not find the MARM core engine on your machine. How do you want to install it?
-   - Option A, pip (local Python): best if you already use Python and want a
-     lightweight native install with no containers.
-   - Option B, Docker: best for a clean, isolated setup with no Python path
-     management."
+Ask: "I could not find the MARM core engine on your machine. How do you want to install it?
+  - Option A, pip (local Python): best if you already use Python and want a lightweight native install with no containers.
+  - Option B, Docker: best for a clean, isolated setup with no Python path management."
 
 4. Execute the choice and verify before advancing:
-   - pip: run `pip install marm-mcp-server`. Confirm success, for example
-     `marm-mcp-server --version` resolves. Record runtime = python.
-   - Docker: run `docker pull lyellr88/marm-mcp-server:latest`. Confirm the image
-     is present with `docker images -q lyellr88/marm-mcp-server`. Record
-     runtime = docker.
+  - pip: run `pip install marm-mcp-server`. Confirm success, for example  `marm-mcp-server --version` resolves. Record runtime = python.
+  - Docker: run `docker pull lyellr88/marm-mcp-server:latest`. Confirm the image is present with `docker images -q lyellr88/marm-mcp-server`. Record runtime = docker.
 
-   If the install fails, surface the actual error and stop. Do not proceed to
-   setup against a missing engine.
+If the install fails, surface the actual error and stop. Do not proceed to setup against a missing engine.
 
 ---
 
@@ -70,16 +54,10 @@ Confirm it is present, or install it, before continuing.
 
 Do this before talking to the user.
 
-1. Read the full MARM protocol from source:
-   `https://raw.githubusercontent.com/Lyellr88/marm-memory/MARM-main/docs/PROTOCOL.md`
-   If the network read fails, fall back in this order:
-   - local repo `docs/PROTOCOL.md`
-   - packaged copy `marm-mcp-server/marm_mcp_server/resources/marm-docs/PROTOCOL.md`
-2. Freshness check: read the `version:` field in this file's frontmatter and
-   compare it against the `version:` in the source copy at `metadata.source`.
-   If the source version is higher, tell the user once:
-   "Your MARM init skill is out of date. Re-run `marm-memory init` to refresh it."
-   Then continue with the version you have.
+1. Read the full MARM protocol from source: `https://raw.githubusercontent.com/Lyellr88/marm-memory/MARM-main/docs/PROTOCOL.md` If the network read fails, fall back in this order:
+  - local repo `docs/PROTOCOL.md`
+  - packaged copy `marm-mcp-server/marm_mcp_server/resources/marm-docs/PROTOCOL.md`
+2. Freshness check: read the `version:` field in this file's frontmatter and compare it against the `version:` in the source copy at `metadata.source`. If the source version is higher, tell the user once: "Your MARM init skill is out of date. Re-run `marm-memory init` to refresh it." Then continue with the version you have.
 
 Hold the protocol in context. You will operate under it after setup.
 
@@ -87,11 +65,9 @@ Hold the protocol in context. You will operate under it after setup.
 
 ## Step 1 - Usage type
 
-Ask: "How will you use MARM, just you on this machine, or multiple users/agents
-over a network?"
-
-- Single user, one machine -> personal/local path
-- Multiple users or agents on a network -> team/swarm path
+Ask: "How will you use MARM, just you on this machine, or multiple users/agents over a network?"
+  - Single user, one machine -> personal/local path
+  - Multiple users or agents on a network -> team/swarm path
 
 Record the answer. It biases the transport recommendation in Step 3.
 
@@ -100,9 +76,8 @@ Record the answer. It biases the transport recommendation in Step 3.
 ## Step 2 - Server location
 
 Ask: "Run MARM locally, or connect to a server you own (VPS or homelab)?"
-
-- Local: runs on this machine, zero infra
-- Remote: runs on a host the user controls, reachable over their network
+  - Local: runs on this machine, zero infra
+  - Remote: runs on a host the user controls, reachable over their network
 
 If remote, you will need the host address later for the connect command.
 
@@ -111,119 +86,81 @@ If remote, you will need the host address later for the connect command.
 ## Step 3 - Transport
 
 Ask: "How should agents connect, HTTP or STDIO?"
+  - HTTP: over the network. Needed for remote servers, multiple machines, or swarm agents. Requires an API key. Recommend this for the team/swarm path.
+  - STDIO: local pipe, single machine, no key. Simplest. Recommend this for the personal/local path.
 
-- HTTP: over the network. Needed for remote servers, multiple machines, or swarm
-  agents. Requires an API key. Recommend this for the team/swarm path.
-- STDIO: local pipe, single machine, no key. Simplest. Recommend this for the
-  personal/local path.
-
-Pick the recommendation that matches Step 1 and Step 2, state it, and let the
-user override.
+Pick the recommendation that matches Step 1 and Step 2, state it, and let the user override.
 
 ---
 
 ## Step 4 - Runtime
 
-If Step 00 already detected or installed a runtime, confirm it instead of asking
-cold: "Looks like you are set up for <docker|python>, use that?" Only ask the
-open question below if the runtime is genuinely unknown.
+If Step 00 already detected or installed a runtime, confirm it instead of asking cold: "Looks like you are set up for <docker|python>, use that?" Only ask the open question below if the runtime is genuinely unknown.
 
 Ask: "Docker or local Python?"
-
-- Docker: isolated, easiest to keep updated.
-- Local Python: runs direct, good if Python is already set up. The package
-  installs two entry points: `marm-mcp-server` (HTTP) and `marm-mcp-stdio` (STDIO).
+  - Docker: isolated, easiest to keep updated.
+  - Local Python: runs direct, good if Python is already set up. The package installs two entry points: `marm-mcp-server` (HTTP) and `marm-mcp-stdio` (STDIO).
 
 You now have enough to act. Run the matching block.
 
 **Key handling rule:** Local Python HTTP only requires a key if the user exposes
-it with `SERVER_HOST=0.0.0.0` (remote/network access). Docker HTTP uses MARM's
-managed key file (`~/.marm/.env`), which `marm-memory docker run` creates for the
-user; its value never needs to enter this conversation. Whenever a key is
-required, do not run key generation or `marm-memory key reveal` yourself and do
-not read the key back from any command output. Have the user handle the value in
-their own terminal instead. Once the server is running, verify with an
-unauthenticated check (`curl http://localhost:8001/health`, no key needed) rather
-than asking them to paste the key back to you.
+it with `SERVER_HOST=0.0.0.0` (remote/network access). Docker HTTP uses MARM's managed key file (`~/.marm/.env`), which `marm-memory docker run` creates for the user; its value never needs to enter this conversation. Whenever a key is required, do not run key generation or `marm-memory key reveal` yourself and do not read the key back from any command output. Have the user handle the value in their own terminal instead. Once the server is running, verify with an unauthenticated check (`curl http://localhost:8001/health`, no key needed) rather than asking them to paste the key back to you.
 
 ### HTTP + Local Python, local-only (no key) -- the fast path, recommend this for single-machine use
-This is the one-shot. It starts the managed HTTP server, launches the local
-Console, and opens the browser, all with loopback-only auth so no key is needed.
+
+This is the one-shot. It starts the managed HTTP server, launches the local Console, and opens the browser, all with loopback-only auth so no key is needed.
+
 Safe to run yourself:
 
-    marm-memory fast-start-http
+  marm-memory fast-start-http
 
-That leaves MARM live at `http://localhost:8001/mcp` and the Console at
-`http://localhost:8002`. Then connect this agent (loopback, no key):
+That leaves MARM live at `http://localhost:8001/mcp` and the Console at `http://localhost:8002`. Then connect this agent (loopback, no key):
 
-    claude mcp add --transport http marm-memory http://localhost:8001/mcp
+  claude mcp add --transport http marm-memory http://localhost:8001/mcp
 
-Because fast-start-http already started the server and the Console, Step 6 has
-nothing left to start; just verify and hand off.
+Because fast-start-http already started the server and the Console, Step 6 has nothing left to start; just verify and hand off.
 
 ### HTTP + Local Python, exposed (key required)
-Only applies if the user asked for remote/network access in Step 2. Give them
-these steps to run themselves; do not execute steps 1 or 2 on their behalf:
+
+Only applies if the user asked for remote/network access in Step 2. Give them these steps to run themselves; do not execute steps 1 or 2 on their behalf:
 1. Generate a key: `marm-memory key generate`
 2. Start with their own key: `MARM_API_KEY=<paste-your-key> SERVER_HOST=0.0.0.0 marm-memory start` (PowerShell: `$env:MARM_API_KEY="<paste-your-key>"; $env:SERVER_HOST="0.0.0.0"; marm-memory start`)
-3. Connect their client with their own key:
-   `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
+3. Connect their client with their own key: `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
 
 Verify with `curl http://localhost:8001/health` once they confirm it's running. Do not ask them to paste the key into the chat.
 
 ### HTTP + Docker (managed, key handled for you)
-`marm-memory docker run` creates the managed container, writes the managed key
-file under `~/.marm/.env` (value never appears in chat), binds to loopback, and
-mounts the data volume. Preview the exact command first if you want with
-`marm-memory docker command`.
+
+`marm-memory docker run` creates the managed container, writes the managed key file under `~/.marm/.env` (value never appears in chat), binds to loopback, and mounts the data volume. Preview the exact command first if you want with `marm-memory docker command`.
 1. Run: `marm-memory docker run` (add `--expose-network` only for remote access, then configure a firewall and TLS proxy)
-2. Connect the client. The key lives in the managed key file; the user reads it
-   themselves (`marm-memory key path` shows the file, `marm-memory key reveal`
-   prints it in their own terminal) and pastes the value into their client, so it
-   never enters chat:
-   `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
-3. Optional, code-graph tools: the container only sees host paths that are
-   mounted, and `marm-memory docker run` refuses to alter an existing container.
-   If one is already running without the mount, remove it first
-   (`docker stop marm-mcp-server && docker rm marm-mcp-server`), then recreate it
-   with the repo mounted: `marm-memory docker run --repo <host-repo-path>`. Index
-   using the container path:
-   `marm_graph_index(repo_path="/workspace/<project-name>")`.
+2. Connect the client. The key lives in the managed key file; the user reads it themselves (`marm-memory key path` shows the file, `marm-memory key reveal` prints it in their own terminal) and pastes the value into their client, so it never enters chat: `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
+3. Optional, code-graph tools: the container only sees host paths that are mounted, and `marm-memory docker run` refuses to alter an existing container. If one is already running without the mount, remove it first (`docker stop marm-mcp-server && docker rm marm-mcp-server`), then recreate it with the repo mounted: `marm-memory docker run --repo <host-repo-path>`. Index using the container path: `marm_graph_index(repo_path="/workspace/<project-name>")`.
 
 Verify with `curl http://localhost:8001/health` and `marm-memory docker status`. Do not ask them to paste the key into the chat.
 
 ### STDIO + Local Python (no key)
-Connect this agent to the STDIO entry point. No key needed:
-   `claude mcp add marm-memory -- marm-mcp-stdio`
+Connect this agent to the STDIO entry point. No key needed: `claude mcp add marm-memory -- marm-mcp-stdio`
 
 ### STDIO + Docker (no key)
-Print the exact client command and wire it into the agent's MCP config:
-   `marm-memory docker stdio-command --client <agent>`
+Print the exact client command and wire it into the agent's MCP config: `marm-memory docker stdio-command --client <agent>`
 
-For any agent that is not Claude, write the equivalent entry into that agent's
-MCP config file instead of using the `claude` CLI. Same transport, same address
-or command. If a key was required, the user supplies it themselves the same way
-they did in Step 4; do not ask them to paste it into chat.
+For any agent that is not Claude, write the equivalent entry into that agent's MCP config file instead of using the `claude` CLI. Same transport, same address or command. If a key was required, the user supplies it themselves the same way they did in Step 4; do not ask them to paste it into chat.
 
 ---
 
 ## Step 5 - Multi-agent linking
 
-Ask: "Want to connect MARM to your other agents? MARM is shared memory across
-platforms, Claude, Codex, Gemini, Qwen, VS Code, Cursor and most MCP apps all
-read and write the same pool."
+Ask: "Want to connect MARM to your other agents? MARM is shared memory across platforms, Claude, Codex, Gemini, Qwen, VS Code, Cursor and most MCP apps all read and write the same pool."
 
 If yes:
-- Use the same transport for every agent. If a key was required, the user
-  provides it themselves for each additional client the same way they did in
-  Step 4; do not ask them to paste it into chat.
-- Use these docs to find the exact connection instructions for each client:
+  - Use the same transport for every agent. If a key was required, the user provides it themselves for each additional client the same way they did in Step 4; do not ask them to paste it into chat.
+  - Use these docs to find the exact connection instructions for each client:
 
-  **CLI clients** — [Claude Code](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#claude-code-recommended) · [Codex](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#codex-cli) · [Gemini CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#gemini-cli) · [Qwen CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#qwen-code) · [Linux variants](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-LINUX.md#client-connections) · [Docker/key](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#client-connections)
+**CLI clients** — [Claude Code](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#claude-code-recommended) · [Codex](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#codex-cli) · [Gemini CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#gemini-cli) · [Qwen CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#qwen-code) · [Linux variants](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-LINUX.md#client-connections) · [Docker/key](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#client-connections)
 
-  **IDE agents** — [VS Code / Copilot Agent](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#vs-code-mcp--github-copilot-agent) · [Cursor](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#cursor) · [Docker/key IDE setup](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#vs-code-mcp--github-copilot-agent)
+**IDE agents** — [VS Code / Copilot Agent](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#vs-code-mcp--github-copilot-agent) · [Cursor](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#cursor) · [Docker/key IDE setup](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#vs-code-mcp--github-copilot-agent)
 
-  **Remote/API platforms** — [xAI / Grok Remote MCP](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#xai--grok-remote-mcp) · [Platform integration](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-PLATFORMS.md)
+**Remote/API platforms** — [xAI / Grok Remote MCP](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#xai--grok-remote-mcp) · [Platform integration](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-PLATFORMS.md)
 
 - Report which agents you wired up and which you could not find.
 
@@ -233,38 +170,23 @@ If no, skip.
 
 ## Step 6 - Handoff and start
 
-1. Start the server only if it is not already running, and honor the exact mode
-   chosen in Steps 3-4:
-   - STDIO (local or Docker): nothing to start; the client launches
-     `marm-mcp-stdio` (or the Docker STDIO command) on demand. Skip to the handoff.
-   - HTTP, local Python, loopback: `marm-memory fast-start-http` (skip if a
-     fast-start-http path already started it).
-   - HTTP, local Python, exposed: the user starts this themselves with their key
-     and `SERVER_HOST=0.0.0.0` (Step 4). Do not auto-run `fast-start-http` here; it
-     binds loopback without their key. Just verify once they confirm it is up.
-   - HTTP, Docker: `marm-memory docker run`, keeping `--expose-network` if the user
-     chose remote access in Step 2.
-2. Verify HTTP setups with a health check: `http://localhost:8001/health` should
-   return ok.
+1. Start the server only if it is not already running, and honor the exact mode chosen in Steps 3-4:
+  - STDIO (local or Docker): nothing to start; the client launches `marm-mcp-stdio` (or the Docker STDIO command) on demand. Skip to the handoff.
+  - HTTP, local Python, loopback: `marm-memory fast-start-http` (skip if a fast-start-http path already started it).
+  - HTTP, local Python, exposed: the user starts this themselves with their key and `SERVER_HOST=0.0.0.0` (Step 4). Do not auto-run `fast-start-http` here; it binds loopback without their key. Just verify once they confirm it is up.
+  - HTTP, Docker: `marm-memory docker run`, keeping `--expose-network` if the user chose remote access in Step 2.
+2. Verify HTTP setups with a health check: `http://localhost:8001/health` should return ok.
 3. Hand off with this message, adapted to what actually happened:
 
-   "Setup complete. Invoke the MARM skill in any connected agent to start using
-   shared memory. Restart your terminal so the MARM connection is picked up. If
-   you want to start your own server later, just ask."
+"Setup complete. Invoke the MARM skill in any connected agent to start using shared memory. Restart your terminal so the MARM connection is picked up. If you want to start your own server later, just ask."
 
-Setup is done. The executor contract above is now closed. Operate under the MARM
-protocol you loaded in Step 0.
+Setup is done. The executor contract above is now closed. Operate under the MARM protocol you loaded in Step 0.
 
 ---
 
 ## Edge cases
 
-- Cross-platform paths: Claude alone has several possible config locations by
-  install method. Check all known paths in Step 5, and accept a user-provided
-  path if the scan misses one.
-- Stale skill file: handled by the Step 0 freshness check. If the source version
-  is higher, tell the user to re-run `marm-memory init`.
-- Remote server: the connect command in Step 4 uses `localhost`. Swap in the
-  real host address when the server runs elsewhere.
-- Non-Claude agents: the `claude mcp add` commands are examples. Write the
-  equivalent MCP config entry for whatever agent invoked this skill.
+- Cross-platform paths: Claude alone has several possible config locations by install method. Check all known paths in Step 5, and accept a user-provided path if the scan misses one.
+- Stale skill file: handled by the Step 0 freshness check. If the source version is higher, tell the user to re-run `marm-memory init`.
+- Remote server: the connect command in Step 4 uses `localhost`. Swap in the real host address when the server runs elsewhere.
+- Non-Claude agents: the `claude mcp add` commands are examples. Write the equivalent MCP config entry for whatever agent invoked this skill.

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - marm-memory
-Version: 2.37.0
+Version: 2.38.0
 """
 
 import os

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -9,6 +9,7 @@ Version: 2.37.0
 """
 
 import os
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import psutil
@@ -48,7 +49,7 @@ logger = structlog.get_logger()
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Modern FastAPI lifespan management for startup and shutdown"""
     logger.info("Initializing MARM MCP Server", version=SERVER_VERSION)
     _warn_if_multi_process_requested()
@@ -107,7 +108,7 @@ app.middleware("http")(auth_middleware)
 app.middleware("http")(rate_limit_middleware)
 
 
-def get_memory_usage():
+def get_memory_usage() -> float:
     """Get current memory usage in MB."""
     process = psutil.Process(os.getpid())
     return process.memory_info().rss / 1024 / 1024

--- a/marm-mcp-server/marm_mcp_server/server_stdio.py
+++ b/marm-mcp-server/marm_mcp_server/server_stdio.py
@@ -19,6 +19,7 @@ builtins.print = lambda *args, **kwargs: _real_print(
 )
 
 import os  # noqa: E402
+from collections.abc import AsyncIterator  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 from typing import Optional  # noqa: E402
 
@@ -55,7 +56,7 @@ from .utils.embedding_state import check_embedding_compatibility  # noqa: E402
 
 
 @asynccontextmanager
-async def _stdio_lifespan(_server: FastMCP):
+async def _stdio_lifespan(_server: FastMCP) -> AsyncIterator[None]:
     """Drain in-flight chunk writes on teardown, inside the loop mcp.run() owns.
 
     This cannot live in main()'s finally: that runs after mcp.run() has already

--- a/marm-mcp-server/marm_mcp_server/services/analytics.py
+++ b/marm-mcp-server/marm_mcp_server/services/analytics.py
@@ -10,7 +10,9 @@ from ..config.settings import ANALYTICS_DB_PATH
 logger = structlog.get_logger()
 
 
-def track_usage(event_type: str, endpoint: str = None, user_data: dict = None):
+def track_usage(
+    event_type: str, endpoint: str | None = None, user_data: dict | None = None
+):
     """Track MCP usage events for launch analytics"""
     try:
         usage_db = ANALYTICS_DB_PATH

--- a/marm-mcp-server/marm_mcp_server/services/analytics.py
+++ b/marm-mcp-server/marm_mcp_server/services/analytics.py
@@ -12,7 +12,7 @@ logger = structlog.get_logger()
 
 def track_usage(
     event_type: str, endpoint: str | None = None, user_data: dict | None = None
-):
+) -> None:
     """Track MCP usage events for launch analytics"""
     try:
         usage_db = ANALYTICS_DB_PATH

--- a/marm-mcp-server/marm_mcp_server/services/automation.py
+++ b/marm-mcp-server/marm_mcp_server/services/automation.py
@@ -4,19 +4,19 @@ from ..core.memory import memory
 from ..core.events import events
 
 
-async def auto_classify_content(data: dict):
+async def auto_classify_content(data: dict) -> None:
     """Auto-classify log entries"""
     content = data.get("content", "")
     context_type = await memory.auto_classify_content(content)
     print(f"Auto-classified '{content[:50]}...' as '{context_type}'")
 
 
-async def update_knowledge_index(data: dict):
+async def update_knowledge_index(data: dict) -> None:
     """Update search index when notebook entries added"""
     print(f"Knowledge index updated for: {data.get('name')}")
 
 
-def register_event_handlers():
+def register_event_handlers() -> None:
     """Register all automation event handlers."""
     events.on("log_entry_created", auto_classify_content)
     events.on("notebook_entry_added", update_knowledge_index)

--- a/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
+++ b/marm-mcp-server/marm_mcp_server/services/compaction_apply.py
@@ -6,11 +6,11 @@ import uuid
 from datetime import datetime, timezone
 
 from ..core.consolidation import compute_content_hash
-from ..core.memory import sanitize_content, _safe_print
+from ..core.memory import MARMMemory, sanitize_content, _safe_print
 from ..core.memory_utils import _embedding_to_bytes
 
 
-async def apply_compaction_write(memory_store, candidate_id: str) -> str:
+async def apply_compaction_write(memory_store: MARMMemory, candidate_id: str) -> str:
     """Execute the atomic compaction write inside BEGIN IMMEDIATE. Returns summary_id.
 
     Fetches all candidate and source data fresh inside the lock so this function

--- a/marm-mcp-server/marm_mcp_server/services/compaction_summarize.py
+++ b/marm-mcp-server/marm_mcp_server/services/compaction_summarize.py
@@ -7,7 +7,7 @@ import uuid
 import numpy as np
 from datetime import datetime, timezone
 
-from ..core.memory import _safe_print
+from ..core.memory import MARMMemory, _safe_print
 from ..config.settings import COMPACTION_ENABLED
 
 
@@ -75,7 +75,7 @@ def centroid_extract_summary(
     return "\n\n".join(selected_content)
 
 
-def _mark_candidate_stale(memory_store, candidate_id: str) -> None:
+def _mark_candidate_stale(memory_store: MARMMemory, candidate_id: str) -> None:
     now = datetime.now(timezone.utc).isoformat()
     with memory_store.get_connection() as conn:
         conn.execute(
@@ -98,7 +98,7 @@ def _parse_source_ids(source_ids_json: str) -> list[str]:
     return parsed
 
 
-async def process_nudge_exhausted_candidates(memory_store) -> int:
+async def process_nudge_exhausted_candidates(memory_store: MARMMemory) -> int:
     """Promote nudge_exhausted compaction candidates to summary_staged using
     server-side centroid extraction. Returns count of candidates processed.
 

--- a/marm-mcp-server/marm_mcp_server/services/documentation.py
+++ b/marm-mcp-server/marm_mcp_server/services/documentation.py
@@ -12,7 +12,7 @@ from ..core.memory import memory
 from ..utils.helpers import docs_dir as helpers_docs_dir
 
 
-def guess_context_type(filename):
+def guess_context_type(filename) -> str:
     filename_lower = filename.lower()
     if "protocol" in filename_lower:
         return "protocol"
@@ -259,7 +259,7 @@ async def ensure_marm_started(session_name: str = "default") -> None:
         pass
 
 
-async def reload_marm_documentation():
+async def reload_marm_documentation() -> None:
     """Force a fresh doc load regardless of prior state."""
     global _docs_loaded
     _docs_loaded = False
@@ -275,7 +275,7 @@ _LEGACY_SYSTEM_NOTEBOOK_NAMES = {
 }
 
 
-async def load_marm_documentation():
+async def load_marm_documentation() -> None:
     """Index all marm-docs/ files into memories for semantic search."""
     global _docs_loaded
 

--- a/marm-mcp-server/marm_mcp_server/services/documentation.py
+++ b/marm-mcp-server/marm_mcp_server/services/documentation.py
@@ -12,7 +12,7 @@ from ..core.memory import memory
 from ..utils.helpers import docs_dir as helpers_docs_dir
 
 
-def guess_context_type(filename) -> str:
+def guess_context_type(filename: str) -> str:
     filename_lower = filename.lower()
     if "protocol" in filename_lower:
         return "protocol"
@@ -56,7 +56,7 @@ def _docs_dir() -> Path | None:
     return helpers_docs_dir()
 
 
-def get_docs_to_load():
+def get_docs_to_load() -> list[dict]:
     """Return all docs from marm-docs/ for memory indexing."""
     docs_dir = _docs_dir()
 

--- a/marm-mcp-server/marm_mcp_server/services/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/services/notebook.py
@@ -2,7 +2,7 @@
 
 import threading
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 from ..config.settings import MARM_PLATFORM, MARM_PROJECT
 from ..core.docs_db import DocsDB
@@ -237,7 +237,7 @@ async def _save(
         )
 
     mirror_status = "synced"
-    memory_id = doc_row.memory_id
+    mirror_memory_id: str | None = None
 
     if not was_created and doc_row.memory_id:
         # Before the replacement is written, not after. Cleanup strips every
@@ -258,7 +258,7 @@ async def _save(
             )
 
     try:
-        memory_id = await memory.store_doc_mirror(
+        mirror_memory_id = await memory.store_doc_mirror(
             content,
             session_name,
             scoped_project,
@@ -274,9 +274,9 @@ async def _save(
         _safe_print(f"Doc mirror write failed for doc {doc_row.id}: {e}")
         mirror_status = "pending"
 
-    if mirror_status == "synced":
+    if mirror_memory_id is not None:
         with docs_db.get_connection() as conn:
-            docs_db.set_memory_id(conn, doc_row.id, memory_id)
+            docs_db.set_memory_id(conn, doc_row.id, mirror_memory_id)
 
     verb = "saved" if was_created else "updated"
     promoted_note = " (promoted from scratch)" if source_notebook_name else ""
@@ -284,12 +284,14 @@ async def _save(
         "status": "success",
         "message": f"📄 Doc '{name}' {verb}{promoted_note}",
         "doc_id": doc_row.id,
-        "memory_id": memory_id if mirror_status == "synced" else doc_row.memory_id,
+        "memory_id": mirror_memory_id
+        if mirror_status == "synced"
+        else doc_row.memory_id,
         "mirror_status": mirror_status,
     }
 
 
-_ACTION_HANDLERS = {
+_ACTION_HANDLERS: dict[str, Callable[..., Awaitable[dict]]] = {
     "add": _add,
     "use": _use,
     "show": _show,

--- a/marm-mcp-server/marm_mcp_server/services/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/services/notebook.py
@@ -43,7 +43,7 @@ async def _add(
     session_name: str = "main",
     project: Optional[str] = None,
     platform: Optional[str] = None,
-    **_,
+    **_: object,
 ) -> dict:
     if not name or not name.strip() or not data or not data.strip():
         return {
@@ -86,7 +86,7 @@ async def _add(
     }
 
 
-async def _use(names: Optional[str], session_name: str = "main", **_) -> dict:
+async def _use(names: Optional[str], session_name: str = "main", **_: object) -> dict:
     if not names or not names.strip():
         return {"status": "error", "message": "names is required for action='use'"}
     name_list = [n.strip() for n in names.split(",") if n.strip()]
@@ -124,7 +124,7 @@ async def _use(names: Optional[str], session_name: str = "main", **_) -> dict:
     }
 
 
-async def _show(session_name: str = "main", **_) -> dict:
+async def _show(session_name: str = "main", **_: object) -> dict:
     with memory.get_connection() as conn:
         cursor = conn.execute(
             """
@@ -152,7 +152,7 @@ async def _show(session_name: str = "main", **_) -> dict:
     }
 
 
-async def _status(session_name: str = "main", **_) -> dict:
+async def _status(session_name: str = "main", **_: object) -> dict:
     active_entries = memory.get_active_notebook_entries(session_name)
     active_names = [entry["name"] for entry in active_entries]
     return {
@@ -164,7 +164,7 @@ async def _status(session_name: str = "main", **_) -> dict:
     }
 
 
-async def _clear(session_name: str = "main", **_) -> dict:
+async def _clear(session_name: str = "main", **_: object) -> dict:
     memory.clear_active_notebook_entries(session_name)
     return {
         "status": "success",
@@ -179,7 +179,7 @@ async def _save(
     session_name: str = "main",
     project: Optional[str] = None,
     platform: Optional[str] = None,
-    **_,
+    **_: object,
 ) -> dict:
     """Promote a scratch entry (or new inline content) into the permanent
     docs store. Copy, not move -- the source scratch entry is left

--- a/marm-mcp-server/marm_mcp_server/services/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/services/notebook.py
@@ -275,8 +275,16 @@ async def _save(
         mirror_status = "pending"
 
     if mirror_memory_id is not None:
-        with docs_db.get_connection() as conn:
-            docs_db.set_memory_id(conn, doc_row.id, mirror_memory_id)
+        try:
+            with docs_db.get_connection() as conn:
+                docs_db.set_memory_id(conn, doc_row.id, mirror_memory_id)
+        except Exception as e:
+            # The mirror row is written but the docs row does not point at it.
+            # Reported as pending rather than raised, for the same reason a failed
+            # mirror write is: the durable save already succeeded. store_doc_mirror
+            # resolves the orphan by doc_id, so the repair costs no duplicate.
+            _safe_print(f"Doc mirror id link failed for doc {doc_row.id}: {e}")
+            mirror_status = "pending"
 
     verb = "saved" if was_created else "updated"
     promoted_note = " (promoted from scratch)" if source_notebook_name else ""

--- a/marm-mcp-server/marm_mcp_server/services/product_workflows.py
+++ b/marm-mcp-server/marm_mcp_server/services/product_workflows.py
@@ -7,6 +7,7 @@ import os
 import socket
 import sys
 from pathlib import Path
+from typing import Callable
 
 from ..config import settings
 from ..config.settings import SERVER_HOST, SERVER_PORT
@@ -115,7 +116,7 @@ def fast_start_http(args: argparse.Namespace) -> int:
     return 0
 
 
-def upgrade(args: argparse.Namespace, *, print_payload) -> int:
+def upgrade(args: argparse.Namespace, *, print_payload: Callable[..., None]) -> int:
     """Check or upgrade a pip-managed installation without touching user data."""
     from ..core import runtime_manager
     from . import package_management

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -26,8 +26,8 @@ async def smart_recall(
     include_logs: bool = False,
     detail: int = 1,
     exact_mode: str = "auto",
-    project: str = None,
-    platform: str = None,
+    project: str | None = None,
+    platform: str | None = None,
 ) -> dict:
     try:
         search_session = None if search_all else session_name

--- a/marm-mcp-server/marm_mcp_server/services/stdio_graph_tools.py
+++ b/marm-mcp-server/marm_mcp_server/services/stdio_graph_tools.py
@@ -14,7 +14,10 @@ regardless of import order.
 """
 
 import asyncio
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
 
 from pydantic import ValidationError
 
@@ -362,7 +365,7 @@ async def marm_concept_recall(
         return {"status": "error", "message": "Concept recall failed."}
 
 
-def register_graph_tools(mcp) -> None:
+def register_graph_tools(mcp: "FastMCP") -> None:
     """Explicit, order-independent tool registration -- called once from
     server_stdio.py after the 7 core tools are already registered, so
     tools/list order never depends on which module happens to import this

--- a/marm-mcp-server/marm_mcp_server/utils/chunk_backfill.py
+++ b/marm-mcp-server/marm_mcp_server/utils/chunk_backfill.py
@@ -22,7 +22,7 @@ from ..core.memory_utils import (
     _chunk_text,
     _embedding_to_bytes,
 )
-from .embedding_migration import _encode_all, _load_encoder
+from .embedding_migration import _Encoder, _encode_all, _load_encoder
 from .embedding_state import get_default_concept_db_path, inspect_embedding_state
 
 _MEMORY_PROFILE = {
@@ -134,7 +134,7 @@ def rechunk_memories(
     memory_db_path: str,
     concept_db_path: str | None = None,
     *,
-    encoder_factory: Callable[[], object] | None = None,
+    encoder_factory: Callable[[], _Encoder] | None = None,
     progress: Callable[[str], None] = print,
 ) -> dict:
     """Re-split stale chunks, fill missing ones, and drop chunks below threshold."""
@@ -177,6 +177,9 @@ def rechunk_memories(
         for item in work:
             embeddings: list[bytes] = []
             if item["desired"]:
+                # needs_encoder is any(item["desired"]), so this branch is only
+                # reachable once the encoder is loaded.
+                assert encoder is not None
                 embeddings = [
                     _embedding_to_bytes(vector)
                     for vector in _encode_all(encoder, item["desired"])

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_migration.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterable
 from contextlib import closing
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Protocol
+
+import numpy as np
 
 from ..config.settings import DEFAULT_SEMANTIC_DIM, DEFAULT_SEMANTIC_MODEL
 from ..core.memory_utils import _embedding_to_bytes
@@ -25,6 +28,18 @@ _MEMORY_TABLES = (
 _CONCEPT_TABLES = (("entities", "name", "name_embedding"),)
 
 
+class _Encoder(Protocol):
+    """All the migration needs from an encoder. Not TextEmbedding: encoder_factory
+    exists so tests can inject a double, and pinning the concrete class would
+    make every one of those call sites a type error.
+
+    Positional-only because the doubles name the parameter `texts` while fastembed
+    names it `documents`, and a named parameter would only accept one of them.
+    """
+
+    def embed(self, documents: list[str], /) -> Iterable[np.ndarray]: ...
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     return (
         conn.execute(
@@ -38,7 +53,7 @@ def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
     return any(row[1] == column for row in conn.execute(f"PRAGMA table_info({table})"))
 
 
-def _load_encoder():
+def _load_encoder() -> _Encoder:
     from fastembed import TextEmbedding
 
     return TextEmbedding(model_name=DEFAULT_SEMANTIC_MODEL)
@@ -79,15 +94,15 @@ def _length_bounded_batches(texts: list[str]) -> list[list[str]]:
     return batches
 
 
-def _encode_all(encoder, texts: list[str]) -> list:
+def _encode_all(encoder: _Encoder, texts: list[str]) -> list[np.ndarray]:
     """Encode every text, splitting into memory-safe batches first."""
-    vectors: list = []
+    vectors: list[np.ndarray] = []
     for batch in _length_bounded_batches(texts):
         vectors.extend(_encode_batch(encoder, batch))
     return vectors
 
 
-def _encode_batch(encoder, texts: list[str]) -> list:
+def _encode_batch(encoder: _Encoder, texts: list[str]) -> list[np.ndarray]:
     vectors = list(encoder.embed(texts))
     if len(vectors) != len(texts):
         raise RuntimeError(
@@ -105,7 +120,7 @@ def _encode_batch(encoder, texts: list[str]) -> list:
 def _migrate_database(
     path: Path,
     tables: tuple[tuple[str, str, str], ...],
-    encoder,
+    encoder: _Encoder,
     batch_size: int,
     progress: Callable[[str], None],
     force_reencode: bool = False,
@@ -172,7 +187,7 @@ def migrate_embeddings(
     concept_db_path: str | None = None,
     *,
     batch_size: int = 100,
-    encoder_factory: Callable[[], object] | None = None,
+    encoder_factory: Callable[[], _Encoder] | None = None,
     progress: Callable[[str], None] = print,
 ) -> dict:
     """Migrate incompatible vectors and mark success only after both DBs verify."""

--- a/marm-mcp-server/marm_mcp_server/utils/helpers.py
+++ b/marm-mcp-server/marm_mcp_server/utils/helpers.py
@@ -16,7 +16,7 @@ def docs_dir() -> Path | None:
     return DOCS_DIR if DOCS_DIR.is_dir() else None
 
 
-async def read_protocol_file():
+async def read_protocol_file() -> str:
     """Read the PROTOCOL.md file and return its content."""
     try:
         protocol_path = DOCS_DIR / "PROTOCOL.md"
@@ -29,7 +29,7 @@ async def read_protocol_file():
         return f"Error reading PROTOCOL.md: {e!s}"
 
 
-async def read_protocol_lite_file():
+async def read_protocol_lite_file() -> str:
     """Read the PROTOCOL-LITE.md file and return its content."""
     try:
         lite_path = DOCS_DIR / "PROTOCOL-LITE.md"

--- a/marm-mcp-server/marm_mcp_server/utils/security.py
+++ b/marm-mcp-server/marm_mcp_server/utils/security.py
@@ -137,20 +137,20 @@ def _set_windows_owner_only_dacl(path: Path) -> bool:
             ):
                 return False
             try:
-                return (
-                    advapi32.SetNamedSecurityInfoW(
-                        str(path),
-                        se_file_object,
-                        owner_security_information
-                        | dacl_security_information
-                        | protected_dacl_security_information,
-                        token_user.user.sid,
-                        None,
-                        dacl,
-                        None,
-                    )
-                    == 0
+                # restype is DWORD, so ctypes hands back an int; naming it keeps
+                # that contract visible instead of leaking ctypes' untyped call.
+                status: int = advapi32.SetNamedSecurityInfoW(
+                    str(path),
+                    se_file_object,
+                    owner_security_information
+                    | dacl_security_information
+                    | protected_dacl_security_information,
+                    token_user.user.sid,
+                    None,
+                    dacl,
+                    None,
                 )
+                return status == 0
             finally:
                 kernel32.LocalFree(dacl)
         finally:

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "isort>=5.10.0",
     "flake8>=5.0.0",
     "mypy>=2.3.0",
+    "types-psutil>=6.0.0",
     "ruff>=0.4.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
@@ -105,8 +106,19 @@ disallow_untyped_defs = true
 # Without this, Pydantic models read as plain classes and every optional field
 # looks like a required constructor argument.
 plugins = ["pydantic.mypy"]
-# core/ is the checked scope; imports out of it are resolved but not reported.
 follow_imports = "silent"
+
+# Third-party packages that ship no py.typed marker and have no stubs on PyPI.
+# Listed one library at a time on purpose: a global ignore_missing_imports would
+# also swallow a mistyped or deleted MARM import, which is the one import error
+# worth catching. psutil is deliberately absent, since types-psutil covers it.
+[[tool.mypy.overrides]]
+module = [
+    "codebase_memory_mcp.*",
+    "apscheduler.*",
+    "fastapi_mcp",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -70,11 +70,11 @@ dev = [
     "build>=1.2.2",
     "jsonschema>=4.0.0",
     "requests>=2.31.0",
-    "black>=22.0.0",
-    "isort>=5.10.0",
-    "flake8>=5.0.0",
     "mypy>=2.3.0",
     "types-psutil>=6.0.0",
+    # ruff owns both lint and format. black/isort/flake8 were removed rather
+    # than satisfied: black disagreed with ruff format on 13 files, and flake8
+    # only reported E501 against its own 79-char default while this uses 88.
     "ruff>=0.4.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
@@ -87,16 +87,6 @@ exclude = ["tests*", "*.tests*", "docs*"]
 [tool.setuptools.package-data]
 "*" = ["*.json", "*.yaml", "*.yml", "config/*", "templates/*", "models/en_core_web_sm/**/*", "resources/**/*"]
 "marm_mcp_server.console" = ["static/*", "static/**/*"]
-
-[tool.black]
-line-length = 88
-target-version = ['py310']
-include = '\.pyi?$'
-
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 88
 
 [tool.mypy]
 python_version = "3.10"

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.37.0"
+version = "2.38.0"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.37.0",
+      "version": "2.38.0",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.37.0",
+      "identifier": "lyellr88/marm-mcp-server:2.38.0",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_notebook_service.py
+++ b/marm-mcp-server/tests/test_notebook_service.py
@@ -488,3 +488,94 @@ async def test_save_preserves_session_project_platform_on_mirror(
             (result["memory_id"],),
         ).fetchone()
     assert row == ("proj-session", "marm", "claude-code")
+
+
+# --- action='save' mirror link failure and repair ---
+
+
+@pytest.mark.asyncio
+async def test_save_reports_pending_when_docs_memory_id_link_fails(
+    notebook_svc, tmp_path, monkeypatch
+):
+    """A set_memory_id failure must not escape _save.
+
+    The docs row is already committed at that point, so raising would report
+    total failure for a save that durably succeeded, and would drop the
+    mirror_status the caller uses to know a repair is owed.
+    """
+    dispatch, _ = notebook_svc
+    from marm_mcp_server.core.docs_db import DocsDB
+
+    def boom(self, conn, doc_id, memory_id):
+        raise sqlite3.OperationalError("docs db is locked")
+
+    monkeypatch.setattr(DocsDB, "set_memory_id", boom)
+    result = await dispatch(action="save", name="link-fail", data="durable content")
+
+    assert result["status"] == "success"
+    assert result["mirror_status"] == "pending"
+
+    # Docs row committed, but not yet pointing at the mirror.
+    with sqlite3.connect(str(tmp_path / "nb-docs.db")) as conn:
+        row = conn.execute(
+            "SELECT content, memory_id FROM docs WHERE name = 'link-fail'"
+        ).fetchone()
+    assert row[0] == "durable content"
+    assert row[1] is None
+
+    # The mirror itself exists, orphaned from the docs row.
+    with sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
+        mirrors = conn.execute(
+            "SELECT content FROM memories WHERE context_type = 'doc'"
+        ).fetchall()
+    assert len(mirrors) == 1
+    assert mirrors[0][0] == "durable content"
+
+
+@pytest.mark.asyncio
+async def test_save_after_failed_link_repairs_instead_of_duplicating_mirror(
+    notebook_svc, tmp_path, monkeypatch
+):
+    """The whole point of the pending status: the next save must repair.
+
+    With docs.memory_id still NULL, the resave passes existing_memory_id=None.
+    Before store_doc_mirror resolved the orphan by metadata.doc_id, that created
+    a second mirror row for one doc on every subsequent save.
+    """
+    dispatch, _ = notebook_svc
+    from marm_mcp_server.core.docs_db import DocsDB
+
+    original = DocsDB.set_memory_id
+
+    def boom(self, conn, doc_id, memory_id):
+        raise sqlite3.OperationalError("docs db is locked")
+
+    monkeypatch.setattr(DocsDB, "set_memory_id", boom)
+    first = await dispatch(action="save", name="repairable", data="version one")
+    assert first["mirror_status"] == "pending"
+
+    with sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
+        orphan_id = conn.execute(
+            "SELECT id FROM memories WHERE context_type = 'doc'"
+        ).fetchone()[0]
+
+    monkeypatch.setattr(DocsDB, "set_memory_id", original)
+    second = await dispatch(action="save", name="repairable", data="version two")
+
+    assert second["mirror_status"] == "synced"
+    assert second["doc_id"] == first["doc_id"]
+    # Same row reused, not a new one.
+    assert second["memory_id"] == orphan_id
+
+    with sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
+        mirrors = conn.execute(
+            "SELECT id, content FROM memories WHERE context_type = 'doc'"
+        ).fetchall()
+    assert len(mirrors) == 1
+    assert mirrors[0] == (orphan_id, "version two")
+
+    with sqlite3.connect(str(tmp_path / "nb-docs.db")) as conn:
+        linked = conn.execute(
+            "SELECT memory_id FROM docs WHERE name = 'repairable'"
+        ).fetchone()[0]
+    assert linked == orphan_id

--- a/scripts/typecheck.py
+++ b/scripts/typecheck.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Run mypy on the checked scope and gate on the error baseline.
 
-Local only for now. core/ carries a backlog of annotation errors, so this fails
-only when the count goes *up* rather than demanding zero. Lower BASELINE as
+Local only for now. The package carries a backlog of annotation errors, so this
+fails only when the count goes *up* rather than demanding zero. Lower BASELINE as
 errors are fixed; that edit is the record of progress. Once the backlog is
 cleared this becomes a CI job: install requirements.txt plus a pinned mypy, then
 run this script. The mypy version must be pinned there, because BASELINE is
@@ -22,11 +22,16 @@ import subprocess
 import sys
 from collections import Counter
 
-BASELINE = 113
+BASELINE = 155
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 PACKAGE_DIR = REPO_ROOT / "marm-mcp-server"
-TARGET = "marm_mcp_server/core/"
+
+# The whole package, not just core/. Checking core/ alone hid both ends of the
+# same defect: an implicit-Optional parameter counted once inside core/ while
+# every caller honestly passing None to it went unreported. It also let new
+# errors land freely in endpoints/, services/, and console/.
+TARGET = "marm_mcp_server/"
 
 _ERROR_LINE = re.compile(
     r"^(?P<path>.*?\.py):\d+: error: .*?(?:\[(?P<code>[a-z-]+)\])?$"
@@ -44,6 +49,16 @@ def run_mypy() -> tuple[str, int]:
     return proc.stdout + proc.stderr, proc.returncode
 
 
+def _relative(path: str) -> str:
+    """mypy's path, normalized to forward slashes.
+
+    Keyed on the full relative path rather than the basename: nine basenames
+    repeat across subpackages (memory.py, concepts.py, models.py, cli.py, ...),
+    so grouping on the name alone merged distinct files into one count.
+    """
+    return path.replace("\\", "/")
+
+
 def parse(output: str) -> tuple[Counter, Counter, int]:
     by_file: Counter = Counter()
     by_code: Counter = Counter()
@@ -53,7 +68,7 @@ def parse(output: str) -> tuple[Counter, Counter, int]:
         if not match:
             continue
         total += 1
-        by_file[pathlib.Path(match.group("path")).name] += 1
+        by_file[_relative(match.group("path"))] += 1
         by_code[match.group("code") or "uncoded"] += 1
     return by_file, by_code, total
 
@@ -104,12 +119,12 @@ def main() -> int:
         print("\nby file")
         for name, count in by_file.most_common():
             print(f"  {count:5d}  {name}")
-        clean = sorted(
-            p.name for p in (PACKAGE_DIR / TARGET).glob("*.py") if p.name not in by_file
-        )
-        print(f"\nclean: {len(clean)} of {len(clean) + len(by_file)} files")
-        for name in clean:
-            print(f"         {name}")
+        checked = {
+            _relative(str(path.relative_to(PACKAGE_DIR)))
+            for path in (PACKAGE_DIR / TARGET).rglob("*.py")
+            if "__pycache__" not in path.parts
+        }
+        print(f"\nclean: {len(checked - set(by_file))} of {len(checked)} files")
 
     print()
     if total > BASELINE:

--- a/scripts/typecheck.py
+++ b/scripts/typecheck.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 from collections import Counter
 
-BASELINE = 155
+BASELINE = 78
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 PACKAGE_DIR = REPO_ROOT / "marm-mcp-server"

--- a/scripts/typecheck.py
+++ b/scripts/typecheck.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Run mypy on the checked scope and gate on the error baseline.
 
-Local only for now. The package carries a backlog of annotation errors, so this
-fails only when the count goes *up* rather than demanding zero. Lower BASELINE as
-errors are fixed; that edit is the record of progress. Once the backlog is
-cleared this becomes a CI job: install requirements.txt plus a pinned mypy, then
-run this script. The mypy version must be pinned there, because BASELINE is
-version-specific.
+Local only for now. This fails when the count goes *up*, not when it is nonzero.
+Lower BASELINE as errors are fixed; that edit is the record of progress.
+
+The remaining 2 are both endpoints/graph.py's Optional get_client() race, which
+needs a supervisor-level fix (see docs/current/graph-client-none-guard.md), not
+an annotation. Reaching 0 is a code change, not a typing one.
+
+Promoting this to CI needs requirements.txt plus a pinned mypy. The pin is not
+optional: BASELINE is version-specific.
 
     python scripts/typecheck.py            summary + gate
     python scripts/typecheck.py --raw      full mypy output, no gate
@@ -22,7 +25,7 @@ import subprocess
 import sys
 from collections import Counter
 
-BASELINE = 78
+BASELINE = 2
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 PACKAGE_DIR = REPO_ROOT / "marm-mcp-server"

--- a/skills/marm-init/SKILL.md
+++ b/skills/marm-init/SKILL.md
@@ -13,21 +13,13 @@ metadata:
 === MARM INIT PROTOCOL - YOU ARE THE INSTALLER ===
 
 RULE ZERO (highest priority):
-This file is not documentation to summarize. It is a setup program and you are
-the runtime. Execute it top to bottom. Run the steps, ask the questions, write
-the files, and start the server. Do not paste this content back to the user as
-text. Do not narrate what the skill "would" do. You do it.
+This file is not documentation to summarize. It is a setup program and you are the runtime. Execute it top to bottom. Run the steps, ask the questions, write the files, and start the server. Do not paste this content back to the user as text. Do not narrate what the skill "would" do. You do it.
 
-You are MARM's installer for this agent. Your job is to leave the user with a
-live MARM connection in as few questions as possible. One question at a time,
-wait for the answer, then act on it before moving on.
+You are MARM's installer for this agent. Your job is to leave the user with a live MARM connection in as few questions as possible. One question at a time, wait for the answer, then act on it before moving on.
 
-Scope: this protocol governs only the setup conversation below. Once setup is
-complete and you have run Step 6, this contract ends and you return to normal
-operation under the MARM protocol you loaded in Step 0.
+Scope: this protocol governs only the setup conversation below. Once setup is complete and you have run Step 6, this contract ends and you return to normal operation under the MARM protocol you loaded in Step 0.
 
-Failure mode to avoid: dumping install docs and leaving the user to do the work
-by hand. That is the exact outcome this skill exists to prevent.
+Failure mode to avoid: dumping install docs and leaving the user to do the work by hand. That is the exact outcome this skill exists to prevent.
 
 </MARM_INIT_EXECUTOR_ACTIVE>
 
@@ -35,34 +27,26 @@ by hand. That is the exact outcome this skill exists to prevent.
 
 ## Step 00 - Engine pre-flight 
 
-Run this first, before anything else. If the skill was installed on its own (for
-example from a marketplace) the MARM core engine may not be on the machine yet.
-Confirm it is present, or install it, before continuing.
+Run this first, before anything else. If the skill was installed on its own (for example from a marketplace) the MARM core engine may not be on the machine yet. Confirm it is present, or install it, before continuing.
 
 1. Scan the host for the core engine:
-   - CLI entry points on PATH. Unix: `command -v marm-memory || command -v marm-mcp-server || command -v marm-mcp-stdio`. PowerShell: `Get-Command marm-memory, marm-mcp-server, marm-mcp-stdio -ErrorAction SilentlyContinue`.
-   - Docker image present locally: `docker images -q lyellr88/marm-mcp-server`.
+  - CLI entry points on PATH. Unix: `command -v marm-memory || command -v marm-mcp-server || command -v marm-mcp-stdio`. PowerShell: `Get-Command marm-memory, marm-mcp-server, marm-mcp-stdio -ErrorAction SilentlyContinue`.
+  - Docker image present locally: `docker images -q lyellr88/marm-mcp-server`.
 
 2. Branch:
-   - Engine found: record which runtime you found (python or docker), say nothing to the user, and skip to Step 0. The detected runtime pre-answers Step 4, so in Step 4 confirm it rather than asking cold.
-   - Nothing found: stop and run the install prompt below.
+  - Engine found: record which runtime you found (python or docker), say nothing to the user, and skip to Step 0. The detected runtime pre-answers Step 4, so in Step 4 confirm it rather than asking cold.
+  - Nothing found: stop and run the install prompt below.
 
 3. Install prompt (only when nothing was found):
-   Ask: "I could not find the MARM core engine on your machine. How do you want to install it?
-   - Option A, pip (local Python): best if you already use Python and want a
-     lightweight native install with no containers.
-   - Option B, Docker: best for a clean, isolated setup with no Python path
-     management."
+Ask: "I could not find the MARM core engine on your machine. How do you want to install it?
+  - Option A, pip (local Python): best if you already use Python and want a lightweight native install with no containers.
+  - Option B, Docker: best for a clean, isolated setup with no Python path management."
 
 4. Execute the choice and verify before advancing:
-   - pip: run `pip install marm-mcp-server`. Confirm success, for example
-     `marm-mcp-server --version` resolves. Record runtime = python.
-   - Docker: run `docker pull lyellr88/marm-mcp-server:latest`. Confirm the image
-     is present with `docker images -q lyellr88/marm-mcp-server`. Record
-     runtime = docker.
+  - pip: run `pip install marm-mcp-server`. Confirm success, for example  `marm-mcp-server --version` resolves. Record runtime = python.
+  - Docker: run `docker pull lyellr88/marm-mcp-server:latest`. Confirm the image is present with `docker images -q lyellr88/marm-mcp-server`. Record runtime = docker.
 
-   If the install fails, surface the actual error and stop. Do not proceed to
-   setup against a missing engine.
+If the install fails, surface the actual error and stop. Do not proceed to setup against a missing engine.
 
 ---
 
@@ -70,16 +54,10 @@ Confirm it is present, or install it, before continuing.
 
 Do this before talking to the user.
 
-1. Read the full MARM protocol from source:
-   `https://raw.githubusercontent.com/Lyellr88/marm-memory/MARM-main/docs/PROTOCOL.md`
-   If the network read fails, fall back in this order:
-   - local repo `docs/PROTOCOL.md`
-   - packaged copy `marm-mcp-server/marm_mcp_server/resources/marm-docs/PROTOCOL.md`
-2. Freshness check: read the `version:` field in this file's frontmatter and
-   compare it against the `version:` in the source copy at `metadata.source`.
-   If the source version is higher, tell the user once:
-   "Your MARM init skill is out of date. Re-run `marm-memory init` to refresh it."
-   Then continue with the version you have.
+1. Read the full MARM protocol from source: `https://raw.githubusercontent.com/Lyellr88/marm-memory/MARM-main/docs/PROTOCOL.md` If the network read fails, fall back in this order:
+  - local repo `docs/PROTOCOL.md`
+  - packaged copy `marm-mcp-server/marm_mcp_server/resources/marm-docs/PROTOCOL.md`
+2. Freshness check: read the `version:` field in this file's frontmatter and compare it against the `version:` in the source copy at `metadata.source`. If the source version is higher, tell the user once: "Your MARM init skill is out of date. Re-run `marm-memory init` to refresh it." Then continue with the version you have.
 
 Hold the protocol in context. You will operate under it after setup.
 
@@ -87,11 +65,9 @@ Hold the protocol in context. You will operate under it after setup.
 
 ## Step 1 - Usage type
 
-Ask: "How will you use MARM, just you on this machine, or multiple users/agents
-over a network?"
-
-- Single user, one machine -> personal/local path
-- Multiple users or agents on a network -> team/swarm path
+Ask: "How will you use MARM, just you on this machine, or multiple users/agents over a network?"
+  - Single user, one machine -> personal/local path
+  - Multiple users or agents on a network -> team/swarm path
 
 Record the answer. It biases the transport recommendation in Step 3.
 
@@ -100,9 +76,8 @@ Record the answer. It biases the transport recommendation in Step 3.
 ## Step 2 - Server location
 
 Ask: "Run MARM locally, or connect to a server you own (VPS or homelab)?"
-
-- Local: runs on this machine, zero infra
-- Remote: runs on a host the user controls, reachable over their network
+  - Local: runs on this machine, zero infra
+  - Remote: runs on a host the user controls, reachable over their network
 
 If remote, you will need the host address later for the connect command.
 
@@ -111,119 +86,81 @@ If remote, you will need the host address later for the connect command.
 ## Step 3 - Transport
 
 Ask: "How should agents connect, HTTP or STDIO?"
+  - HTTP: over the network. Needed for remote servers, multiple machines, or swarm agents. Requires an API key. Recommend this for the team/swarm path.
+  - STDIO: local pipe, single machine, no key. Simplest. Recommend this for the personal/local path.
 
-- HTTP: over the network. Needed for remote servers, multiple machines, or swarm
-  agents. Requires an API key. Recommend this for the team/swarm path.
-- STDIO: local pipe, single machine, no key. Simplest. Recommend this for the
-  personal/local path.
-
-Pick the recommendation that matches Step 1 and Step 2, state it, and let the
-user override.
+Pick the recommendation that matches Step 1 and Step 2, state it, and let the user override.
 
 ---
 
 ## Step 4 - Runtime
 
-If Step 00 already detected or installed a runtime, confirm it instead of asking
-cold: "Looks like you are set up for <docker|python>, use that?" Only ask the
-open question below if the runtime is genuinely unknown.
+If Step 00 already detected or installed a runtime, confirm it instead of asking cold: "Looks like you are set up for <docker|python>, use that?" Only ask the open question below if the runtime is genuinely unknown.
 
 Ask: "Docker or local Python?"
-
-- Docker: isolated, easiest to keep updated.
-- Local Python: runs direct, good if Python is already set up. The package
-  installs two entry points: `marm-mcp-server` (HTTP) and `marm-mcp-stdio` (STDIO).
+  - Docker: isolated, easiest to keep updated.
+  - Local Python: runs direct, good if Python is already set up. The package installs two entry points: `marm-mcp-server` (HTTP) and `marm-mcp-stdio` (STDIO).
 
 You now have enough to act. Run the matching block.
 
 **Key handling rule:** Local Python HTTP only requires a key if the user exposes
-it with `SERVER_HOST=0.0.0.0` (remote/network access). Docker HTTP uses MARM's
-managed key file (`~/.marm/.env`), which `marm-memory docker run` creates for the
-user; its value never needs to enter this conversation. Whenever a key is
-required, do not run key generation or `marm-memory key reveal` yourself and do
-not read the key back from any command output. Have the user handle the value in
-their own terminal instead. Once the server is running, verify with an
-unauthenticated check (`curl http://localhost:8001/health`, no key needed) rather
-than asking them to paste the key back to you.
+it with `SERVER_HOST=0.0.0.0` (remote/network access). Docker HTTP uses MARM's managed key file (`~/.marm/.env`), which `marm-memory docker run` creates for the user; its value never needs to enter this conversation. Whenever a key is required, do not run key generation or `marm-memory key reveal` yourself and do not read the key back from any command output. Have the user handle the value in their own terminal instead. Once the server is running, verify with an unauthenticated check (`curl http://localhost:8001/health`, no key needed) rather than asking them to paste the key back to you.
 
 ### HTTP + Local Python, local-only (no key) -- the fast path, recommend this for single-machine use
-This is the one-shot. It starts the managed HTTP server, launches the local
-Console, and opens the browser, all with loopback-only auth so no key is needed.
+
+This is the one-shot. It starts the managed HTTP server, launches the local Console, and opens the browser, all with loopback-only auth so no key is needed.
+
 Safe to run yourself:
 
-    marm-memory fast-start-http
+  marm-memory fast-start-http
 
-That leaves MARM live at `http://localhost:8001/mcp` and the Console at
-`http://localhost:8002`. Then connect this agent (loopback, no key):
+That leaves MARM live at `http://localhost:8001/mcp` and the Console at `http://localhost:8002`. Then connect this agent (loopback, no key):
 
-    claude mcp add --transport http marm-memory http://localhost:8001/mcp
+  claude mcp add --transport http marm-memory http://localhost:8001/mcp
 
-Because fast-start-http already started the server and the Console, Step 6 has
-nothing left to start; just verify and hand off.
+Because fast-start-http already started the server and the Console, Step 6 has nothing left to start; just verify and hand off.
 
 ### HTTP + Local Python, exposed (key required)
-Only applies if the user asked for remote/network access in Step 2. Give them
-these steps to run themselves; do not execute steps 1 or 2 on their behalf:
+
+Only applies if the user asked for remote/network access in Step 2. Give them these steps to run themselves; do not execute steps 1 or 2 on their behalf:
 1. Generate a key: `marm-memory key generate`
 2. Start with their own key: `MARM_API_KEY=<paste-your-key> SERVER_HOST=0.0.0.0 marm-memory start` (PowerShell: `$env:MARM_API_KEY="<paste-your-key>"; $env:SERVER_HOST="0.0.0.0"; marm-memory start`)
-3. Connect their client with their own key:
-   `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
+3. Connect their client with their own key: `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
 
 Verify with `curl http://localhost:8001/health` once they confirm it's running. Do not ask them to paste the key into the chat.
 
 ### HTTP + Docker (managed, key handled for you)
-`marm-memory docker run` creates the managed container, writes the managed key
-file under `~/.marm/.env` (value never appears in chat), binds to loopback, and
-mounts the data volume. Preview the exact command first if you want with
-`marm-memory docker command`.
+
+`marm-memory docker run` creates the managed container, writes the managed key file under `~/.marm/.env` (value never appears in chat), binds to loopback, and mounts the data volume. Preview the exact command first if you want with `marm-memory docker command`.
 1. Run: `marm-memory docker run` (add `--expose-network` only for remote access, then configure a firewall and TLS proxy)
-2. Connect the client. The key lives in the managed key file; the user reads it
-   themselves (`marm-memory key path` shows the file, `marm-memory key reveal`
-   prints it in their own terminal) and pastes the value into their client, so it
-   never enters chat:
-   `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
-3. Optional, code-graph tools: the container only sees host paths that are
-   mounted, and `marm-memory docker run` refuses to alter an existing container.
-   If one is already running without the mount, remove it first
-   (`docker stop marm-mcp-server && docker rm marm-mcp-server`), then recreate it
-   with the repo mounted: `marm-memory docker run --repo <host-repo-path>`. Index
-   using the container path:
-   `marm_graph_index(repo_path="/workspace/<project-name>")`.
+2. Connect the client. The key lives in the managed key file; the user reads it themselves (`marm-memory key path` shows the file, `marm-memory key reveal` prints it in their own terminal) and pastes the value into their client, so it never enters chat: `claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer <paste-your-key>"`
+3. Optional, code-graph tools: the container only sees host paths that are mounted, and `marm-memory docker run` refuses to alter an existing container. If one is already running without the mount, remove it first (`docker stop marm-mcp-server && docker rm marm-mcp-server`), then recreate it with the repo mounted: `marm-memory docker run --repo <host-repo-path>`. Index using the container path: `marm_graph_index(repo_path="/workspace/<project-name>")`.
 
 Verify with `curl http://localhost:8001/health` and `marm-memory docker status`. Do not ask them to paste the key into the chat.
 
 ### STDIO + Local Python (no key)
-Connect this agent to the STDIO entry point. No key needed:
-   `claude mcp add marm-memory -- marm-mcp-stdio`
+Connect this agent to the STDIO entry point. No key needed: `claude mcp add marm-memory -- marm-mcp-stdio`
 
 ### STDIO + Docker (no key)
-Print the exact client command and wire it into the agent's MCP config:
-   `marm-memory docker stdio-command --client <agent>`
+Print the exact client command and wire it into the agent's MCP config: `marm-memory docker stdio-command --client <agent>`
 
-For any agent that is not Claude, write the equivalent entry into that agent's
-MCP config file instead of using the `claude` CLI. Same transport, same address
-or command. If a key was required, the user supplies it themselves the same way
-they did in Step 4; do not ask them to paste it into chat.
+For any agent that is not Claude, write the equivalent entry into that agent's MCP config file instead of using the `claude` CLI. Same transport, same address or command. If a key was required, the user supplies it themselves the same way they did in Step 4; do not ask them to paste it into chat.
 
 ---
 
 ## Step 5 - Multi-agent linking
 
-Ask: "Want to connect MARM to your other agents? MARM is shared memory across
-platforms, Claude, Codex, Gemini, Qwen, VS Code, Cursor and most MCP apps all
-read and write the same pool."
+Ask: "Want to connect MARM to your other agents? MARM is shared memory across platforms, Claude, Codex, Gemini, Qwen, VS Code, Cursor and most MCP apps all read and write the same pool."
 
 If yes:
-- Use the same transport for every agent. If a key was required, the user
-  provides it themselves for each additional client the same way they did in
-  Step 4; do not ask them to paste it into chat.
-- Use these docs to find the exact connection instructions for each client:
+  - Use the same transport for every agent. If a key was required, the user provides it themselves for each additional client the same way they did in Step 4; do not ask them to paste it into chat.
+  - Use these docs to find the exact connection instructions for each client:
 
-  **CLI clients** — [Claude Code](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#claude-code-recommended) · [Codex](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#codex-cli) · [Gemini CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#gemini-cli) · [Qwen CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#qwen-code) · [Linux variants](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-LINUX.md#client-connections) · [Docker/key](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#client-connections)
+**CLI clients** — [Claude Code](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#claude-code-recommended) · [Codex](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#codex-cli) · [Gemini CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#gemini-cli) · [Qwen CLI](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#qwen-code) · [Linux variants](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-LINUX.md#client-connections) · [Docker/key](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#client-connections)
 
-  **IDE agents** — [VS Code / Copilot Agent](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#vs-code-mcp--github-copilot-agent) · [Cursor](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#cursor) · [Docker/key IDE setup](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#vs-code-mcp--github-copilot-agent)
+**IDE agents** — [VS Code / Copilot Agent](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#vs-code-mcp--github-copilot-agent) · [Cursor](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md#cursor) · [Docker/key IDE setup](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#vs-code-mcp--github-copilot-agent)
 
-  **Remote/API platforms** — [xAI / Grok Remote MCP](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#xai--grok-remote-mcp) · [Platform integration](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-PLATFORMS.md)
+**Remote/API platforms** — [xAI / Grok Remote MCP](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md#xai--grok-remote-mcp) · [Platform integration](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-PLATFORMS.md)
 
 - Report which agents you wired up and which you could not find.
 
@@ -233,38 +170,23 @@ If no, skip.
 
 ## Step 6 - Handoff and start
 
-1. Start the server only if it is not already running, and honor the exact mode
-   chosen in Steps 3-4:
-   - STDIO (local or Docker): nothing to start; the client launches
-     `marm-mcp-stdio` (or the Docker STDIO command) on demand. Skip to the handoff.
-   - HTTP, local Python, loopback: `marm-memory fast-start-http` (skip if a
-     fast-start-http path already started it).
-   - HTTP, local Python, exposed: the user starts this themselves with their key
-     and `SERVER_HOST=0.0.0.0` (Step 4). Do not auto-run `fast-start-http` here; it
-     binds loopback without their key. Just verify once they confirm it is up.
-   - HTTP, Docker: `marm-memory docker run`, keeping `--expose-network` if the user
-     chose remote access in Step 2.
-2. Verify HTTP setups with a health check: `http://localhost:8001/health` should
-   return ok.
+1. Start the server only if it is not already running, and honor the exact mode chosen in Steps 3-4:
+  - STDIO (local or Docker): nothing to start; the client launches `marm-mcp-stdio` (or the Docker STDIO command) on demand. Skip to the handoff.
+  - HTTP, local Python, loopback: `marm-memory fast-start-http` (skip if a fast-start-http path already started it).
+  - HTTP, local Python, exposed: the user starts this themselves with their key and `SERVER_HOST=0.0.0.0` (Step 4). Do not auto-run `fast-start-http` here; it binds loopback without their key. Just verify once they confirm it is up.
+  - HTTP, Docker: `marm-memory docker run`, keeping `--expose-network` if the user chose remote access in Step 2.
+2. Verify HTTP setups with a health check: `http://localhost:8001/health` should return ok.
 3. Hand off with this message, adapted to what actually happened:
 
-   "Setup complete. Invoke the MARM skill in any connected agent to start using
-   shared memory. Restart your terminal so the MARM connection is picked up. If
-   you want to start your own server later, just ask."
+"Setup complete. Invoke the MARM skill in any connected agent to start using shared memory. Restart your terminal so the MARM connection is picked up. If you want to start your own server later, just ask."
 
-Setup is done. The executor contract above is now closed. Operate under the MARM
-protocol you loaded in Step 0.
+Setup is done. The executor contract above is now closed. Operate under the MARM protocol you loaded in Step 0.
 
 ---
 
 ## Edge cases
 
-- Cross-platform paths: Claude alone has several possible config locations by
-  install method. Check all known paths in Step 5, and accept a user-provided
-  path if the scan misses one.
-- Stale skill file: handled by the Step 0 freshness check. If the source version
-  is higher, tell the user to re-run `marm-memory init`.
-- Remote server: the connect command in Step 4 uses `localhost`. Swap in the
-  real host address when the server runs elsewhere.
-- Non-Claude agents: the `claude mcp add` commands are examples. Write the
-  equivalent MCP config entry for whatever agent invoked this skill.
+- Cross-platform paths: Claude alone has several possible config locations by install method. Check all known paths in Step 5, and accept a user-provided path if the scan misses one.
+- Stale skill file: handled by the Step 0 freshness check. If the source version is higher, tell the user to re-run `marm-memory init`.
+- Remote server: the connect command in Step 4 uses `localhost`. Swap in the real host address when the server runs elsewhere.
+- Non-Claude agents: the `claude mcp add` commands are examples. Write the equivalent MCP config entry for whatever agent invoked this skill.


### PR DESCRIPTION
v2.38.0 strengthens MARM’s internal reliability without changing its MCP tools, parameters, stored data, or HTTP/STDIO behavior.

- Mypy now checks all 110 server modules, with a strict baseline that prevents new type errors from landing unnoticed.
- Core contracts were tightened across memory storage, recall, embeddings, compaction, queues, graph coordination, FastAPI paths, and CLI services.

- The encoder now accurately distinguishes single-text and batch embedding results, while migration and rechunking continue to support injected test encoders.

- Ruff is now the single formatter/linter used locally and in CI; conflicting Black, isort, and Flake8 dependencies were removed.

- Full validation passed: 1,078 tests, server.json validation, Mypy gate, and v2.38.0 wheel/sdist build.

Two known graph-shutdown race findings remain deliberately visible in the Mypy baseline and are documented for a dedicated lifecycle fix rather than suppressed in this type-safety release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an engine pre-flight step to setup instructions, including detection or installation before protocol loading.
  * Improved notebook synchronization handling for pending or failed updates, including reuse of existing memory links.

* **Documentation**
  * Updated installation, setup, and changelog documentation for version 2.38.0.
  * Clarified transport selection, runtime configuration, linking, handoff, and edge-case procedures.

* **Chores**
  * Expanded type checking across the server package and reduced the tracked error baseline.
  * Standardized formatting and linting around Ruff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->