### PR TITLE
ci: build and test dependency bumps before they can be merged

### DIFF
--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -1,0 +1,75 @@
+name: Console CI
+
+# The release workflow already builds the console, but it runs on a version tag,
+# so a broken console dependency surfaced there fails a release that is already
+# tagged. Dependabot console PRs otherwise pass on the Ruff job alone, which never
+# reads package.json or the lockfile.
+#
+# No `paths:` filter, deliberately. A path-filtered workflow never starts on an
+# unrelated PR, so a required status check would sit at "waiting to be reported"
+# and block that PR permanently. The job runs every time and decides internally
+# whether there is work, which keeps it eligible to be a required check.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: console-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  console:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect relevant changes
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh pr diff "${{ github.event.number }}" --name-only)
+          if printf '%s\n' "$files" | grep -qE '^(marm-console/|\.github/workflows/console\.yml$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No console paths changed. Reporting success without installing."
+          fi
+
+      # Node and pnpm versions match publish-mcp.yml's console build. If they
+      # drift, this job stops predicting the release build.
+      - name: Set up Node
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Set up pnpm
+        if: steps.scope.outputs.run == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10'
+
+      # --frozen-lockfile, so a package.json edit that was never locked fails
+      # here rather than resolving to something the release build will not get.
+      - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
+        working-directory: marm-console
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        if: steps.scope.outputs.run == 'true'
+        working-directory: marm-console
+        run: pnpm typecheck
+
+      # The step that catches peer-dependency breakage. A plugin major that
+      # outruns its host (plugin-react 6 needs vite 8) installs and typechecks
+      # clean, then fails loading vite.config.ts.
+      - name: Build
+        if: steps.scope.outputs.run == 'true'
+        working-directory: marm-console
+        run: pnpm build

--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -16,16 +16,25 @@ permissions:
   contents: read
   pull-requests: read
 
+# Keyed on the PR number, not head_ref: two PRs from different forks can both
+# use a branch called `main`, and sharing a group means one cancels the other's
+# required check, leaving that PR blocked with nothing to report.
 concurrency:
-  group: console-${{ github.head_ref || github.ref }}
+  group: console-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   console:
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false because `pnpm install` below runs lifecycle
+      # scripts from a PR-controlled lockfile, and the default leaves the job's
+      # token in .git/config where those scripts can read it. The gh call below
+      # passes GH_TOKEN itself, so it is unaffected.
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Detect relevant changes
         id: scope

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -56,7 +56,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r marm-mcp-server/requirements.txt
           pip install -e './marm-mcp-server' --no-deps
-          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil ruff==0.16.2
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil==7.2.2.20260518 ruff==0.16.2
 
       - name: Validate server.json
         run: |

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -56,12 +56,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r marm-mcp-server/requirements.txt
           pip install -e './marm-mcp-server' --no-deps
-          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy ruff
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 ruff==0.16.2
 
       - name: Validate server.json
         run: |
           cd marm-mcp-server
           python validate_server_json.py
+
+      # Gates the release on the type baseline. Both tools above are pinned
+      # because this gate compares against an absolute error count and Ruff
+      # promotes rules between minor releases; unpinned, either can fail a tag
+      # whose code is unchanged.
+      - name: Typecheck gate
+        run: python scripts/typecheck.py
+
+      - name: Lint and format
+        working-directory: marm-mcp-server
+        run: |
+          ruff check
+          ruff format --check
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -56,7 +56,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r marm-mcp-server/requirements.txt
           pip install -e './marm-mcp-server' --no-deps
-          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 ruff==0.16.2
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil ruff==0.16.2
 
       - name: Validate server.json
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,17 +28,24 @@ permissions:
   pull-requests: read
 
 # Several pushes in a row would otherwise queue a full suite each. Only the
-# newest run per ref matters.
+# newest run per ref matters. Keyed on the PR number rather than head_ref: two
+# PRs from different forks can both use a branch called `main`, and sharing a
+# group means one cancels the other's required check.
 concurrency:
-  group: python-${{ github.head_ref || github.ref }}
+  group: python-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   python:
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false because pip installs and runs PR-controlled
+      # package code, and the default leaves the job's token in .git/config where
+      # that code can read it. The gh call below passes GH_TOKEN itself.
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Replaces the trigger-level path filter. Asking the API for the PR's file
       # list avoids reconstructing a diff range, which is fragile on force-pushes
@@ -84,17 +91,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      # mypy is pinned because scripts/typecheck.py gates on an absolute error
-      # count. A different mypy reports a different count and fails the job on a
-      # PR that changed nothing. Keep this equal to the local mypy that set
-      # BASELINE.
+      # mypy and its stubs are pinned because scripts/typecheck.py gates on an
+      # absolute error count, and either one reports a different count at a
+      # different version, failing a PR that changed nothing. The dev extra in
+      # pyproject.toml pins the same versions, so a developer checks against
+      # this checker rather than a newer one that resolves from a floor.
       - name: Install dependencies
         if: steps.scope.outputs.run == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r marm-mcp-server/requirements.txt
           pip install -e './marm-mcp-server' --no-deps
-          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil==7.2.2.20260518
 
       - name: Validate server.json
         if: steps.scope.outputs.run == 'true'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,119 @@
+name: Python CI
+
+# Ruff alone passes a dependency bump that breaks at runtime: it reads style, not
+# behavior. The test suite lives in publish-mcp.yml, which runs on a version tag,
+# so without this a bad pip bump is found after the tag is already spent.
+#
+# No `paths:` filter, deliberately. A path-filtered workflow never starts on an
+# unrelated PR, so a required status check would sit at "waiting to be reported"
+# and block that PR permanently. The job runs every time and decides internally
+# whether there is work, which keeps it eligible to be a required check.
+#
+# Both events run the typecheck gate; only pull requests run the suite. mypy needs
+# the real dependencies installed (without fastapi/pydantic/numpy it reports
+# unresolved imports and the baseline count is meaningless), so there is no
+# cheaper standalone typecheck job to split out.
+#
+# pull_request carries no branch filter on purpose, so a PR into a release branch
+# is checked the same as one into MARM-main.
+on:
+  push:
+    branches:
+      - MARM-main
+      - 'release/**'
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Several pushes in a row would otherwise queue a full suite each. Only the
+# newest run per ref matters.
+concurrency:
+  group: python-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Replaces the trigger-level path filter. Asking the API for the PR's file
+      # list avoids reconstructing a diff range, which is fragile on force-pushes
+      # and on a branch's first push.
+      - name: Detect relevant changes
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh pr diff "${{ github.event.number }}" --name-only)
+          if printf '%s\n' "$files" | grep -qE '^(marm-mcp-server/|scripts/|\.github/workflows/python\.yml$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No Python-owned paths changed. Reporting success without installing."
+          fi
+
+      # Python version matches publish-mcp.yml's validate-and-test. If they
+      # drift, this job stops predicting the release gate.
+      - name: Set up Python
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Concept extraction tests are skipif-guarded on the model being present,
+      # so without this a spaCy bump would skip the very tests that would catch
+      # it and still report green.
+      - name: Bundle concept extraction model
+        if: steps.scope.outputs.run == 'true'
+        run: python marm-mcp-server/scripts/bundle-concept-model.py
+
+      - name: Cache pip
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('marm-mcp-server/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # mypy is pinned because scripts/typecheck.py gates on an absolute error
+      # count. A different mypy reports a different count and fails the job on a
+      # PR that changed nothing. Keep this equal to the local mypy that set
+      # BASELINE.
+      - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r marm-mcp-server/requirements.txt
+          pip install -e './marm-mcp-server' --no-deps
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0
+
+      - name: Validate server.json
+        if: steps.scope.outputs.run == 'true'
+        working-directory: marm-mcp-server
+        run: python validate_server_json.py
+
+      # Ahead of the tests: a dependency that dropped or added type information
+      # shows up here in seconds rather than after the full suite.
+      - name: Typecheck gate
+        if: steps.scope.outputs.run == 'true'
+        run: python scripts/typecheck.py
+
+      # Pull requests only: a direct push gets the type gate above, which is the
+      # part that cannot wait, while the suite stays where it can block a merge.
+      #
+      # docker is excluded because no image is built here, so those tests would
+      # self-skip anyway. smoke_lifecycle races a real HTTP stop inside a fixed
+      # window and is environment-sensitive, which publish-mcp.yml also excludes.
+      - name: Run tests
+        if: steps.scope.outputs.run == 'true' && github.event_name == 'pull_request'
+        working-directory: marm-mcp-server
+        run: python -m pytest tests/ -q -m "not docker and not smoke_lifecycle"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -94,7 +94,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r marm-mcp-server/requirements.txt
           pip install -e './marm-mcp-server' --no-deps
-          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil
 
       - name: Validate server.json
         if: steps.scope.outputs.run == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 ### Fixed: A Doc Save No Longer Fails Or Duplicates Its Memory Mirror
 
 - Saving a doc commits the docs row first, then links it to a memories mirror in a second write. If that link failed, the save reported an error even though the doc was already stored durably, and the mirror row was left behind pointing at nothing.
-- The link failure is now reported as `mirror_status: "pending"` on an otherwise successful save, matching how a failed mirror write already behaved.
-- A later save repairs the link rather than creating a second mirror. The mirror write resolves a doc's existing mirror by its `doc_id`, so a doc keeps exactly one mirror row however many times the link has to be retried. Installs that already accumulated duplicate mirrors keep them; the fix stops new ones.
+- The link failure is now reported as `mirror_status: "pending"` on an otherwise successful save, matching how a failed mirror write already behaved. The response's `memory_id` names the mirror row whenever one was written, including in that pending state; previously both pending causes reported the doc's stored link, which is null or points at a deleted row precisely when an unlinked mirror exists. It is null only when the mirror write itself failed and there is no row to name.
+- A later save repairs the link rather than creating a second mirror. The mirror write resolves a doc's existing mirror by its `doc_id`, so a doc keeps exactly one mirror row however many times the link has to be retried. That resolve now runs whenever the linked id fails to match a row, not only when the caller has no id at all: on an install carrying duplicates from before this fix, deleting the linked mirror left the link dangling and the next save added a third row on top of the surviving duplicate.
+- Installs that already accumulated duplicate mirrors keep them. Removing them means deleting memory rows, their chunks, and their concept provenance, which is a migration rather than a fix and is not done silently. Saves do now converge on a single one of them: the mirror is resolved by row id rather than by timestamp, because the save rewrites the timestamp it was ordering on and so kept picking whichever duplicate it had not just written, alternating between them indefinitely while a doc's link kept failing.
 
 ### Developer Note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,17 @@
 - A later save repairs the link rather than creating a second mirror. The mirror write resolves a doc's existing mirror by its `doc_id`, so a doc keeps exactly one mirror row however many times the link has to be retried. That resolve now runs whenever the linked id fails to match a row, not only when the caller has no id at all: on an install carrying duplicates from before this fix, deleting the linked mirror left the link dangling and the next save added a third row on top of the surviving duplicate.
 - Installs that already accumulated duplicate mirrors keep them. Removing them means deleting memory rows, their chunks, and their concept provenance, which is a migration rather than a fix and is not done silently. Saves do now converge on a single one of them: the mirror is resolved by row id rather than by timestamp, because the save rewrites the timestamp it was ordering on and so kept picking whichever duplicate it had not just written, alternating between them indefinitely while a doc's link kept failing.
 
+### Fixed: A Never-Indexed Project Is Indexed On The First Poll
+
+- A project that had never been indexed waited out the full `GRAPH_AUTO_INDEX_FULL_INTERVAL` (300s) before its first index whenever the machine had been running for less than that interval. Fresh containers and just-rebooted machines were affected; a long-running host was not, which is why this stayed quiet.
+- The cause was the "last indexed" marker starting at `0.0` and being compared against `time.monotonic()`, which counts from boot rather than from the epoch. At `0.0` a project that had never been indexed was indistinguishable from one indexed the moment the machine started. The marker now starts at negative infinity, so "never" cannot read as "just now" at any uptime.
+
 ### Developer Note
 
 - The typecheck gate ends at two deliberately visible graph-shutdown race findings. They are documented in `docs/current/graph-client-none-guard.md` rather than suppressed: resolving them requires a supervisor lifecycle change, not an annotation workaround.
+- The type baseline is now platform-independent. Mypy narrows platform on `sys.platform` and not on `os.name`, so Windows-only branches guarded by `os.name` were analyzed on Linux, where the flags they reach for do not exist. The count is now identical on both.
+- `pip install -e ".[dev]"` pins mypy, its type stubs, and Ruff to the versions the gates pin, rather than flooring them. A floor resolved a different checker than CI ran, which defeats a gate that compares an absolute error count. Upgrading any of the three is a deliberate re-baseline, not an incidental dependency bump.
+- Pull requests now build the Console and run the Python suite. Both previously ran only on a version tag, so a dependency bump that broke either was found after the tag was already spent.
 
 </details>
 

--- a/marm-mcp-server/marm_mcp_server/console/cli.py
+++ b/marm-mcp-server/marm_mcp_server/console/cli.py
@@ -96,7 +96,8 @@ def run_console(
         bound_log_file(log_path)
         flags = 0
         kwargs: dict[str, Any] = {}
-        if os.name == "nt":
+        # sys.platform, not os.name: mypy narrows platform on the former only.
+        if sys.platform == "win32":
             flags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
         else:
             kwargs["start_new_session"] = True

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
@@ -166,7 +166,11 @@ class _Watched:
     def __init__(self, root: str) -> None:
         self.root = root
         self.signature: Optional[tuple[str, bool]] = None
-        self.last_full: float = 0.0
+        # -inf, not 0.0: this is compared as `monotonic() - last_full < interval`,
+        # and monotonic() counts from boot. At 0.0 a never-indexed project reads as
+        # "indexed at boot", so on a machine up for less than the interval its
+        # first index waited the interval out instead of running immediately.
+        self.last_full: float = float("-inf")
         self.last_indexed: Optional[str] = None
         # Set after a failure so the next attempt waits out a backoff instead of
         # retrying on the next cycle. Cleared by a success.

--- a/marm-mcp-server/marm_mcp_server/core/memory_ops.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_ops.py
@@ -395,11 +395,11 @@ async def _store_doc_mirror(
     of the memory profile. If existing_memory_id is provided and its row
     still exists, the row is replaced in place (keeps its id stable, so
     a routine resave never needs to touch docs.memory_id). Without a usable
-    id, the doc's existing mirror is resolved by metadata.doc_id, so the
-    write is idempotent per doc even when the caller lost the id. Only when
-    neither locates a row is a fresh one created with a new id -- that is
-    the repair path for a doc whose prior mirror was deleted out from under
-    it (e.g. via a direct Console memory delete).
+    id, or with one that no longer resolves, the doc's existing mirror is
+    resolved by metadata.doc_id, so the write is idempotent per doc even when
+    the caller lost the id. Only when neither locates a row is a fresh one
+    created with a new id -- that is the repair path for a doc whose prior
+    mirror was deleted out from under it (e.g. via a direct Console delete).
     """
     sanitized_content = sanitize_content(content)
     content_hash = compute_content_hash(sanitized_content)
@@ -415,49 +415,60 @@ async def _store_doc_mirror(
     timestamp = datetime.now(timezone.utc).isoformat()
 
     with mem.get_connection() as conn:
+
+        def _replace_in_place(row_id: str) -> bool:
+            cursor = conn.execute(
+                """
+                UPDATE memories SET content = ?, session_name = ?, embedding = ?,
+                   content_hash = ?, timestamp = ?, context_type = 'doc',
+                   metadata = ?, project = ?, platform = ?
+                WHERE id = ?
+                """,
+                (
+                    sanitized_content,
+                    session,
+                    embedding_bytes,
+                    content_hash,
+                    timestamp,
+                    json.dumps(metadata),
+                    project,
+                    platform,
+                    row_id,
+                ),
+            )
+            return cursor.rowcount > 0
+
         conn.execute("BEGIN IMMEDIATE")
         try:
-            # A caller with no id may still have a mirror: docs.memory_id is set
-            # in a second, separate write, so a failure between the two leaves
-            # this row orphaned rather than absent. Resolving it by the doc_id
-            # already in metadata makes the write idempotent per doc; creating a
-            # fresh row instead would duplicate the mirror on every later save.
-            # Inside the transaction so the resolve cannot race the write.
-            if not existing_memory_id and metadata.get("doc_id") is not None:
+            replaced = False
+            if existing_memory_id:
+                replaced = _replace_in_place(existing_memory_id)
+
+            # Keyed on the id having missed, not on the caller having none:
+            # docs.memory_id is written second, so a failure between the two
+            # writes leaves a mirror orphaned rather than absent, and a deleted
+            # linked row can still leave an older duplicate behind. Either way an
+            # INSERT here would add a mirror to a doc that already has one, so
+            # the doc_id in metadata resolves it instead. Inside the transaction
+            # so the resolve cannot race the write.
+            #
+            # Ordered by id, not timestamp: the write below mutates timestamp, so
+            # ordering on it made each save pick whichever duplicate it had not
+            # just touched. On a doc with two mirrors and a link that keeps
+            # failing, saves alternated between them forever. id never changes.
+            if not replaced and metadata.get("doc_id") is not None:
                 orphan = conn.execute(
                     """
                     SELECT id FROM memories
                     WHERE context_type = 'doc'
                       AND json_extract(metadata, '$.doc_id') = ?
-                    ORDER BY timestamp LIMIT 1
+                    ORDER BY id LIMIT 1
                     """,
                     (metadata["doc_id"],),
                 ).fetchone()
                 if orphan is not None:
                     existing_memory_id = orphan[0]
-
-            replaced = False
-            if existing_memory_id:
-                cursor = conn.execute(
-                    """
-                    UPDATE memories SET content = ?, session_name = ?, embedding = ?,
-                       content_hash = ?, timestamp = ?, context_type = 'doc',
-                       metadata = ?, project = ?, platform = ?
-                    WHERE id = ?
-                    """,
-                    (
-                        sanitized_content,
-                        session,
-                        embedding_bytes,
-                        content_hash,
-                        timestamp,
-                        json.dumps(metadata),
-                        project,
-                        platform,
-                        existing_memory_id,
-                    ),
-                )
-                replaced = cursor.rowcount > 0
+                    replaced = _replace_in_place(orphan[0])
 
             if replaced:
                 assert existing_memory_id is not None

--- a/marm-mcp-server/marm_mcp_server/core/runtime_manager.py
+++ b/marm-mcp-server/marm_mcp_server/core/runtime_manager.py
@@ -308,7 +308,10 @@ def start_background(
     env["MARM_RUNTIME_PROFILE"] = profile
     creationflags = 0
     kwargs: dict[str, Any] = {}
-    if os.name == "nt":
+    # sys.platform, not os.name: mypy narrows platform on the former only, so
+    # with os.name it checks this branch on Linux, where these two flags do not
+    # exist. Equivalent at runtime.
+    if sys.platform == "win32":
         creationflags = (
             subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
         )

--- a/marm-mcp-server/marm_mcp_server/services/notebook.py
+++ b/marm-mcp-server/marm_mcp_server/services/notebook.py
@@ -187,6 +187,10 @@ async def _save(
     memories mirror that gives the concept graph reach is best-effort --
     a failed mirror sync never rolls back the durable save, it just
     reports mirror_status='pending' so a later save can repair it.
+
+    memory_id names the mirror row when one was written, whatever
+    mirror_status says; on 'pending' it is the row the docs link does not
+    point at yet, and it is null only when the mirror write itself failed.
     """
     if not name or not name.strip():
         return {"status": "error", "message": "name is required for action='save'"}
@@ -292,8 +296,13 @@ async def _save(
         "status": "success",
         "message": f"📄 Doc '{name}' {verb}{promoted_note}",
         "doc_id": doc_row.id,
+        # Keyed on a mirror row existing, not on the link being recorded. Both
+        # pending causes used to report the doc's old link, which was right while
+        # pending only meant the mirror write itself failed. Now that a written
+        # mirror can go unlinked, that answer names a dangling or absent row while
+        # a real mirror exists; mirror_status already says the link is not saved.
         "memory_id": mirror_memory_id
-        if mirror_status == "synced"
+        if mirror_memory_id is not None
         else doc_row.memory_id,
         "mirror_status": mirror_status,
     }

--- a/marm-mcp-server/marm_mcp_server/utils/security.py
+++ b/marm-mcp-server/marm_mcp_server/utils/security.py
@@ -23,7 +23,15 @@ def generate_api_key(length: int = 40) -> str:
 
 
 def _set_windows_owner_only_dacl(path: Path) -> bool:
-    """Replace a file DACL with one full-control entry for the process user."""
+    """Replace a file DACL with one full-control entry for the process user.
+
+    Guards its own platform rather than trusting the caller: everything below
+    dereferences ctypes.WinDLL, which does not exist off Windows, so a direct
+    call elsewhere would raise AttributeError instead of returning False.
+    """
+    if sys.platform != "win32":
+        return False
+
     from ctypes import wintypes
 
     token_query = 0x0008

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -70,12 +70,19 @@ dev = [
     "build>=1.2.2",
     "jsonschema>=4.0.0",
     "requests>=2.31.0",
-    "mypy>=2.3.0",
-    "types-psutil>=6.0.0",
+    # Pinned, not floored, unlike everything above: these three decide whether
+    # a gate passes by absolute output rather than by pass/fail, so a floor lets
+    # a developer check against a different checker than CI does. mypy and its
+    # stubs set the error count scripts/typecheck.py compares to BASELINE, and
+    # ruff promotes rules between minor releases (0.16.2 graduated RUF036 and
+    # failed a PR whose code had not changed). Upgrading any of them is a
+    # deliberate re-baseline: bump here and in every workflow that pins them.
+    "mypy==2.1.0",
+    "types-psutil==7.2.2.20260518",
     # ruff owns both lint and format. black/isort/flake8 were removed rather
     # than satisfied: black disagreed with ruff format on 13 files, and flake8
     # only reported E501 against its own 79-char default while this uses 88.
-    "ruff>=0.4.0",
+    "ruff==0.16.2",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 

--- a/marm-mcp-server/tests/test_notebook_service.py
+++ b/marm-mcp-server/tests/test_notebook_service.py
@@ -1,3 +1,4 @@
+import uuid
 import sqlite3
 import sys
 import pytest
@@ -459,6 +460,9 @@ async def test_save_mirror_write_failure_still_saves_doc_as_pending(
     assert result["status"] == "success"
     assert result["mirror_status"] == "pending"
     assert result["doc_id"] is not None
+    # The other pending cause: no mirror row was written, so there is no id to
+    # report. This half is released behavior and must not start naming a row.
+    assert result["memory_id"] is None
 
     with sqlite3.connect(str(tmp_path / "nb-docs.db")) as conn:
         row = conn.execute(
@@ -466,6 +470,14 @@ async def test_save_mirror_write_failure_still_saves_doc_as_pending(
         ).fetchone()
     assert row[0] == "durable content"
     assert row[1] is None
+
+    with sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM memories WHERE context_type = 'doc'"
+            ).fetchone()[0]
+            == 0
+        )
 
 
 @pytest.mark.asyncio
@@ -526,10 +538,13 @@ async def test_save_reports_pending_when_docs_memory_id_link_fails(
     # The mirror itself exists, orphaned from the docs row.
     with sqlite3.connect(str(tmp_path / "nb-test.db")) as conn:
         mirrors = conn.execute(
-            "SELECT content FROM memories WHERE context_type = 'doc'"
+            "SELECT id, content FROM memories WHERE context_type = 'doc'"
         ).fetchall()
     assert len(mirrors) == 1
-    assert mirrors[0][0] == "durable content"
+    assert mirrors[0][1] == "durable content"
+    # Names the row that exists, not the link that was never written. Reporting
+    # docs.memory_id here would hand back NULL while a real mirror sits orphaned.
+    assert result["memory_id"] == mirrors[0][0]
 
 
 @pytest.mark.asyncio
@@ -579,3 +594,120 @@ async def test_save_after_failed_link_repairs_instead_of_duplicating_mirror(
             "SELECT memory_id FROM docs WHERE name = 'repairable'"
         ).fetchone()[0]
     assert linked == orphan_id
+
+
+@pytest.mark.asyncio
+async def test_save_with_dangling_link_reuses_a_surviving_duplicate_mirror(
+    notebook_svc, tmp_path
+):
+    """A stale docs.memory_id must not add a mirror when one already survives.
+
+    Reaching this needs a doc that already has two mirrors, which only an
+    install predating the doc_id resolve can have. Deleting the linked one
+    leaves docs.memory_id dangling, and resolving by doc_id only when the
+    caller passed no id at all skipped the survivor and inserted a third row.
+    """
+    dispatch, _ = notebook_svc
+    first = await dispatch(action="save", name="dupe", data="version one")
+    linked_id = first["memory_id"]
+    db = str(tmp_path / "nb-test.db")
+
+    duplicate_id = str(uuid.uuid4())
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            INSERT INTO memories
+                (id, session_name, content, embedding, content_hash, timestamp,
+                 context_type, metadata, project, platform)
+            SELECT ?, session_name, content, embedding, content_hash, timestamp,
+                   context_type, metadata, project, platform
+            FROM memories WHERE id = ?
+            """,
+            (duplicate_id, linked_id),
+        )
+        conn.execute("DELETE FROM memories WHERE id = ?", (linked_id,))
+        conn.commit()
+
+    second = await dispatch(action="save", name="dupe", data="version two")
+
+    assert second["memory_id"] == duplicate_id
+    with sqlite3.connect(db) as conn:
+        mirrors = conn.execute(
+            "SELECT id, content FROM memories WHERE context_type = 'doc'"
+        ).fetchall()
+    assert mirrors == [(duplicate_id, "version two")]
+
+    with sqlite3.connect(str(tmp_path / "nb-docs.db")) as conn:
+        linked = conn.execute(
+            "SELECT memory_id FROM docs WHERE name = 'dupe'"
+        ).fetchone()[0]
+    assert linked == duplicate_id
+
+
+@pytest.mark.asyncio
+async def test_repeated_saves_converge_on_one_of_two_duplicate_mirrors(
+    notebook_svc, tmp_path, monkeypatch
+):
+    """Resolution must be stable across saves, not just within one save.
+
+    The resolve reads a column the write then mutates, so ordering by timestamp
+    made each save pick whichever duplicate it had not just touched, alternating
+    between them and leaving whichever it skipped stale.
+    """
+    dispatch, _ = notebook_svc
+    from marm_mcp_server.core.docs_db import DocsDB
+
+    first = await dispatch(action="save", name="tie", data="version one")
+    db = str(tmp_path / "nb-test.db")
+
+    # Two duplicates sharing one doc_id and one timestamp, as rows cloned by the
+    # pre-fix double-insert would be. The linked row goes, so neither is linked.
+    clones = [str(uuid.uuid4()) for _ in range(2)]
+    with sqlite3.connect(db) as conn:
+        for clone_id in clones:
+            conn.execute(
+                """
+                INSERT INTO memories
+                    (id, session_name, content, embedding, content_hash, timestamp,
+                     context_type, metadata, project, platform)
+                SELECT ?, session_name, content, embedding, content_hash, timestamp,
+                       context_type, metadata, project, platform
+                FROM memories WHERE id = ?
+                """,
+                (clone_id, first["memory_id"]),
+            )
+        conn.execute("DELETE FROM memories WHERE id = ?", (first["memory_id"],))
+        conn.commit()
+
+    # The link never succeeds, so every save arrives with a stale docs.memory_id
+    # and has to re-resolve. Without that, the first save repairs the link and
+    # later saves never reach the resolve at all, which hides the instability.
+    def boom(self, conn, doc_id, memory_id):
+        raise sqlite3.OperationalError("docs db is locked")
+
+    monkeypatch.setattr(DocsDB, "set_memory_id", boom)
+
+    # Asserted against the rows themselves: a pending save reports the doc's old
+    # link as memory_id, not the row it wrote, so the response cannot show this.
+    written = []
+    for n in range(2, 6):
+        await dispatch(action="save", name="tie", data=f"version {n}")
+        with sqlite3.connect(db) as conn:
+            written.append(
+                conn.execute(
+                    "SELECT id FROM memories WHERE context_type = 'doc' AND content = ?",
+                    (f"version {n}",),
+                ).fetchone()[0]
+            )
+
+    assert len(set(written)) == 1, f"saves alternated between duplicates: {written}"
+    with sqlite3.connect(db) as conn:
+        rows = dict(
+            conn.execute(
+                "SELECT id, content FROM memories WHERE context_type = 'doc'"
+            ).fetchall()
+        )
+    assert rows[written[0]] == "version 5"
+    # The skipped duplicate is left alone, never half-updated.
+    other = next(c for c in clones if c != written[0])
+    assert rows[other] == "version one"

--- a/scripts/check-console-pr.py
+++ b/scripts/check-console-pr.py
@@ -48,6 +48,7 @@ def run(
         text=True,
         timeout=timeout,
         shell=False,
+        check=False,
     )
 
 
@@ -104,7 +105,11 @@ def check(ref: str, label: str, workdir: Path) -> tuple[bool, str, set[str]]:
         except subprocess.TimeoutExpired:
             return False, f"{name} timed out", set()
         if proc.returncode != 0:
-            return False, f"{name} failed\n{_first_error(proc.stdout + proc.stderr)}", set()
+            return (
+                False,
+                f"{name} failed\n{_first_error(proc.stdout + proc.stderr)}",
+                set(),
+            )
 
     return True, "install, typecheck, build all passed", assets(tree)
 
@@ -116,10 +121,20 @@ def _first_error(output: str) -> str:
         for line in output.splitlines()
         if any(
             marker in line
-            for marker in ("error", "Error", "ERR_", "failed", "not defined", "Cannot find")
+            for marker in (
+                "error",
+                "Error",
+                "ERR_",
+                "failed",
+                "not defined",
+                "Cannot find",
+            )
         )
     ]
-    return "\n".join(f"      {line.strip()}" for line in keep[:8]) or "      (no error lines captured)"
+    return (
+        "\n".join(f"      {line.strip()}" for line in keep[:8])
+        or "      (no error lines captured)"
+    )
 
 
 def prune(workdir: Path) -> None:
@@ -179,7 +194,9 @@ def main() -> int:
                 # Every later verdict would be meaningless: a failure could be
                 # the base branch rather than the PR.
                 print(f"\nFAIL  baseline {BASE_REF} does not build.\n{detail}")
-                print("Fix the base branch first; PR verdicts cannot be trusted until then.")
+                print(
+                    "Fix the base branch first; PR verdicts cannot be trusted until then."
+                )
                 return 2
             print(f"  baseline ok, {len(baseline)} asset(s)")
 
@@ -188,7 +205,9 @@ def main() -> int:
             ok, detail, produced = check(ref, label, workdir)
             if ok and baseline:
                 if produced == baseline:
-                    detail += "\n      bundle identical to baseline (same content hashes)"
+                    detail += (
+                        "\n      bundle identical to baseline (same content hashes)"
+                    )
                 else:
                     changed = sorted(produced ^ baseline)
                     detail += "\n      bundle changed: " + ", ".join(changed[:6])

--- a/scripts/check-console-pr.py
+++ b/scripts/check-console-pr.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Decide whether a console dependency PR is safe to merge.
+
+Green CI does not answer this. The Ruff job never reads package.json or the
+lockfile, and the console build only runs on a release tag, so a broken
+dependency stays invisible until a tag is already cut.
+
+Builds the PR in a throwaway git worktree, so the working tree, the current
+branch, and marm-console/node_modules are untouched. Compares the emitted asset
+filenames against the base branch: those names are content hashes, so identical
+names mean an identical bundle.
+
+    python scripts/check-console-pr.py 137          one PR
+    python scripts/check-console-pr.py 135 136 137  several
+    python scripts/check-console-pr.py --ref MARM-main   a branch instead
+
+Needs node, pnpm, and gh on PATH. Exits non-zero if any target fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONSOLE = "marm-console"
+ASSET_DIR = "artifacts/marm-console/dist/public/assets"
+BASE_REF = "origin/MARM-main"
+
+
+def run(
+    cmd: list[str], cwd: Path, timeout: int = 900
+) -> subprocess.CompletedProcess[str]:
+    # Resolved rather than passed bare: pnpm is a .cmd shim on Windows, which
+    # CreateProcess cannot launch by name without a shell. Resolving keeps
+    # shell=False instead of reaching for shell=True.
+    resolved = shutil.which(cmd[0]) or cmd[0]
+    return subprocess.run(
+        [resolved, *cmd[1:]],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        shell=False,
+    )
+
+
+def tool_missing() -> list[str]:
+    return [t for t in ("node", "pnpm", "gh", "git") if shutil.which(t) is None]
+
+
+def fetch_pr(number: str) -> tuple[str, str]:
+    """Fetch a PR into a local ref. Returns (ref, label suffix).
+
+    Prefers refs/pull/N/merge, GitHub's preview of the PR already merged into
+    the base. Testing the head alone compares a branch that may predate recent
+    base commits, which reports every intervening change as a difference in this
+    PR. Falls back to the head when no merge ref exists, which is GitHub's way
+    of saying the PR does not merge cleanly.
+    """
+    local = f"console-check/pr{number}"
+    for ref, suffix in ((f"refs/pull/{number}/merge", "merged"), (f"refs/pull/{number}/head", "head only, does not merge cleanly")):
+        proc = run(
+            ["git", "fetch", "--force", "origin", f"{ref}:{local}"], REPO_ROOT, 120
+        )
+        if proc.returncode == 0:
+            return local, suffix
+    raise RuntimeError(f"could not fetch PR {number}: no merge or head ref")
+
+
+def assets(worktree: Path) -> set[str]:
+    d = worktree / CONSOLE / ASSET_DIR
+    return {p.name for p in d.iterdir()} if d.is_dir() else set()
+
+
+def check(ref: str, label: str, workdir: Path) -> tuple[bool, str, set[str]]:
+    """Install, typecheck, and build one ref. Returns (ok, detail, asset names)."""
+    tree = workdir / label.replace("/", "_").replace("#", "")
+    add = run(["git", "worktree", "add", "-q", "--detach", str(tree), ref], REPO_ROOT)
+    if add.returncode != 0:
+        return False, f"worktree failed: {add.stderr.strip()}", set()
+
+    console = tree / CONSOLE
+    for name, cmd in (
+        ("install", ["pnpm", "install", "--frozen-lockfile"]),
+        ("typecheck", ["pnpm", "typecheck"]),
+        ("build", ["pnpm", "build"]),
+    ):
+        print(f"  {label}: {name} ...", flush=True)
+        try:
+            proc = run(cmd, console)
+        except subprocess.TimeoutExpired:
+            return False, f"{name} timed out", set()
+        if proc.returncode != 0:
+            return False, f"{name} failed\n{_first_error(proc.stdout + proc.stderr)}", set()
+
+    return True, "install, typecheck, build all passed", assets(tree)
+
+
+def _first_error(output: str) -> str:
+    """The lines a reader needs, not the whole log."""
+    keep = [
+        line
+        for line in output.splitlines()
+        if any(
+            marker in line
+            for marker in ("error", "Error", "ERR_", "failed", "not defined", "Cannot find")
+        )
+    ]
+    return "\n".join(f"      {line.strip()}" for line in keep[:8]) or "      (no error lines captured)"
+
+
+def prune(workdir: Path) -> None:
+    """Drop git's worktree records. The directories themselves live in the OS
+    temp dir; nested node_modules paths regularly defeat rmtree on Windows, and
+    a leftover temp directory is not worth failing the run over."""
+    run(["git", "worktree", "prune"], REPO_ROOT, 60)
+    for ref in run(
+        ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/console-check"],
+        REPO_ROOT,
+        60,
+    ).stdout.split():
+        run(["git", "branch", "-D", ref], REPO_ROOT, 60)
+    shutil.rmtree(workdir, ignore_errors=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("prs", nargs="*", help="PR numbers to check")
+    parser.add_argument("--ref", action="append", default=[], help="git ref to check")
+    parser.add_argument(
+        "--no-baseline",
+        action="store_true",
+        help="skip the base-branch build (faster, but no bundle comparison)",
+    )
+    args = parser.parse_args()
+
+    if not args.prs and not args.ref:
+        parser.error("give at least one PR number or --ref")
+
+    missing = tool_missing()
+    if missing:
+        print(f"FAIL  missing required tools: {', '.join(missing)}")
+        return 2
+
+    run(["git", "fetch", "--quiet", "origin", "MARM-main"], REPO_ROOT, 120)
+
+    targets: list[tuple[str, str]] = []
+    for number in args.prs:
+        try:
+            ref, suffix = fetch_pr(number)
+            targets.append((ref, f"PR #{number} ({suffix})"))
+        except RuntimeError as exc:
+            print(f"FAIL  {exc}")
+            return 2
+    targets += [(ref, ref) for ref in args.ref]
+
+    workdir = Path(tempfile.mkdtemp(prefix="marm-console-check-"))
+    results: list[tuple[str, bool, str]] = []
+    try:
+        baseline: set[str] = set()
+        if not args.no_baseline:
+            print(f"baseline: {BASE_REF}")
+            ok, detail, baseline = check(BASE_REF, "baseline", workdir)
+            if not ok:
+                # Every later verdict would be meaningless: a failure could be
+                # the base branch rather than the PR.
+                print(f"\nFAIL  baseline {BASE_REF} does not build.\n{detail}")
+                print("Fix the base branch first; PR verdicts cannot be trusted until then.")
+                return 2
+            print(f"  baseline ok, {len(baseline)} asset(s)")
+
+        for ref, label in targets:
+            print(f"\n{label}  ({ref})")
+            ok, detail, produced = check(ref, label, workdir)
+            if ok and baseline:
+                if produced == baseline:
+                    detail += "\n      bundle identical to baseline (same content hashes)"
+                else:
+                    changed = sorted(produced ^ baseline)
+                    detail += "\n      bundle changed: " + ", ".join(changed[:6])
+            results.append((label, ok, detail))
+    finally:
+        prune(workdir)
+
+    print("\n" + "=" * 60)
+    for label, ok, detail in results:
+        print(f"{'SAFE' if ok else 'UNSAFE'}  {label}\n      {detail.lstrip()}")
+    failed = [label for label, ok, _ in results if not ok]
+    print("=" * 60)
+    if failed:
+        print(f"\n{len(failed)} of {len(results)} unsafe to merge: {', '.join(failed)}")
+        return 1
+    print(f"\nAll {len(results)} safe to merge.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-console-pr.py
+++ b/scripts/check-console-pr.py
@@ -31,6 +31,8 @@ CONSOLE = "marm-console"
 ASSET_DIR = "artifacts/marm-console/dist/public/assets"
 BASE_REF = "origin/MARM-main"
 
+_created_refs: list[str] = []
+
 
 def run(
     cmd: list[str], cwd: Path, timeout: int = 900
@@ -53,8 +55,8 @@ def tool_missing() -> list[str]:
     return [t for t in ("node", "pnpm", "gh", "git") if shutil.which(t) is None]
 
 
-def fetch_pr(number: str) -> tuple[str, str]:
-    """Fetch a PR into a local ref. Returns (ref, label suffix).
+def fetch_pr(number: str) -> tuple[str, str, bool]:
+    """Fetch a PR into a private ref. Returns (ref, label suffix, mergeable).
 
     Prefers refs/pull/N/merge, GitHub's preview of the PR already merged into
     the base. Testing the head alone compares a branch that may predate recent
@@ -62,13 +64,19 @@ def fetch_pr(number: str) -> tuple[str, str]:
     PR. Falls back to the head when no merge ref exists, which is GitHub's way
     of saying the PR does not merge cleanly.
     """
-    local = f"console-check/pr{number}"
-    for ref, suffix in ((f"refs/pull/{number}/merge", "merged"), (f"refs/pull/{number}/head", "head only, does not merge cleanly")):
+    # Under refs/console-check/ rather than refs/heads/: a branch there would
+    # collide with a developer's own branch of that name, which cleanup deletes.
+    local = f"refs/console-check/pr{number}"
+    for ref, suffix, mergeable in (
+        (f"refs/pull/{number}/merge", "merged", True),
+        (f"refs/pull/{number}/head", "head only, does not merge cleanly", False),
+    ):
         proc = run(
             ["git", "fetch", "--force", "origin", f"{ref}:{local}"], REPO_ROOT, 120
         )
         if proc.returncode == 0:
-            return local, suffix
+            _created_refs.append(local)
+            return local, suffix, mergeable
     raise RuntimeError(f"could not fetch PR {number}: no merge or head ref")
 
 
@@ -119,12 +127,8 @@ def prune(workdir: Path) -> None:
     temp dir; nested node_modules paths regularly defeat rmtree on Windows, and
     a leftover temp directory is not worth failing the run over."""
     run(["git", "worktree", "prune"], REPO_ROOT, 60)
-    for ref in run(
-        ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/console-check"],
-        REPO_ROOT,
-        60,
-    ).stdout.split():
-        run(["git", "branch", "-D", ref], REPO_ROOT, 60)
+    for ref in _created_refs:
+        run(["git", "update-ref", "-d", ref], REPO_ROOT, 60)
     shutil.rmtree(workdir, ignore_errors=True)
 
 
@@ -147,17 +151,22 @@ def main() -> int:
         print(f"FAIL  missing required tools: {', '.join(missing)}")
         return 2
 
-    run(["git", "fetch", "--quiet", "origin", "MARM-main"], REPO_ROOT, 120)
+    # Checked, not fired and forgotten: silently reusing a stale origin/MARM-main
+    # makes base drift show up as a bundle difference the PR did not cause.
+    fetched = run(["git", "fetch", "--quiet", "origin", "MARM-main"], REPO_ROOT, 120)
+    if fetched.returncode != 0:
+        print(f"FAIL  could not fetch {BASE_REF}:\n      {fetched.stderr.strip()}")
+        return 2
 
-    targets: list[tuple[str, str]] = []
+    targets: list[tuple[str, str, bool]] = []
     for number in args.prs:
         try:
-            ref, suffix = fetch_pr(number)
-            targets.append((ref, f"PR #{number} ({suffix})"))
+            ref, suffix, mergeable = fetch_pr(number)
+            targets.append((ref, f"PR #{number} ({suffix})", mergeable))
         except RuntimeError as exc:
             print(f"FAIL  {exc}")
             return 2
-    targets += [(ref, ref) for ref in args.ref]
+    targets += [(ref, ref, True) for ref in args.ref]
 
     workdir = Path(tempfile.mkdtemp(prefix="marm-console-check-"))
     results: list[tuple[str, bool, str]] = []
@@ -174,7 +183,7 @@ def main() -> int:
                 return 2
             print(f"  baseline ok, {len(baseline)} asset(s)")
 
-        for ref, label in targets:
+        for ref, label, mergeable in targets:
             print(f"\n{label}  ({ref})")
             ok, detail, produced = check(ref, label, workdir)
             if ok and baseline:
@@ -183,6 +192,11 @@ def main() -> int:
                 else:
                     changed = sorted(produced ^ baseline)
                     detail += "\n      bundle changed: " + ", ".join(changed[:6])
+            if ok and not mergeable:
+                # A clean build of the head says nothing about a PR GitHub cannot
+                # merge, so the verdict has to override the build result.
+                ok = False
+                detail += "\n      no merge ref: GitHub cannot merge this PR cleanly"
             results.append((label, ok, detail))
     finally:
         prune(workdir)

--- a/scripts/typecheck.py
+++ b/scripts/typecheck.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Run mypy on the checked scope and gate on the error baseline.
 
-Local only for now. This fails when the count goes *up*, not when it is nonzero.
-Lower BASELINE as errors are fixed; that edit is the record of progress.
+This fails when the count goes *up*, not when it is nonzero. Lower BASELINE as
+errors are fixed; that edit is the record of progress.
 
 The remaining 2 are both endpoints/graph.py's Optional get_client() race, which
 needs a supervisor-level fix (see docs/current/graph-client-none-guard.md), not
 an annotation. Reaching 0 is a code change, not a typing one.
 
-Promoting this to CI needs requirements.txt plus a pinned mypy. The pin is not
-optional: BASELINE is version-specific.
+Runs in python.yml and publish-mcp.yml as well as locally. BASELINE is specific
+to a mypy version and to its stub versions, so all three places pin the same
+ones (pyproject.toml's dev extra included); upgrading either is a re-baseline.
 
     python scripts/typecheck.py            summary + gate
     python scripts/typecheck.py --raw      full mypy output, no gate


### PR DESCRIPTION
## CI depth for dependency bumps

Dependabot PRs were passing on the Ruff job alone, which never reads `package.json`, the lockfile, or `pyproject.toml`. The console build and the test suite both lived in `publish-mcp.yml`, which runs on a version tag, so a broken bump surfaced only after the tag was already spent. PR #136 is the live example: three green checks, and it fails the console build.

- **`console.yml`** runs `pnpm install --frozen-lockfile`, `typecheck`, and `build` on pull requests.
- **`python.yml`** runs `server.json` validation, the mypy baseline gate, and the suite (1086 tests). A push to `MARM-main` or `release/**` runs the type gate only; the suite is reserved for pull requests, where it can block a merge.
- **The release gate** now runs the typecheck gate and Ruff. It was already installing both and invoking neither.
- **mypy and Ruff are pinned everywhere they run.** `scripts/typecheck.py` gates on an absolute error count and Ruff promotes rules between minor releases, so an unpinned tool fails a PR whose code did not change. Ruff 0.16.2 did exactly that on #138.
- **`scripts/check-console-pr.py`** answers the same question locally, building `refs/pull/N/merge` in a throwaway worktree and comparing emitted asset hashes against the base branch.

Neither new workflow filters paths at the trigger. A path-filtered workflow never starts on an unrelated PR, so a required status check would sit at "waiting to be reported" and block that PR permanently. Each job runs every time and decides internally whether there is work, keeping both eligible to be required checks.

### Validation

Every gate was run locally with the exact command CI uses: typecheck `OK 2 errors, unchanged from baseline`; `ruff check` clean over 205 files; `pytest -m "not docker and not smoke_lifecycle"` at 1086 passed, 2 skipped. Path detection was checked against four real PR shapes (docs-only, this PR, a Dependabot pip bump, and #136).

### Upgrade Note

`MARM-main` now requires the `ruff` check. Once this merges, promote the two new checks:

```
gh api -X PUT repos/Lyellr88/marm-memory/branches/MARM-main/protection --input <payload with contexts ruff, python, console>
```

Promoting them before this merges would block this PR, since the checks would not yet exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Console validation, including type checks, production builds, and asset comparisons.
  * Added Python CI checks for relevant changes and pull requests.
* **Bug Fixes**
  * Improved mirror-save recovery and duplicate handling.
  * Improved Windows process handling and cross-platform security checks.
  * Ensured projects qualify for initial full indexing.
* **Chores**
  * Added change-aware workflows that skip unnecessary builds and cancel outdated runs.
  * Pinned validation tools for consistent results.
  * Expanded documentation for mirror reliability and CI type-check requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->