### PR TITLE
Cga bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ xAI connects from its own infrastructure, so `localhost` will not work. Expose M
 
 </details>
 
-Full platform walkthroughs, key setup, and OS-specific notes: [Windows](docs/INSTALL-WINDOWS.md#client-connections) · [Linux](docs/INSTALL-LINUX.md#client-connections) · [Docker/key mode](docs/INSTALL-DOCKER.md#client-connections) · [Other platforms](docs/INSTALL-PLATFORMS.md)
+Full platform walkthroughs, key setup, and OS-specific notes: [Windows](docs/INSTALL-WINDOWS.md#client-connections) · [macOS](docs/INSTALL-MACOS.md#start-marm-yourself) · [Linux](docs/INSTALL-LINUX.md#client-connections) · [Docker/key mode](docs/INSTALL-DOCKER.md#client-connections) · [Other platforms](docs/INSTALL-PLATFORMS.md)
 
 > Using a client that isn't listed? [Open an issue](https://github.com/Lyellr88/marm-memory/issues/new/choose) and let us know; client adapters are a first-class feature request.
 
@@ -1040,7 +1040,7 @@ It re-splits stale chunks, fills in any lost to an interrupted write, and drops 
 - Check Python version: `python --version` (must be 3.10+)
 - Verify port 8001 isn't in use: `lsof -i :8001` (macOS/Linux) or `netstat -ano | findstr :8001` (Windows)
 - Check for permission errors in home directory (`~/.marm/` must be readable/writable)
-- See platform-specific troubleshooting: [INSTALL-DOCKER.md](docs/INSTALL-DOCKER.md), [INSTALL-WINDOWS.md](docs/INSTALL-WINDOWS.md), [INSTALL-LINUX.md](docs/INSTALL-LINUX.md)
+- See platform-specific troubleshooting: [INSTALL-DOCKER.md](docs/INSTALL-DOCKER.md), [INSTALL-WINDOWS.md](docs/INSTALL-WINDOWS.md), [INSTALL-MACOS.md](docs/INSTALL-MACOS.md), [INSTALL-LINUX.md](docs/INSTALL-LINUX.md)
 
 **STDIO connection fails**
 
@@ -1233,6 +1233,7 @@ Copyright © 2026 Ryan A. Lyell. MARM is released under the [Apache 2.0 License]
 
 - **[INSTALL-DOCKER.md](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-DOCKER.md)** - Docker deployment (recommended)
 - **[INSTALL-WINDOWS.md](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-WINDOWS.md)** - Windows installation guide
+- **[INSTALL-MACOS.md](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-MACOS.md)** - macOS installation guide
 - **[INSTALL-LINUX.md](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-LINUX.md)** - Linux installation guide
 - **[INSTALL-PLATFORMS.md](https://github.com/Lyellr88/marm-memory/blob/MARM-main/docs/INSTALL-PLATFORMS.md)** - Platform installation guide
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,7 +7,7 @@ artifacts.
 ## codebase-memory-mcp
 
 - **Project:** codebase-memory-mcp
-- **Version:** 0.8.1
+- **Version:** 0.9.0
 - **Source:** https://github.com/DeusData/codebase-memory-mcp
 - **License:** MIT
 - **Copyright:** Copyright (c) 2025 DeusData

--- a/docs/INSTALL-MACOS.md
+++ b/docs/INSTALL-MACOS.md
@@ -1,0 +1,52 @@
+# MARM MCP Server - macOS Installation
+
+This is the recommended native macOS path. It uses `uv` to manage MARM's Python environment, so it does not depend on the Python versions already installed on your Mac.
+
+## Quick Start
+
+Install [Homebrew](https://brew.sh/) if needed, then run:
+
+```bash
+brew install uv
+uv tool install --python 3.12 marm-mcp-server
+marm-memory init --g-claude --g-codex --g-gemini
+```
+
+If `uv` says that `marm-memory` is not on your `PATH`, run this once and open a new terminal:
+
+```bash
+uv tool update-shell
+```
+
+Then tell your connected agent: **"Use the marm-init skill to set up MARM."** It will guide the remaining HTTP or STDIO connection setup.
+
+## Start MARM Yourself
+
+To start the local HTTP server and Console:
+
+```bash
+marm-memory fast-start-http
+```
+
+Then connect a client:
+
+```bash
+claude mcp add --transport http marm-memory http://localhost:8001/mcp
+codex mcp add marm-memory --url http://localhost:8001/mcp
+```
+
+For a private local STDIO connection instead:
+
+```bash
+claude mcp add --transport stdio marm-memory-stdio marm-mcp-stdio
+codex mcp add marm-memory-stdio -- marm-mcp-stdio
+```
+
+## Update or Troubleshoot
+
+```bash
+uv tool upgrade marm-mcp-server
+marm-memory doctor
+```
+
+If a native dependency does not install cleanly, use the [Docker installation guide](INSTALL-DOCKER.md) and open an issue with your macOS version, whether the Mac is Apple silicon or Intel, `uv --version`, and the full install error.

--- a/marm-mcp-server/marm_graph/endpoints/graph_ai.py
+++ b/marm-mcp-server/marm_graph/endpoints/graph_ai.py
@@ -50,8 +50,10 @@ async def marm_graph_trace(req: GraphTraceRequest) -> dict:
     """Trace call paths / data flow through the graph from a function.
 
     `direction=inbound` finds callers, `outbound` finds callees, `both` for all.
-    `mode=data_flow` follows value propagation; `cross_service` crosses HTTP/async
-    boundaries. Use for impact analysis, dependency tracing, "who calls this".
+    `mode=data_flow` follows value propagation. `cross_service` attempts HTTP/async
+    boundaries but does not currently join a client call to its server handler, so
+    treat an empty result as unknown rather than as "nothing calls this".
+    Use for impact analysis, dependency tracing, "who calls this".
     """
     return await asyncio.to_thread(R.do_trace, get_client(), req)
 

--- a/marm-mcp-server/marm_graph/server_stdio.py
+++ b/marm-mcp-server/marm_graph/server_stdio.py
@@ -118,7 +118,9 @@ async def marm_graph_trace(
     """Trace call paths / data flow from a function.
 
     direction=inbound (callers), outbound (callees), both. mode=data_flow follows
-    value propagation; cross_service crosses HTTP/async boundaries.
+    value propagation. cross_service attempts HTTP/async boundaries but does not
+    currently join a client call to its server handler, so treat an empty result
+    as unknown rather than as "nothing calls this".
     """
     req, err = _build(
         GraphTraceRequest,

--- a/marm-mcp-server/marm_mcp_server/endpoints/graph.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/graph.py
@@ -271,8 +271,10 @@ async def marm_graph_trace(req: GraphTraceRequest) -> dict:
     """Trace call paths / data flow through the graph from a function.
 
     `direction=inbound` finds callers, `outbound` finds callees, `both` for all.
-    `mode=data_flow` follows value propagation; `cross_service` crosses HTTP/async
-    boundaries. Use for impact analysis, dependency tracing, "who calls this".
+    `mode=data_flow` follows value propagation. `cross_service` attempts HTTP/async
+    boundaries but does not currently join a client call to its server handler, so
+    treat an empty result as unknown rather than as "nothing calls this".
+    Use for impact analysis, dependency tracing, "who calls this".
     """
     client = await asyncio.to_thread(graph_supervisor.get_client)
     if client is None:

--- a/marm-mcp-server/marm_mcp_server/services/stdio_graph_tools.py
+++ b/marm-mcp-server/marm_mcp_server/services/stdio_graph_tools.py
@@ -184,8 +184,10 @@ async def marm_graph_trace(
     🧭 Trace call paths / data flow through the graph from a function.
 
     `direction=inbound` finds callers, `outbound` finds callees, `both` for all.
-    `mode=data_flow` follows value propagation; `cross_service` crosses HTTP/async
-    boundaries. Use for impact analysis, dependency tracing, "who calls this".
+    `mode=data_flow` follows value propagation. `cross_service` attempts HTTP/async
+    boundaries but does not currently join a client call to its server handler, so
+    treat an empty result as unknown rather than as "nothing calls this".
+    Use for impact analysis, dependency tracing, "who calls this".
 
     Parameters:
     - function_name: function or method to trace from

--- a/scripts/benchmarking/accuracy/code-graph/awaited-calls-results.json
+++ b/scripts/benchmarking/accuracy/code-graph/awaited-calls-results.json
@@ -1,0 +1,49 @@
+{
+  "provenance": {
+    "commit": "c3539c2",
+    "branch": "cga-bench",
+    "engine_version": "0.9.0",
+    "os": "Windows 11",
+    "store": "C:\\Users\\lyell\\.cache\\codebase-memory-mcp\\C-Users-lyell-Desktop-MARM-Systems.db",
+    "source": "direct graph-store read, NOT a public-tool result",
+    "population": "direct-name calls only (ast.Name); attribute calls excluded because resolving their owner needs type inference. Both ends must resolve to exactly one indexed graph symbol."
+  },
+  "resolved_pairs": 1940,
+  "unresolved_sites": 3583,
+  "plain": {
+    "recorded": 1318,
+    "missed": 515,
+    "recall": 0.719
+  },
+  "awaited": {
+    "recorded": 45,
+    "missed": 62,
+    "recall": 0.421
+  },
+  "sample_misses": {
+    "awaited": [
+      "_reindex -> run_exclusive",
+      "update_memory -> _update_memory",
+      "store_memory -> _store_memory",
+      "recall_similar -> _recall_similar",
+      "recall_text_search -> _recall_text_search",
+      "_store_memory -> find_semantic_duplicate",
+      "graceful_shutdown -> drain_chunk_writes",
+      "marm_apply_compaction -> apply_compaction_write",
+      "marm_graph_index -> run_exclusive",
+      "console_delete_project -> run_exclusive"
+    ],
+    "plain": [
+      "marm_graph_index -> get_client",
+      "marm_code_lookup -> get_client",
+      "marm_graph_trace -> get_client",
+      "marm_graph_architecture -> get_client",
+      "marm_graph_impact -> get_client",
+      "_call -> get_client",
+      "lifespan -> get_client",
+      "lifespan -> reset_client",
+      "health -> get_client",
+      "marm_graph_index -> get_client"
+    ]
+  }
+}

--- a/scripts/benchmarking/accuracy/code-graph/awaited_calls.py
+++ b/scripts/benchmarking/accuracy/code-graph/awaited_calls.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Does the code graph record awaited calls as reliably as plain ones?
+
+Compares call edges in the graph against call sites resolved from Python's own
+`ast`, matched by qualified name rather than by bare name.
+
+Bare-name matching is what an earlier throwaway version of this did, and it is
+wrong in both directions: same-named functions in different modules collapse into
+one, so a call resolved against the wrong definition scores as a hit. That biases
+recall upward. Every pair here is resolved through the importing file's own import
+table and matched on a module-qualified suffix.
+
+Only pairs where BOTH ends resolve to an indexed graph symbol are counted. Calls
+into builtins, the stdlib, and third-party packages are excluded: those were never
+graph nodes, so counting them would report a low rate that means nothing.
+
+Usage, from repo root:
+    python scripts/benchmarking/accuracy/code-graph/awaited_calls.py
+    python scripts/benchmarking/accuracy/code-graph/awaited_calls.py --db <path> --json out.json
+
+Reads the graph store directly. That is deliberate and is the exception to the
+tool-surface rule in the spec: no public tool enumerates every call edge, and this
+measures the graph's contents rather than what a caller receives.
+"""
+
+import argparse
+import ast
+import json
+import platform
+import sqlite3
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PACKAGE_ROOT = REPO_ROOT / "marm-mcp-server"
+STORE_DIR = Path.home() / ".cache" / "codebase-memory-mcp"
+
+
+@dataclass
+class CallSite:
+    caller: str
+    callee: str
+    awaited: bool
+
+
+@dataclass
+class FileScan:
+    module: str
+    imports: dict[str, str] = field(default_factory=dict)
+    sites: list[CallSite] = field(default_factory=list)
+
+
+def _store_for_repo() -> Path | None:
+    """The engine store for this checkout, found rather than hard-coded.
+
+    The engine names each store after the mangled absolute repo path, so any
+    literal default only works on the machine that wrote it. Matching on the
+    mangled form keeps this runnable from any clone.
+    """
+    key = str(REPO_ROOT).replace("\\", "-").replace("/", "-").replace(":", "")
+    candidate = STORE_DIR / f"{key}.db"
+    if candidate.exists():
+        return candidate
+    tail = REPO_ROOT.name.lower()
+    matches = [
+        p
+        for p in STORE_DIR.glob("*.db")
+        if p.stem.lower().endswith(tail) and p.stem != "_config"
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _provenance(db: Path) -> dict:
+    """Recorded with every result set. Engine accuracy is not under MARM's control,
+    so a number with no engine version attached is worthless six months on."""
+
+    def _git(*args: str) -> str:
+        try:
+            return subprocess.run(
+                ["git", "-C", str(REPO_ROOT), *args],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            ).stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            return "unknown"
+
+    try:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        from marm_graph.config import settings as gs
+
+        engine = gs.PINNED_CBM_VERSION
+    except Exception:
+        engine = "unknown"
+
+    return {
+        "commit": _git("rev-parse", "--short", "HEAD"),
+        "branch": _git("branch", "--show-current"),
+        "engine_version": engine,
+        "os": f"{platform.system()} {platform.release()}",
+        "store": str(db),
+        "source": "direct graph-store read, NOT a public-tool result",
+        "population": (
+            "direct-name calls only (ast.Name); attribute calls excluded because "
+            "resolving their owner needs type inference. Both ends must resolve to "
+            "exactly one indexed graph symbol."
+        ),
+    }
+
+
+def _module_of(path: Path) -> str:
+    rel = path.relative_to(PACKAGE_ROOT).with_suffix("")
+    parts = [p for p in rel.parts if p != "__init__"]
+    return ".".join(parts)
+
+
+class _Scanner(ast.NodeVisitor):
+    """Collects the import table and every resolvable call site in one file."""
+
+    def __init__(self, module: str) -> None:
+        self.out = FileScan(module=module)
+        self._stack: list[str] = []
+        self._awaited: set[int] = set()
+
+    # ── imports ────────────────────────────────────────────────────
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.out.imports[alias.asname or alias.name.split(".")[0]] = alias.name
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        # Relative imports resolve against this file's own package, which is what
+        # makes `from ..services.analytics import track_usage` resolvable at all.
+        base = node.module or ""
+        if node.level:
+            owner = self.out.module.split(".")
+            trim = node.level if self.out.module else 0
+            prefix = owner[: max(0, len(owner) - trim)]
+            base = ".".join([*prefix, base]) if base else ".".join(prefix)
+        for alias in node.names:
+            self.out.imports[alias.asname or alias.name] = f"{base}.{alias.name}"
+
+    # ── scopes ─────────────────────────────────────────────────────
+    def _scoped(self, node) -> None:
+        self._stack.append(node.name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    visit_ClassDef = _scoped
+    visit_FunctionDef = _scoped
+    visit_AsyncFunctionDef = _scoped
+
+    # ── calls ──────────────────────────────────────────────────────
+    def visit_Await(self, node: ast.Await) -> None:
+        if isinstance(node.value, ast.Call):
+            self._awaited.add(id(node.value))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        self.generic_visit(node)
+        if not self._stack or not isinstance(node.func, ast.Name):
+            # Attribute calls need type inference to resolve an owner, which is
+            # beyond ast. Excluded rather than guessed.
+            return
+        caller = f"{self.out.module}.{'.'.join(self._stack)}"
+        # Imported name first, otherwise assume the same module. Without the
+        # fallback only cross-module imported calls are measured, which silently
+        # drops every same-file call and makes the population unrepresentative.
+        target = self.out.imports.get(node.func.id) or (
+            f"{self.out.module}.{node.func.id}"
+        )
+        self.out.sites.append(
+            CallSite(caller=caller, callee=target, awaited=id(node) in self._awaited)
+        )
+
+
+def _graph(db: Path) -> tuple[dict[str, set[str]], set[tuple[str, str]]]:
+    """Symbol suffix index, and the set of recorded CALLS pairs by qualified name."""
+    conn = sqlite3.connect(str(db))
+    by_suffix: dict[str, set[str]] = {}
+    for qname, name in conn.execute(
+        "SELECT qualified_name, name FROM nodes WHERE label IN ('Function','Method')"
+    ):
+        if not qname or not name:
+            continue
+        by_suffix.setdefault(name, set()).add(qname)
+    edges = {
+        (s, t)
+        for s, t in conn.execute(
+            """SELECT s.qualified_name, t.qualified_name FROM edges e
+               JOIN nodes s ON s.id = e.source_id
+               JOIN nodes t ON t.id = e.target_id
+               WHERE e.type = 'CALLS'"""
+        )
+    }
+    conn.close()
+    return by_suffix, edges
+
+
+def _resolve(dotted: str, by_suffix: dict[str, set[str]]) -> str | None:
+    """A graph qualified_name for a dotted Python path, or None if ambiguous.
+
+    The graph prefixes qualified names with the project and the on-disk directory,
+    so matching is by suffix. A dotted path that matches more than one symbol is
+    dropped: guessing between them is exactly the error bare-name matching makes.
+    """
+    leaf = dotted.rsplit(".", 1)[-1]
+    candidates = by_suffix.get(leaf)
+    if not candidates:
+        return None
+    tail = dotted.replace(".", "/")
+    hits = {q for q in candidates if q.replace(".", "/").endswith(tail)}
+    return next(iter(hits)) if len(hits) == 1 else None
+
+
+def analyse(db: Path) -> dict:
+    by_suffix, edges = _graph(db)
+    pairs: dict[tuple[str, str], bool] = {}
+    unresolved = 0
+
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        if "build" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        scanner = _Scanner(_module_of(path))
+        scanner.visit(tree)
+        for site in scanner.out.sites:
+            caller = _resolve(site.caller, by_suffix)
+            callee = _resolve(site.callee, by_suffix)
+            if not caller or not callee:
+                unresolved += 1
+                continue
+            key = (caller, callee)
+            pairs[key] = pairs.get(key, False) or site.awaited
+
+    counts: Counter = Counter()
+    misses: dict[str, list[str]] = {"awaited": [], "plain": []}
+    for (caller, callee), awaited in pairs.items():
+        hit = (caller, callee) in edges
+        counts[("awaited" if awaited else "plain", hit)] += 1
+        if not hit:
+            bucket = misses["awaited" if awaited else "plain"]
+            if len(bucket) < 10:
+                bucket.append(f"{caller.split('.')[-1]} -> {callee.split('.')[-1]}")
+
+    out = {
+        "provenance": _provenance(db),
+        "resolved_pairs": len(pairs),
+        "unresolved_sites": unresolved,
+    }
+    for shape in ("plain", "awaited"):
+        hit, miss = counts[(shape, True)], counts[(shape, False)]
+        total = hit + miss
+        out[shape] = {
+            "recorded": hit,
+            "missed": miss,
+            "recall": round(hit / total, 3) if total else None,
+        }
+    out["sample_misses"] = misses
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--db",
+        type=Path,
+        help="graph store to read; omit to pick the store for this repo",
+    )
+    ap.add_argument("--json", type=Path, help="also write raw results here")
+    args = ap.parse_args()
+
+    db = args.db or _store_for_repo()
+    if db is None:
+        print(f"no graph store found for {REPO_ROOT} under {STORE_DIR}; pass --db")
+        return 2
+    if not db.exists():
+        print(f"no graph store at {db}")
+        return 2
+
+    r = analyse(db)
+    print(
+        f"resolved call pairs: {r['resolved_pairs']}  (unresolved sites: {r['unresolved_sites']})\n"
+    )
+    print(f"{'shape':10} {'recorded':>9} {'missed':>7} {'recall':>8}")
+    for shape in ("plain", "awaited"):
+        d = r[shape]
+        print(f"{shape:10} {d['recorded']:9} {d['missed']:7} {d['recall']!s:>8}")
+    if r["awaited"]["recall"] is not None and r["plain"]["recall"] is not None:
+        print(
+            f"\nawaited penalty: {r['plain']['recall'] - r['awaited']['recall']:+.3f}"
+        )
+    print("\nsample awaited misses:")
+    for line in r["sample_misses"]["awaited"]:
+        print(f"  {line}")
+
+    if args.json:
+        args.json.write_text(json.dumps(r, indent=2), encoding="utf-8")
+        print(f"\nraw results: {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmarking/accuracy/code-graph/awaited_calls.py
+++ b/scripts/benchmarking/accuracy/code-graph/awaited_calls.py
@@ -59,18 +59,17 @@ def _store_for_repo() -> Path | None:
     The engine names each store after the mangled absolute repo path, so any
     literal default only works on the machine that wrote it. Matching on the
     mangled form keeps this runnable from any clone.
+
+    Exact match only. A basename fallback used to accept any store whose name ended
+    in the repository directory name, which selects a sibling checkout's store on a
+    machine holding two clones, then reports that store's metrics under this
+    checkout's commit and branch. Returning nothing is the correct answer: this
+    script indexes no repositories, so a missing store means the caller has not
+    indexed this one yet.
     """
     key = str(REPO_ROOT).replace("\\", "-").replace("/", "-").replace(":", "")
     candidate = STORE_DIR / f"{key}.db"
-    if candidate.exists():
-        return candidate
-    tail = REPO_ROOT.name.lower()
-    matches = [
-        p
-        for p in STORE_DIR.glob("*.db")
-        if p.stem.lower().endswith(tail) and p.stem != "_config"
-    ]
-    return matches[0] if len(matches) == 1 else None
+    return candidate if candidate.exists() else None
 
 
 def _provenance(db: Path) -> dict:

--- a/scripts/benchmarking/accuracy/code-graph/pilot-results.json
+++ b/scripts/benchmarking/accuracy/code-graph/pilot-results.json
@@ -1,0 +1,82 @@
+{
+  "provenance": {
+    "commit": "c3539c2",
+    "head_sha": "c3539c28a87508f180317be2f91bb18a2b29680d",
+    "branch": "cga-bench",
+    "engine_version": "0.9.0",
+    "os": "Windows 11 10.0.26200",
+    "index_mode": "moderate",
+    "isolated_index": true,
+    "project": "C-Users-lyell-AppData-Local-Temp-cga-bench-0si2wy9t-tree",
+    "manifest_version": "pilot-2"
+  },
+  "C1": {
+    "metric": "inbound reference recall",
+    "symbol": "notebook_dispatch",
+    "caller_count": 0,
+    "callers": [],
+    "expected": [
+      "marm_notebook"
+    ],
+    "missing_expected": [
+      "marm_notebook"
+    ],
+    "recall": 0.0,
+    "pass": false
+  },
+  "C4": {
+    "metric": "route-to-handler exposure",
+    "routes_returned": 20,
+    "with_handler": 0,
+    "exposure_rate": 0.0,
+    "sample": [
+      {
+        "method": "POST",
+        "path": "/ui/projects",
+        "handler": ""
+      },
+      {
+        "method": "POST",
+        "path": "/ui/index_status",
+        "handler": ""
+      },
+      {
+        "method": "POST",
+        "path": "/ui/graph_schema",
+        "handler": ""
+      },
+      {
+        "method": "POST",
+        "path": "/ui/query_graph",
+        "handler": ""
+      },
+      {
+        "method": "POST",
+        "path": "/ui/delete_project",
+        "handler": ""
+      }
+    ],
+    "pass": false
+  },
+  "C6": {
+    "metric": "cross-service path completion",
+    "symbol": "getMemory",
+    "callees": [
+      "/memories/:id",
+      "MarmApiError",
+      "buildQuery",
+      "request"
+    ],
+    "reached_route": [
+      "/memories/:id"
+    ],
+    "reached_python_handler": [],
+    "completed": false,
+    "dead_ends_at_route": true,
+    "pass": false
+  },
+  "cleanup": {
+    "ok": true,
+    "issues": []
+  }
+}

--- a/scripts/benchmarking/accuracy/code-graph/pilot.py
+++ b/scripts/benchmarking/accuracy/code-graph/pilot.py
@@ -47,12 +47,20 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from store_cleanup import drop_project, succeeded  # noqa: E402
 
-# C1. One production caller, verified by hand at server_stdio.py:259. The five
-# test callers are excluded because no caller can ask for them: the engine filters
-# test files from traces, and GraphTraceRequest exposes no include_tests field, so
-# they are unreachable through MARM's public surface at any setting.
+# C1. Two production callers, verified by hand: endpoints/notebook.py:24 for HTTP
+# and server_stdio.py:259 for STDIO. Both are named marm_notebook and differ only
+# by module, so the expectation is a qualified-name suffix per caller. A bare-name
+# set of one collapsed them and scored recall 1.0 on whichever transport resolved,
+# even when the other transport's edge was missing entirely.
+#
+# The five test callers are excluded because no caller can ask for them: the engine
+# filters test files from traces, and GraphTraceRequest exposes no include_tests
+# field, so they are unreachable through MARM's public surface at any setting.
 C1_SYMBOL = "notebook_dispatch"
-C1_EXPECTED_CALLERS = {"marm_notebook"}
+C1_EXPECTED_CALLERS = {
+    "marm_mcp_server.server_stdio.marm_notebook",
+    "marm_mcp_server.endpoints.notebook.marm_notebook",
+}
 
 # C6. The TypeScript client calls GET /api/memories/{memory_id} through a baseURL
 # that strips the /api prefix. Completion means the trace reaches Python.
@@ -133,6 +141,21 @@ def _names(entries) -> list[str]:
     return out
 
 
+def _qualified_names(entries) -> list[str]:
+    """Qualified name per entry, falling back to the bare name when absent.
+
+    Two callers of notebook_dispatch share the bare name marm_notebook and differ
+    only by module, so anything scored on names alone counts them as one.
+    """
+    out = []
+    for item in entries or []:
+        if isinstance(item, dict):
+            out.append(str(item.get("qualified_name") or item.get("name", "")))
+        else:
+            out.append(str(item))
+    return out
+
+
 async def _resolve_project(tools, repo_path: Path) -> str | None:
     """Project name for a path, from the engine rather than a guessed key.
 
@@ -161,13 +184,20 @@ async def probe_c1(tools, project: str) -> dict:
         ),
         "marm_graph_trace",
     )
-    callers = _names(res.get("callers"))
-    found = {c for c in callers if c in C1_EXPECTED_CALLERS}
+    qualified = _qualified_names(res.get("callers"))
+    # Suffix match: the engine prefixes every qualified name with the mangled
+    # project path, which differs per machine and per isolated run.
+    found = {
+        want
+        for want in C1_EXPECTED_CALLERS
+        if any(q == want or q.endswith(f".{want}") for q in qualified)
+    }
     return {
         "metric": "inbound reference recall",
         "symbol": C1_SYMBOL,
-        "caller_count": len(callers),
-        "callers": sorted(set(callers)),
+        "caller_count": len(qualified),
+        "callers": sorted(set(_names(res.get("callers")))),
+        "callers_qualified": sorted(set(qualified)),
         "expected": sorted(C1_EXPECTED_CALLERS),
         "missing_expected": sorted(C1_EXPECTED_CALLERS - found),
         "recall": round(len(found) / len(C1_EXPECTED_CALLERS), 3),
@@ -353,9 +383,16 @@ def _report(r: dict) -> bool:
             print(f"    {issue}")
 
     # An execution error is not a pass and not a measured failure. It exits
-    # non-zero because the run produced no result, not because C1 missed.
-    c1_ok = "execution_error" not in r["C1"] and bool(r["C1"].get("pass"))
-    return c1_ok and (r.get("cleanup") or {}).get("ok", True)
+    # non-zero because the run produced no result, not because a metric missed, and
+    # that holds for every probe: C4 and C6 failing their metric is a finding worth
+    # recording, but C4 or C6 never running means the run is incomplete. Only C1
+    # gates on its metric, per the stop rule.
+    all_ran = all("execution_error" not in r[name] for name in ("C1", "C4", "C6"))
+    return (
+        all_ran
+        and bool(r["C1"].get("pass"))
+        and (r.get("cleanup") or {}).get("ok", True)
+    )
 
 
 def main() -> int:

--- a/scripts/benchmarking/accuracy/code-graph/pilot.py
+++ b/scripts/benchmarking/accuracy/code-graph/pilot.py
@@ -39,11 +39,13 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(REPO_ROOT / "marm-mcp-server"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from store_cleanup import drop_project, succeeded  # noqa: E402
 
 # C1. One production caller, verified by hand at server_stdio.py:259. The five
 # test callers are excluded because no caller can ask for them: the engine filters
@@ -86,75 +88,6 @@ def _git_checked(*args: str) -> str:
         if proc.returncode == 0
         else (proc.stderr.strip() or f"exit {proc.returncode}")
     )
-
-
-async def _drop_project(project: str) -> str:
-    """Remove the throwaway project's store. Returns a status for the caller to print.
-
-    Runs under run_exclusive, the same cross-process lease every other engine
-    store mutation takes. Deleting outside the gate can race a concurrent index:
-    a MARM server running on this machine re-indexes watched projects on a 30s
-    cycle, and an isolated run's project joins that watch set the moment it is
-    indexed, so an ungated delete can be undone by the other process.
-
-    Via the engine CLI because marm_graph_index exposes no delete action: its
-    actions are auto/index/status/list plus the auto_* switches.
-
-    Retried and verified rather than fired once. Two tries are still needed with
-    the lease held, which rules the auto-indexer out as the cause, since no other
-    gate-respecting process can index while we hold it. What remains is this run's
-    own engine child writing its store back as it dies. The gate is still correct
-    to take: it is the project rule for every store mutation, and it removes the
-    other process from the picture, which is what made the cause identifiable.
-    """
-    try:
-        from codebase_memory_mcp import _cli
-
-        binary = _cli._bin_path(_cli._version())
-    except Exception as exc:
-        return f"could not resolve engine binary: {exc}"
-
-    def _cli_call(*args: str) -> str:
-        try:
-            proc = subprocess.run(
-                [str(binary), "cli", *args], capture_output=True, timeout=120
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            return f"__error__ {exc}"
-        return proc.stdout.decode(errors="replace")
-
-    def _absent() -> bool:
-        return project not in _cli_call("list_projects")
-
-    def _delete_and_verify() -> str:
-        """Delete, then confirm twice with a settle gap between.
-
-        A single check right after the delete is racy and reports success it has
-        not earned: the run's dying engine child writes its store back a moment
-        later, so the project is absent when checked and present by the time the
-        command exits. Observed exactly that, with cleanup reporting "deleted"
-        while the database was still on disk. Two agreeing checks either side of a
-        pause is what distinguishes a real delete from that window.
-        """
-        for attempt in range(5):
-            _cli_call("delete_project", "--project", project)
-            time.sleep(1.0)
-            if _absent():
-                time.sleep(0.75)
-                if _absent():
-                    return (
-                        "deleted"
-                        if attempt == 0
-                        else f"deleted after {attempt + 1} tries"
-                    )
-        return f"still present after 5 tries, remove {project} by hand"
-
-    from marm_mcp_server.core.graph_index_lock import GraphIndexBusy, run_exclusive
-
-    try:
-        return await run_exclusive(f"cga_pilot_cleanup:{project}", _delete_and_verify)
-    except GraphIndexBusy as exc:
-        return f"gate busy ({exc}), remove {project} by hand"
 
 
 def _provenance(isolated: bool, project: str) -> dict:
@@ -357,9 +290,9 @@ async def run(isolate: bool) -> dict:
             from marm_mcp_server.core.graph_supervisor import graph_supervisor
 
             graph_supervisor.stop()
-            status = await _drop_project(project)
+            status = await drop_project(project)
             print(f"cleanup: {status}")
-            if not status.startswith("deleted"):
+            if not succeeded(status):
                 issues.append(f"project {project}: {status}")
         removed = _git_checked("worktree", "remove", "--force", str(work))
         if removed:

--- a/scripts/benchmarking/accuracy/code-graph/pilot.py
+++ b/scripts/benchmarking/accuracy/code-graph/pilot.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Fresh-index pilot for the code graph accuracy benchmark.
+
+Three probes, one per metric in docs/current/code-graph-accuracy-benchmark.md,
+run before any ground-truth labeling is spent:
+
+  C1  inbound reference recall       notebook_dispatch
+  C4  route-to-handler exposure      marm_graph_architecture routes[].handler
+  C6  cross-service path completion  getMemory (marm-console TypeScript)
+
+Calls MARM's own graph tool functions, so graph_supervisor, tool_router, and the
+response shaping are all exercised. It does NOT go over MCP transport, so
+registration, schema validation, and serialization are not covered: this is the
+service layer an MCP call lands on, not an MCP client.
+
+Only what a caller receives counts as a result. SQLite inspection is diagnosis,
+and the two genuinely disagree here, which is the point of C4.
+
+Run from repo root:
+    python scripts/benchmarking/accuracy/code-graph/pilot.py --isolate
+    python scripts/benchmarking/accuracy/code-graph/pilot.py --json out.json
+
+`--isolate` builds a git worktree at HEAD, indexes that path into its own project,
+probes it, and tears both down. That is the reproducible mode and it never touches
+the store your running MARM uses. Without it the live store is probed as-is, which
+is fine for a quick look but is not a benchmark run: nothing guarantees the store
+matches HEAD.
+
+Exit code is non-zero when C1 misses its stop rule, when a probe could not run,
+or when cleanup left a graph project or worktree behind. A run that measures
+cleanly and then leaks a project has not succeeded.
+"""
+
+import argparse
+import asyncio
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT / "marm-mcp-server"))
+
+# C1. One production caller, verified by hand at server_stdio.py:259. The five
+# test callers are excluded because no caller can ask for them: the engine filters
+# test files from traces, and GraphTraceRequest exposes no include_tests field, so
+# they are unreachable through MARM's public surface at any setting.
+C1_SYMBOL = "notebook_dispatch"
+C1_EXPECTED_CALLERS = {"marm_notebook"}
+
+# C6. The TypeScript client calls GET /api/memories/{memory_id} through a baseURL
+# that strips the /api prefix. Completion means the trace reaches Python.
+C6_SYMBOL = "getMemory"
+C6_PYTHON_HANDLERS = {"get_memory", "read_memory", "get_memory_by_id"}
+
+
+def _git(*args: str, cwd: Path | None = None) -> str:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(cwd or REPO_ROOT), *args],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def _git_checked(*args: str) -> str:
+    """Empty string on success, otherwise the reason. For cleanup that must be seen."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return str(exc)
+    return (
+        ""
+        if proc.returncode == 0
+        else (proc.stderr.strip() or f"exit {proc.returncode}")
+    )
+
+
+async def _drop_project(project: str) -> str:
+    """Remove the throwaway project's store. Returns a status for the caller to print.
+
+    Runs under run_exclusive, the same cross-process lease every other engine
+    store mutation takes. Deleting outside the gate can race a concurrent index:
+    a MARM server running on this machine re-indexes watched projects on a 30s
+    cycle, and an isolated run's project joins that watch set the moment it is
+    indexed, so an ungated delete can be undone by the other process.
+
+    Via the engine CLI because marm_graph_index exposes no delete action: its
+    actions are auto/index/status/list plus the auto_* switches.
+
+    Retried and verified rather than fired once. Two tries are still needed with
+    the lease held, which rules the auto-indexer out as the cause, since no other
+    gate-respecting process can index while we hold it. What remains is this run's
+    own engine child writing its store back as it dies. The gate is still correct
+    to take: it is the project rule for every store mutation, and it removes the
+    other process from the picture, which is what made the cause identifiable.
+    """
+    try:
+        from codebase_memory_mcp import _cli
+
+        binary = _cli._bin_path(_cli._version())
+    except Exception as exc:
+        return f"could not resolve engine binary: {exc}"
+
+    def _cli_call(*args: str) -> str:
+        try:
+            proc = subprocess.run(
+                [str(binary), "cli", *args], capture_output=True, timeout=120
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return f"__error__ {exc}"
+        return proc.stdout.decode(errors="replace")
+
+    def _absent() -> bool:
+        return project not in _cli_call("list_projects")
+
+    def _delete_and_verify() -> str:
+        """Delete, then confirm twice with a settle gap between.
+
+        A single check right after the delete is racy and reports success it has
+        not earned: the run's dying engine child writes its store back a moment
+        later, so the project is absent when checked and present by the time the
+        command exits. Observed exactly that, with cleanup reporting "deleted"
+        while the database was still on disk. Two agreeing checks either side of a
+        pause is what distinguishes a real delete from that window.
+        """
+        for attempt in range(5):
+            _cli_call("delete_project", "--project", project)
+            time.sleep(1.0)
+            if _absent():
+                time.sleep(0.75)
+                if _absent():
+                    return (
+                        "deleted"
+                        if attempt == 0
+                        else f"deleted after {attempt + 1} tries"
+                    )
+        return f"still present after 5 tries, remove {project} by hand"
+
+    from marm_mcp_server.core.graph_index_lock import GraphIndexBusy, run_exclusive
+
+    try:
+        return await run_exclusive(f"cga_pilot_cleanup:{project}", _delete_and_verify)
+    except GraphIndexBusy as exc:
+        return f"gate busy ({exc}), remove {project} by hand"
+
+
+def _provenance(isolated: bool, project: str) -> dict:
+    try:
+        from marm_graph.config import settings as gs
+
+        engine = gs.PINNED_CBM_VERSION
+    except Exception:
+        engine = "unknown"
+    return {
+        "commit": _git("rev-parse", "--short", "HEAD"),
+        "head_sha": _git("rev-parse", "HEAD"),
+        "branch": _git("branch", "--show-current"),
+        "engine_version": engine,
+        "os": f"{platform.system()} {platform.release()} {platform.version()}",
+        "index_mode": "moderate",
+        "isolated_index": isolated,
+        "project": project,
+        "manifest_version": "pilot-2",
+    }
+
+
+class ProbeError(RuntimeError):
+    """The graph could not answer. Distinct from the graph answering badly.
+
+    Without this an unavailable backend returns {"status": "error"}, every probe
+    then finds no callers and no routes, and the run reports three clean metric
+    failures. That reads as evidence of a graph defect when it is evidence of
+    nothing at all.
+    """
+
+
+def _checked(res: dict, tool: str) -> dict:
+    if res.get("status") == "error":
+        raise ProbeError(f"{tool}: {res.get('message') or res}")
+    return res
+
+
+def _names(entries) -> list[str]:
+    out = []
+    for item in entries or []:
+        out.append(str(item.get("name", "")) if isinstance(item, dict) else str(item))
+    return out
+
+
+async def _resolve_project(tools, repo_path: Path) -> str | None:
+    """Project name for a path, from the engine rather than a guessed key.
+
+    The engine derives its key by mangling the absolute path, so hard-coding it
+    only works on the machine it was written on.
+    """
+    res = await tools.marm_graph_index(action="list")
+    want = str(repo_path).replace("\\", "/").rstrip("/").lower()
+    for proj in res.get("projects") or []:
+        root = str((proj or {}).get("root_path") or "").replace("\\", "/").rstrip("/")
+        if root.lower() == want:
+            return proj.get("name") or proj.get("project")
+    return None
+
+
+async def probe_c1(tools, project: str) -> dict:
+    """Inbound reference recall. The baseline category, and the stop rule.
+
+    Test callers are unreachable here by construction, not by choice: MARM's trace
+    request has no include_tests field to pass. The number is what an agent gets
+    when it asks "who calls this", which is the only number that matters.
+    """
+    res = _checked(
+        await tools.marm_graph_trace(
+            function_name=C1_SYMBOL, project=project, direction="inbound", depth=2
+        ),
+        "marm_graph_trace",
+    )
+    callers = _names(res.get("callers"))
+    found = {c for c in callers if c in C1_EXPECTED_CALLERS}
+    return {
+        "metric": "inbound reference recall",
+        "symbol": C1_SYMBOL,
+        "caller_count": len(callers),
+        "callers": sorted(set(callers)),
+        "expected": sorted(C1_EXPECTED_CALLERS),
+        "missing_expected": sorted(C1_EXPECTED_CALLERS - found),
+        "recall": round(len(found) / len(C1_EXPECTED_CALLERS), 3),
+        "pass": not (C1_EXPECTED_CALLERS - found),
+    }
+
+
+async def probe_c4(tools, project: str) -> dict:
+    """Route-to-handler exposure, measured on the field that carries it.
+
+    An earlier version asked marm_code_lookup for the route path and called it
+    linked when the same result set held both a Route and a Function. That was
+    vacuous: BM25 returns whatever matches, and it scored `/tools/graph_index` as
+    linked partly on `register_graph_tools`, which handles nothing.
+
+    marm_graph_architecture returns routes[] with method, path, and handler, so
+    the handler field is the actual public contract. marm_graph_impact cannot be
+    used: it is a git-diff blast radius tool keyed on since/base_branch, not a
+    per-symbol query. No trace mode follows HANDLES either.
+    """
+    res = _checked(
+        await tools.marm_graph_architecture(project=project), "marm_graph_architecture"
+    )
+    routes = [r for r in (res.get("routes") or []) if isinstance(r, dict)]
+    filled = [r for r in routes if (r.get("handler") or "").strip()]
+    return {
+        "metric": "route-to-handler exposure",
+        "routes_returned": len(routes),
+        "with_handler": len(filled),
+        "exposure_rate": round(len(filled) / len(routes), 3) if routes else None,
+        "sample": routes[:5],
+        "pass": bool(routes) and len(filled) == len(routes),
+    }
+
+
+async def probe_c6(tools, project: str) -> dict:
+    """Cross-service path completion."""
+    res = _checked(
+        await tools.marm_graph_trace(
+            function_name=C6_SYMBOL,
+            project=project,
+            direction="both",
+            depth=4,
+            mode="cross_service",
+        ),
+        "marm_graph_trace",
+    )
+    callees = _names(res.get("callees"))
+    reached_route = [c for c in callees if c.startswith("/")]
+    reached_python = [c for c in callees if c in C6_PYTHON_HANDLERS]
+    return {
+        "metric": "cross-service path completion",
+        "symbol": C6_SYMBOL,
+        "callees": sorted(set(callees)),
+        "reached_route": sorted(set(reached_route)),
+        "reached_python_handler": sorted(set(reached_python)),
+        "completed": bool(reached_python),
+        "dead_ends_at_route": bool(reached_route) and not reached_python,
+        "pass": bool(reached_python),
+    }
+
+
+async def _probe_all(tools, project: str, isolated: bool) -> dict:
+    results = {"provenance": _provenance(isolated, project)}
+    for name, fn in (("C1", probe_c1), ("C4", probe_c4), ("C6", probe_c6)):
+        try:
+            results[name] = await fn(tools, project)
+        except ProbeError as exc:
+            # Not a metric result. `pass` is left unset so nothing downstream can
+            # read an execution failure as a measured miss.
+            results[name] = {"execution_error": str(exc)}
+        except Exception as exc:
+            results[name] = {"execution_error": f"{type(exc).__name__}: {exc}"}
+    return results
+
+
+async def run(isolate: bool) -> dict:
+    from marm_mcp_server.services import stdio_graph_tools as tools
+
+    if not isolate:
+        print("live store, NOT verified against HEAD. Use --isolate for a real run.\n")
+        project = await _resolve_project(tools, REPO_ROOT)
+        if project is None:
+            return {"error": f"no indexed project for {REPO_ROOT}"}
+        results = await _probe_all(tools, project, isolated=False)
+        results["cleanup"] = {"ok": True, "issues": [], "note": "nothing to clean"}
+        return results
+
+    # A worktree gets its own path, so the engine files it under its own project
+    # and its own database. The live store is never opened.
+    work = Path(tempfile.mkdtemp(prefix="cga-bench-")) / "tree"
+    project = None
+    results: dict = {}
+    try:
+        print(f"worktree at {work}")
+        _git("worktree", "add", "--detach", str(work), "HEAD")
+        indexed = await tools.marm_graph_index(
+            repo_path=str(work), action="index", mode="moderate"
+        )
+        project = indexed.get("project")
+        if not project:
+            results = {"error": f"isolated index failed: {indexed}"}
+            return results
+        print(
+            f"indexed {project}: {indexed.get('nodes')} nodes, {indexed.get('edges')} edges\n"
+        )
+        results = await _probe_all(tools, project, isolated=True)
+        return results
+    finally:
+        # Recorded on the result, not merely printed. A run that measures cleanly
+        # and then strands a graph project or a repo checkout in temp has not
+        # succeeded, and once C1 starts passing an exit code that ignores this
+        # would go green while leaking a project per run.
+        issues: list[str] = []
+        if project:
+            # Order matters. The supervisor's engine child holds the store open,
+            # so a delete issued while it is alive leaves the database behind and
+            # reports nothing. stop() is terminal, which is fine: this is the last
+            # thing the run does.
+            from marm_mcp_server.core.graph_supervisor import graph_supervisor
+
+            graph_supervisor.stop()
+            status = await _drop_project(project)
+            print(f"cleanup: {status}")
+            if not status.startswith("deleted"):
+                issues.append(f"project {project}: {status}")
+        removed = _git_checked("worktree", "remove", "--force", str(work))
+        if removed:
+            issues.append(f"worktree {work}: {removed}")
+        try:
+            shutil.rmtree(work.parent)
+        except OSError as exc:
+            issues.append(f"temp dir {work.parent}: {exc}")
+        # Mutating the object already bound for return, so this reaches the caller
+        # whether the body returned normally or raised.
+        results["cleanup"] = {"ok": not issues, "issues": issues}
+
+
+def _report(r: dict) -> bool:
+    if "error" in r:
+        print(f"ERROR: {r['error']}")
+        return False
+    p = r["provenance"]
+    print(f"commit {p['commit']} ({p['branch']})  engine {p['engine_version']}")
+    print(f"isolated: {p['isolated_index']}  project {p['project']}\n")
+
+    def _emit(probe: dict, header: str, body) -> None:
+        """One path for all three, so a probe that never ran can never print a
+        verdict. Printing FAIL for an unreachable backend is what makes a broken
+        engine look like a measured graph defect."""
+        print(header)
+        if "execution_error" in probe:
+            print(f"    DID NOT RUN  {probe['execution_error']}")
+            print("    NO RESULT\n")
+            return
+        for line in body(probe):
+            print(f"    {line}")
+        print(f"    {'PASS' if probe.get('pass') else 'FAIL'}\n")
+
+    def _c1_body(d: dict):
+        yield f"callers returned: {d['caller_count']}  recall {d['recall']}"
+        if d["missing_expected"]:
+            yield f"MISSING {d['missing_expected']}"
+
+    def _c4_body(d: dict):
+        yield (
+            f"routes returned: {d['routes_returned']}  "
+            f"with handler: {d['with_handler']}  rate {d['exposure_rate']}"
+        )
+
+    def _c6_body(d: dict):
+        yield f"reached route:   {d['reached_route']}"
+        yield f"reached handler: {d['reached_python_handler']}"
+
+    _emit(r["C1"], f"C1  inbound reference recall      {C1_SYMBOL}", _c1_body)
+    _emit(r["C4"], "C4  route-to-handler exposure", _c4_body)
+    _emit(r["C6"], f"C6  cross-service path completion  {C6_SYMBOL}", _c6_body)
+
+    cleanup = r.get("cleanup") or {}
+    if not cleanup.get("ok", True):
+        print("CLEANUP FAILED")
+        for issue in cleanup.get("issues", []):
+            print(f"    {issue}")
+
+    # An execution error is not a pass and not a measured failure. It exits
+    # non-zero because the run produced no result, not because C1 missed.
+    c1_ok = "execution_error" not in r["C1"] and bool(r["C1"].get("pass"))
+    return c1_ok and (r.get("cleanup") or {}).get("ok", True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--isolate",
+        action="store_true",
+        help="index a git worktree into its own project; never touches the live store",
+    )
+    ap.add_argument("--json", type=Path, help="also write raw results here")
+    args = ap.parse_args()
+
+    results = asyncio.run(run(args.isolate))
+    run_ok = _report(results)
+    if args.json:
+        args.json.write_text(json.dumps(results, indent=2), encoding="utf-8")
+        print(f"\nraw results: {args.json}")
+    # Only C1 gates. C4 and C6 are known-failing and are the negative controls:
+    # failing the run on them would make a green build impossible until upstream
+    # changes, and would hide a C1 regression behind noise.
+    return 0 if run_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
+++ b/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
@@ -265,15 +265,33 @@ def _run(args, cleanup_failed: list[str]) -> int:
 
     work = Path(tempfile.mkdtemp(prefix="cga-repro-"))
     repo = work / "repro"
-    _write_package(repo / "pkg")
+    # The package sits at the repo root unless --nest moves it down, which is what
+    # separates this layout from MARM's marm-mcp-server/marm_mcp_server/.
+    base = repo / args.nest if args.nest else repo
+    _write_package(base / "pkg")
     if args.filler:
-        _write_filler(repo / "pkg", args.filler)
+        _write_filler(base / "pkg", args.filler)
+    # The engine resolves calls through a language server, which has to be told
+    # where the import root is. Without a project file it can only guess, so this
+    # is a variable rather than scaffolding.
+    if args.pyproject:
+        (base / "pyproject.toml").write_text(
+            '[project]\nname = "repro"\nversion = "0.1.0"\n'
+            '\n[tool.setuptools.packages.find]\nwhere = ["."]\n',
+            encoding="utf-8",
+        )
     subprocess.run(["git", "init", "-q", str(repo)], capture_output=True, timeout=60)
+    print(f"layout: pkg at {(base / 'pkg').relative_to(repo).as_posix()}")
+    if args.pyproject:
+        print(
+            f"config: pyproject.toml at {(base / 'pyproject.toml').relative_to(repo).as_posix()}"
+        )
+    print(f"mode: {args.mode}")
 
     project = None
     try:
         raw = engine_cli(
-            binary, "index_repository", "--repo-path", str(repo), "--mode", "moderate"
+            binary, "index_repository", "--repo-path", str(repo), "--mode", args.mode
         )
         indexed = json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
         project = indexed.get("project")
@@ -336,6 +354,24 @@ def main() -> int:
         type=int,
         default=0,
         help="pad the repo with N unrelated modules to test whether scale matters",
+    )
+    ap.add_argument(
+        "--nest",
+        metavar="DIR",
+        default="",
+        help="put the package under DIR instead of at the repo root, so the import "
+        "root is one level down as it is in MARM (try a plain name and a hyphenated one)",
+    )
+    ap.add_argument(
+        "--pyproject",
+        action="store_true",
+        help="write a pyproject.toml beside the package, declaring the import root",
+    )
+    ap.add_argument(
+        "--mode",
+        default="moderate",
+        choices=["fast", "moderate", "full"],
+        help="engine index mode; moderate and fast filter files, full does not",
     )
     args = ap.parse_args()
 

--- a/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
+++ b/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Minimal reproduction: which Python call shapes does the engine record as CALLS?
+
+WNA-3 in docs/current/code-graph-accuracy-benchmark.md says awaited calls are
+recorded 29.8 points less often than plain ones, and that the mechanism is
+unnamed. Counting more call sites cannot name it. This varies one property at a
+time against a generated package small enough to read in full, so the result is a
+trigger rather than a statistic.
+
+Each probe is a caller whose name encodes its shape, calling exactly one target
+named after it. A missing edge is therefore attributable to that one difference.
+
+A first pass tested `await` alone and recorded every shape, which refutes
+"awaited calls are dropped" as stated. The shapes below add what the real missed
+call in server_stdio.py carries beyond an await: keyword arguments, a call spread
+over several lines, a try block, and stacked decorators.
+
+Runs against the engine CLI, not MARM: the finding is upstream, and an issue is
+only actionable if it reproduces without this project in the picture. Indexes a
+temp directory so it gets its own project and store, then deletes both.
+
+    python scripts/benchmarking/accuracy/code-graph/repro_awaited.py
+    python scripts/benchmarking/accuracy/code-graph/repro_awaited.py --keep
+"""
+
+import argparse
+import asyncio
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from store_cleanup import (
+    drop_project,
+    engine_binary,
+    engine_cli,
+    report_kept,
+    succeeded,
+)
+
+# name -> caller source. The caller is call_<name> and its one target is
+# target_<name>, so a missing edge is attributable to that shape alone.
+SHAPES: dict[str, str] = {
+    "sync_expr": """
+def call_sync_expr():
+    x = target_sync_expr()
+    return x
+""",
+    "sync_return": """
+def call_sync_return():
+    return target_sync_return()
+""",
+    "await_assign": """
+async def call_await_assign():
+    x = await target_await_assign()
+    return x
+""",
+    "await_return": """
+async def call_await_return():
+    return await target_await_return()
+""",
+    "await_expr": """
+async def call_await_expr():
+    await target_await_expr()
+    return 1
+""",
+    "async_no_await": """
+async def call_async_no_await():
+    coro = target_async_no_await()
+    return coro
+""",
+    "await_try": """
+async def call_await_try():
+    try:
+        return await target_await_try()
+    except ValueError:
+        return None
+""",
+    "await_kwargs": """
+async def call_await_kwargs():
+    return await target_await_kwargs(action=1, name=2)
+""",
+    "await_kwargs_multiline": """
+async def call_await_kwargs_multiline():
+    return await target_await_kwargs_multiline(
+        action=1,
+        name=2,
+        data=3,
+        session_name=4,
+    )
+""",
+    "await_try_kwargs_multiline": """
+async def call_await_try_kwargs_multiline():
+    try:
+        return await target_await_try_kwargs_multiline(
+            action=1,
+            name=2,
+            data=3,
+        )
+    except ValueError:
+        return None
+""",
+    "decorated_await": """
+@simple_decorator
+async def call_decorated_await():
+    return await target_decorated_await()
+""",
+    "decorated_await_kwargs_multiline": """
+@simple_decorator
+@second_decorator()
+async def call_decorated_await_kwargs_multiline():
+    try:
+        return await target_decorated_await_kwargs_multiline(
+            action=1,
+            name=2,
+            data=3,
+        )
+    except ValueError:
+        return None
+""",
+    "decorated_sync": """
+@simple_decorator
+def call_decorated_sync():
+    return target_decorated_sync()
+""",
+    "sync_kwargs_multiline": """
+def call_sync_kwargs_multiline():
+    return target_sync_kwargs_multiline(
+        action=1,
+        name=2,
+    )
+""",
+}
+
+DECORATORS = """def simple_decorator(fn):
+    return fn
+
+
+def second_decorator():
+    def wrap(fn):
+        return fn
+
+    return wrap
+"""
+
+# The shapes above all import at the top of the module, relatively. Every real
+# missed call in server_stdio.py does one of these three instead, so each gets its
+# own module to keep import style from mixing with import position.
+IMPORT_STYLES: dict[str, str] = {
+    "relative_top": """from .targets import target_relative_top
+
+
+async def call_relative_top():
+    return await target_relative_top(action=1)
+""",
+    "absolute_top": """from pkg.targets import target_absolute_top
+
+
+async def call_absolute_top():
+    return await target_absolute_top(action=1)
+""",
+    "absolute_late": '''"""Import below module-level code, which is what earns a noqa: E402."""
+
+import os
+
+_MARKER = os.sep
+
+from pkg.targets import target_absolute_late  # noqa: E402
+
+
+async def call_absolute_late():
+    return await target_absolute_late(action=1)
+''',
+    "function_body": """async def call_function_body():
+    from pkg.targets import target_function_body
+
+    return await target_function_body(action=1)
+""",
+}
+
+
+ALL_PROBES = {**SHAPES, **IMPORT_STYLES}
+
+
+def _is_async(name: str) -> bool:
+    return "await" in ALL_PROBES[name]
+
+
+def _write_package(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    (root / "deco.py").write_text(DECORATORS, encoding="utf-8")
+
+    # *args/**kwargs so a target never fails to accept a shape's call, keeping the
+    # signature from becoming a second variable.
+    targets = [
+        f"{'async def' if _is_async(name) else 'def'} target_{name}(*args, **kwargs):\n"
+        f"    return {len(name)}\n"
+        for name in ALL_PROBES
+    ]
+    (root / "targets.py").write_text("\n".join(targets), encoding="utf-8")
+
+    imports = ", ".join(f"target_{n}" for n in SHAPES)
+    body = [
+        f"from .targets import {imports}",
+        "from .deco import simple_decorator, second_decorator",
+        "",
+    ]
+    body.extend(SHAPES.values())
+    (root / "callers.py").write_text("\n".join(body), encoding="utf-8")
+
+    # One module each, so import style and import position never mix.
+    for name, source in IMPORT_STYLES.items():
+        (root / f"imp_{name}.py").write_text(source, encoding="utf-8")
+
+
+def _write_filler(root: Path, modules: int) -> None:
+    """Unrelated modules, to move project size without touching the probes.
+
+    Every probe shape is recorded in a 69-node project while the same shapes are
+    missing from a 4,058-node one, so size is the remaining untested variable.
+    The filler never references a probe, so any change in probe edges is
+    attributable to scale alone.
+    """
+    filler = root / "filler"
+    filler.mkdir(parents=True, exist_ok=True)
+    (filler / "__init__.py").write_text("", encoding="utf-8")
+    for i in range(modules):
+        lines = [f"def filler_{i}_helper(x):\n    return x + {i}\n"]
+        for j in range(6):
+            lines.append(
+                f"async def filler_{i}_fn_{j}(x):\n"
+                f"    y = filler_{i}_helper(x)\n"
+                f"    return await filler_{i}_fn_{(j + 1) % 6}(y) if x else y\n"
+            )
+        (filler / f"mod_{i:04d}.py").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _edges(store: Path) -> set[tuple[str, str]]:
+    conn = sqlite3.connect(str(store))
+    try:
+        return {
+            (s, t)
+            for s, t in conn.execute(
+                """SELECT s.name, t.name FROM edges e
+                   JOIN nodes s ON s.id = e.source_id
+                   JOIN nodes t ON t.id = e.target_id
+                   WHERE e.type = 'CALLS'"""
+            )
+        }
+    finally:
+        conn.close()
+
+
+def _run(args, cleanup_failed: list[str]) -> int:
+    binary = engine_binary()
+    if binary is None or not binary.exists():
+        print("engine binary not found; run MARM once to download it")
+        return 2
+
+    work = Path(tempfile.mkdtemp(prefix="cga-repro-"))
+    repo = work / "repro"
+    _write_package(repo / "pkg")
+    if args.filler:
+        _write_filler(repo / "pkg", args.filler)
+    subprocess.run(["git", "init", "-q", str(repo)], capture_output=True, timeout=60)
+
+    project = None
+    try:
+        raw = engine_cli(
+            binary, "index_repository", "--repo-path", str(repo), "--mode", "moderate"
+        )
+        indexed = json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
+        project = indexed.get("project")
+        store = Path.home() / ".cache" / "codebase-memory-mcp" / f"{project}.db"
+        if not store.exists():
+            print(f"no store at {store}")
+            return 2
+
+        edges = _edges(store)
+        print(f"indexed {indexed.get('nodes')} nodes, {indexed.get('edges')} edges\n")
+        print(f"{'shape':34} {'awaited':>8} {'recorded':>9}")
+        results = {
+            name: (f"call_{name}", f"target_{name}") in edges for name in ALL_PROBES
+        }
+        for name in SHAPES:
+            print(f"{name:34} {_is_async(name)!s:>8} {results[name]!s:>9}")
+        print()
+        print(f"{'import style':34} {'awaited':>8} {'recorded':>9}")
+        for name in IMPORT_STYLES:
+            print(f"{name:34} {_is_async(name)!s:>8} {results[name]!s:>9}")
+
+        aw = [n for n in ALL_PROBES if _is_async(n)]
+        pl = [n for n in ALL_PROBES if not _is_async(n)]
+        print(
+            f"\nawaited: {sum(results[n] for n in aw)}/{len(aw)}   "
+            f"plain: {sum(results[n] for n in pl)}/{len(pl)}"
+        )
+        missed = [n for n, ok in results.items() if not ok]
+        print(f"missed: {missed or 'none'}")
+        return 0
+    finally:
+        # Same contract as pilot.py, via the shared helper: gated, confirmed
+        # twice, and reported. An orphaned project here lands in the store a
+        # running MARM is using, so a silent failure is not acceptable.
+        issues: list[str] = []
+        if project and not args.keep:
+            status = asyncio.run(drop_project(project))
+            print(f"cleanup: {status}")
+            if not succeeded(status):
+                issues.append(f"project {project}: {status}")
+        if not args.keep:
+            try:
+                shutil.rmtree(work)
+            except OSError as exc:
+                issues.append(f"temp dir {work}: {exc}")
+        else:
+            report_kept(project, repo)
+        cleanup_failed.extend(issues)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep the generated files AND the indexed graph project (both need removing by hand afterwards)",
+    )
+    ap.add_argument(
+        "--filler",
+        type=int,
+        default=0,
+        help="pad the repo with N unrelated modules to test whether scale matters",
+    )
+    args = ap.parse_args()
+
+    # Collected by _run's finally block so a leaked project fails the command,
+    # matching pilot.py. A cleanup message nobody acts on is how a race stays
+    # invisible.
+    cleanup_failed: list[str] = []
+    code = _run(args, cleanup_failed)
+    if cleanup_failed:
+        print("CLEANUP FAILED")
+        for issue in cleanup_failed:
+            print(f"    {issue}")
+        return 1
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
+++ b/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
@@ -39,6 +39,7 @@ from store_cleanup import (
     drop_project,
     engine_binary,
     engine_cli,
+    gated,
     report_kept,
     succeeded,
 )
@@ -290,8 +291,18 @@ def _run(args, cleanup_failed: list[str]) -> int:
 
     project = None
     try:
-        raw = engine_cli(
-            binary, "index_repository", "--repo-path", str(repo), "--mode", args.mode
+        # Gated: this writes the shared project list a running MARM is reading.
+        raw = asyncio.run(
+            gated(
+                f"cga_repro_index:{repo.name}",
+                engine_cli,
+                binary,
+                "index_repository",
+                "--repo-path",
+                str(repo),
+                "--mode",
+                args.mode,
+            )
         )
         indexed = json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
         project = indexed.get("project")

--- a/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
+++ b/scripts/benchmarking/accuracy/code-graph/repro_awaited.py
@@ -28,7 +28,6 @@ import asyncio
 import json
 import shutil
 import sqlite3
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -40,6 +39,7 @@ from store_cleanup import (
     engine_binary,
     engine_cli,
     gated,
+    git_init,
     report_kept,
     succeeded,
 )
@@ -258,14 +258,8 @@ def _edges(store: Path) -> set[tuple[str, str]]:
         conn.close()
 
 
-def _run(args, cleanup_failed: list[str]) -> int:
-    binary = engine_binary()
-    if binary is None or not binary.exists():
-        print("engine binary not found; run MARM once to download it")
-        return 2
-
-    work = Path(tempfile.mkdtemp(prefix="cga-repro-"))
-    repo = work / "repro"
+def _build_fixture(args, repo: Path) -> None:
+    """Write the generated package and initialise the repo, reporting the layout."""
     # The package sits at the repo root unless --nest moves it down, which is what
     # separates this layout from MARM's marm-mcp-server/marm_mcp_server/.
     base = repo / args.nest if args.nest else repo
@@ -281,16 +275,32 @@ def _run(args, cleanup_failed: list[str]) -> int:
             '\n[tool.setuptools.packages.find]\nwhere = ["."]\n',
             encoding="utf-8",
         )
-    subprocess.run(["git", "init", "-q", str(repo)], capture_output=True, timeout=60)
+    git_init(repo)
     print(f"layout: pkg at {(base / 'pkg').relative_to(repo).as_posix()}")
     if args.pyproject:
-        print(
-            f"config: pyproject.toml at {(base / 'pyproject.toml').relative_to(repo).as_posix()}"
-        )
+        rel = (base / "pyproject.toml").relative_to(repo).as_posix()
+        print(f"config: pyproject.toml at {rel}")
     print(f"mode: {args.mode}")
 
+
+def _run(args, cleanup_failed: list[str]) -> int:
+    binary = engine_binary()
+    if binary is None or not binary.exists():
+        print("engine binary not found; run MARM once to download it")
+        return 2
+
+    work = Path(tempfile.mkdtemp(prefix="cga-repro-"))
+    repo = work / "repro"
     project = None
     try:
+        # Inside the cleanup scope: --filler writes hundreds of files and a failure
+        # partway used to leave the whole tree behind.
+        try:
+            _build_fixture(args, repo)
+        except (OSError, RuntimeError) as exc:
+            print(f"SETUP FAILED: {exc}")
+            return 2
+
         # Gated: this writes the shared project list a running MARM is reading.
         raw = asyncio.run(
             gated(

--- a/scripts/benchmarking/accuracy/code-graph/repro_routes.py
+++ b/scripts/benchmarking/accuracy/code-graph/repro_routes.py
@@ -22,8 +22,8 @@ than no fixture.
     python scripts/benchmarking/accuracy/code-graph/repro_routes.py
     python scripts/benchmarking/accuracy/code-graph/repro_routes.py --keep
 
-Exit: 0 both findings reproduced, 1 cleanup failed, 2 engine missing,
-3 C4 reproduced but the C6 precondition was not met.
+Exit: 0 both findings reproduced, 1 cleanup failed, 2 setup or engine failed,
+3 C4 reproduced but the C6 precondition was not met, 4 C4 did not reproduce.
 """
 
 import argparse
@@ -31,7 +31,6 @@ import asyncio
 import json
 import shutil
 import sqlite3
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -43,6 +42,7 @@ from store_cleanup import (
     engine_binary,
     engine_cli,
     gated,
+    git_init,
     report_kept,
     succeeded,
 )
@@ -88,7 +88,7 @@ def _build(repo: Path) -> None:
         ' "include": ["src"]}\n',
         encoding="utf-8",
     )
-    subprocess.run(["git", "init", "-q", str(repo)], capture_output=True, timeout=60)
+    git_init(repo)
 
 
 def _handles_edges(store: Path) -> list[tuple[str, str]]:
@@ -130,10 +130,15 @@ def _run(args, cleanup_failed: list[str]) -> int:
 
     work = Path(tempfile.mkdtemp(prefix="cga-routes-"))
     repo = work / "repro"
-    _build(repo)
-
     project = None
     try:
+        # Inside the cleanup scope: a failed setup used to leave the tree behind.
+        try:
+            _build(repo)
+        except (OSError, RuntimeError) as exc:
+            print(f"SETUP FAILED: {exc}")
+            return 2
+
         # Gated: this writes the shared project list a running MARM is reading.
         raw = asyncio.run(
             gated(
@@ -162,6 +167,10 @@ def _run(args, cleanup_failed: list[str]) -> int:
         print(json.dumps(routes, indent=2))
         filled = [r for r in routes if (r.get("handler") or "").strip()]
         print(f"\nroutes: {len(routes)}   with non-empty handler: {len(filled)}")
+        # C4 reproduces only when routes came back AND none carry a handler. No
+        # routes at all is an indexing problem, not the finding; handlers populated
+        # means it was fixed upstream, which must not read as a successful repro.
+        c4_ready = bool(routes) and not filled
 
         print("\n## HANDLES edges actually in the store")
         edges = _handles_edges(store) if store.exists() else []
@@ -192,12 +201,24 @@ def _run(args, cleanup_failed: list[str]) -> int:
         print(f"\nreached the Python handler: {bool(reached)}")
 
         print("\n## Route node keys")
-        routes = _route_keys(store)
-        for qname in routes:
+        route_keys = _route_keys(store)
+        for qname in route_keys:
             print(f"  {qname}")
 
-        c6_ready = any("__route__ANY__" in q for q in routes)
-        print(f"\nC6 precondition, a client-side route node exists: {c6_ready}")
+        c6_ready = any("__route__ANY__" in q for q in route_keys)
+        print("\n## Reproduction status")
+        print(f"  C4 (routes returned, no handler populated): {c4_ready}")
+        print(f"  C6 (a client-side route node exists):       {c6_ready}")
+
+        if not c4_ready:
+            print(
+                "\n"
+                "C4 NOT REPRODUCED. Either no routes came back, which is an indexing\n"
+                "problem rather than the finding, or a handler was populated, which\n"
+                "means the defect was fixed upstream. Re-check the engine version and\n"
+                "the issue tracker before filing: an earlier draft in this repo was\n"
+                "written against a version that had already fixed it."
+            )
         if not c6_ready:
             print(
                 "\n"
@@ -209,6 +230,8 @@ def _run(args, cleanup_failed: list[str]) -> int:
                 "nodes. Until the recognised client shape is known, C4 above is the\n"
                 "only finding this fixture reproduces."
             )
+        if not c4_ready:
+            return 4
         return 0 if c6_ready else 3
     finally:
         issues: list[str] = []

--- a/scripts/benchmarking/accuracy/code-graph/repro_routes.py
+++ b/scripts/benchmarking/accuracy/code-graph/repro_routes.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Executed minimal reproductions for the two route findings.
+
+The drafts in docs/current/upstream/ were written from evidence gathered against
+MARM itself, which is not an upstream-quality report: a maintainer needs the
+smallest project that shows the behaviour, plus the command output it produces.
+This builds exactly that project and runs the two commands against it.
+
+  C4  get_architecture returns routes[].handler empty despite HANDLES edges
+  C6  trace_path --mode cross_service never reaches the server handler
+
+Nine lines of Python and eight of TypeScript, one route, one client call. Runs
+against the engine CLI so nothing about MARM is in the picture. Prints the
+verbatim output to paste into an issue.
+
+    python scripts/benchmarking/accuracy/code-graph/repro_routes.py
+    python scripts/benchmarking/accuracy/code-graph/repro_routes.py --keep
+"""
+
+import argparse
+import asyncio
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from store_cleanup import (
+    drop_project,
+    engine_binary,
+    engine_cli,
+    report_kept,
+    succeeded,
+)
+
+SERVER_PY = """from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/api/memories/{memory_id}")
+async def get_memory(memory_id: str):
+    return {"id": memory_id}
+"""
+
+# Literal path strings, matching how a generated API client is usually written.
+# An interpolated template (`${BASE}/memories/${id}`) produces no client-side route
+# node at all, so it cannot show the key mismatch this is meant to demonstrate.
+CLIENT_TS = """export async function getMemory(id: string) {
+  const res = await fetch("/api/memories/:id", { method: "GET" });
+  return res.json();
+}
+
+export async function listMemories() {
+  const res = await fetch("/api/memories", { method: "GET" });
+  return res.json();
+}
+"""
+
+
+def _build(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "server.py").write_text(SERVER_PY, encoding="utf-8")
+    (repo / "src").mkdir(exist_ok=True)
+    (repo / "src" / "client.ts").write_text(CLIENT_TS, encoding="utf-8")
+    # Project markers, in case the TypeScript side is only analysed inside a
+    # recognised project. Without them a lone .ts file produced no client-side
+    # route node at all.
+    (repo / "package.json").write_text(
+        '{"name": "repro", "version": "1.0.0", "type": "module"}\n', encoding="utf-8"
+    )
+    (repo / "tsconfig.json").write_text(
+        '{"compilerOptions": {"target": "ES2020", "module": "ESNext"},'
+        ' "include": ["src"]}\n',
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(repo)], capture_output=True, timeout=60)
+
+
+def _handles_edges(store: Path) -> list[tuple[str, str]]:
+    conn = sqlite3.connect(str(store))
+    try:
+        return list(
+            conn.execute(
+                """SELECT s.name, t.qualified_name FROM edges e
+                   JOIN nodes s ON s.id = e.source_id
+                   JOIN nodes t ON t.id = e.target_id
+                   WHERE e.type = 'HANDLES'"""
+            )
+        )
+    finally:
+        conn.close()
+
+
+def _run(args, cleanup_failed: list[str]) -> int:
+    binary = engine_binary()
+    if binary is None or not binary.exists():
+        print("engine binary not found; run MARM once to download it")
+        return 2
+
+    work = Path(tempfile.mkdtemp(prefix="cga-routes-"))
+    repo = work / "repro"
+    _build(repo)
+
+    project = None
+    try:
+        raw = engine_cli(
+            binary, "index_repository", "--repo-path", str(repo), "--mode", "moderate"
+        )
+        indexed = json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
+        project = indexed.get("project")
+        print(
+            f"# indexed: {indexed.get('nodes')} nodes, {indexed.get('edges')} edges\n"
+        )
+
+        store = Path.home() / ".cache" / "codebase-memory-mcp" / f"{project}.db"
+
+        print("## C4: get_architecture routes[]")
+        arch_raw = engine_cli(binary, "get_architecture", "--project", project)
+        arch = json.loads(arch_raw[arch_raw.find("{") : arch_raw.rfind("}") + 1])
+        routes = arch.get("routes") or []
+        print(json.dumps(routes, indent=2))
+        filled = [r for r in routes if (r.get("handler") or "").strip()]
+        print(f"\nroutes: {len(routes)}   with non-empty handler: {len(filled)}")
+
+        print("\n## HANDLES edges actually in the store")
+        edges = _handles_edges(store) if store.exists() else []
+        for src, dst in edges:
+            print(f"  {src} -> {dst}")
+        print(f"HANDLES edges: {len(edges)}")
+
+        print("\n## C6: trace_path --mode cross_service from getMemory")
+        trace_raw = engine_cli(
+            binary,
+            "trace_path",
+            "--function-name",
+            "getMemory",
+            "--project",
+            project,
+            "--mode",
+            "cross_service",
+            "--depth",
+            "4",
+        )
+        trace = json.loads(trace_raw[trace_raw.find("{") : trace_raw.rfind("}") + 1])
+        print(json.dumps(trace, indent=2))
+        reached = [
+            c.get("name")
+            for c in (trace.get("callees") or [])
+            if isinstance(c, dict) and c.get("name") == "get_memory"
+        ]
+        print(f"\nreached the Python handler: {bool(reached)}")
+
+        print("\n## Route node keys")
+        if store.exists():
+            conn = sqlite3.connect(str(store))
+            for qname in conn.execute(
+                "SELECT qualified_name FROM nodes WHERE label='Route' ORDER BY qualified_name"
+            ):
+                print(f"  {qname[0]}")
+            conn.close()
+        return 0
+    finally:
+        issues: list[str] = []
+        if project and not args.keep:
+            status = asyncio.run(drop_project(project))
+            print(f"\ncleanup: {status}")
+            if not succeeded(status):
+                issues.append(f"project {project}: {status}")
+        if not args.keep:
+            try:
+                shutil.rmtree(work)
+            except OSError as exc:
+                issues.append(f"temp dir {work}: {exc}")
+        else:
+            report_kept(project, repo)
+        cleanup_failed.extend(issues)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep the generated files AND the indexed graph project (both need removing by hand afterwards)",
+    )
+    args = ap.parse_args()
+
+    cleanup_failed: list[str] = []
+    code = _run(args, cleanup_failed)
+    if cleanup_failed:
+        print("CLEANUP FAILED")
+        for issue in cleanup_failed:
+            print(f"    {issue}")
+        return 1
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmarking/accuracy/code-graph/repro_routes.py
+++ b/scripts/benchmarking/accuracy/code-graph/repro_routes.py
@@ -13,8 +13,17 @@ Nine lines of Python and eight of TypeScript, one route, one client call. Runs
 against the engine CLI so nothing about MARM is in the picture. Prints the
 verbatim output to paste into an issue.
 
+C4 reproduces here. C6 does not, and the run says so: a direct `fetch` produces no
+client-side Route node, so without one there is nothing to mismatch and the trace
+measures client-call recognition instead of the route-key join. Exit 3 marks that,
+because a fixture that looks like it tests C6 while testing something else is worse
+than no fixture.
+
     python scripts/benchmarking/accuracy/code-graph/repro_routes.py
     python scripts/benchmarking/accuracy/code-graph/repro_routes.py --keep
+
+Exit: 0 both findings reproduced, 1 cleanup failed, 2 engine missing,
+3 C4 reproduced but the C6 precondition was not met.
 """
 
 import argparse
@@ -33,6 +42,7 @@ from store_cleanup import (
     drop_project,
     engine_binary,
     engine_cli,
+    gated,
     report_kept,
     succeeded,
 )
@@ -96,6 +106,22 @@ def _handles_edges(store: Path) -> list[tuple[str, str]]:
         conn.close()
 
 
+def _route_keys(store: Path) -> list[str]:
+    if not store.exists():
+        return []
+    conn = sqlite3.connect(str(store))
+    try:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT qualified_name FROM nodes WHERE label='Route' "
+                "ORDER BY qualified_name"
+            )
+        ]
+    finally:
+        conn.close()
+
+
 def _run(args, cleanup_failed: list[str]) -> int:
     binary = engine_binary()
     if binary is None or not binary.exists():
@@ -108,8 +134,18 @@ def _run(args, cleanup_failed: list[str]) -> int:
 
     project = None
     try:
-        raw = engine_cli(
-            binary, "index_repository", "--repo-path", str(repo), "--mode", "moderate"
+        # Gated: this writes the shared project list a running MARM is reading.
+        raw = asyncio.run(
+            gated(
+                f"cga_routes_index:{repo.name}",
+                engine_cli,
+                binary,
+                "index_repository",
+                "--repo-path",
+                str(repo),
+                "--mode",
+                "moderate",
+            )
         )
         indexed = json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
         project = indexed.get("project")
@@ -156,14 +192,24 @@ def _run(args, cleanup_failed: list[str]) -> int:
         print(f"\nreached the Python handler: {bool(reached)}")
 
         print("\n## Route node keys")
-        if store.exists():
-            conn = sqlite3.connect(str(store))
-            for qname in conn.execute(
-                "SELECT qualified_name FROM nodes WHERE label='Route' ORDER BY qualified_name"
-            ):
-                print(f"  {qname[0]}")
-            conn.close()
-        return 0
+        routes = _route_keys(store)
+        for qname in routes:
+            print(f"  {qname}")
+
+        c6_ready = any("__route__ANY__" in q for q in routes)
+        print(f"\nC6 precondition, a client-side route node exists: {c6_ready}")
+        if not c6_ready:
+            print(
+                "\n"
+                "C6 NOT REPRODUCED. Only server-declared routes were indexed, so the\n"
+                "trace above measures whether the client call was recognised at all,\n"
+                "NOT the __route__ANY__ to __route__GET__ join failure it is meant to\n"
+                "show. A direct fetch() is not detected; the real project's client\n"
+                "calls through a shared request() wrapper and does produce these\n"
+                "nodes. Until the recognised client shape is known, C4 above is the\n"
+                "only finding this fixture reproduces."
+            )
+        return 0 if c6_ready else 3
     finally:
         issues: list[str] = []
         if project and not args.keep:

--- a/scripts/benchmarking/accuracy/code-graph/store_cleanup.py
+++ b/scripts/benchmarking/accuracy/code-graph/store_cleanup.py
@@ -122,6 +122,23 @@ async def drop_project(project: str) -> str:
         return f"gate busy ({exc}), remove {project} by hand"
 
 
+async def gated(purpose: str, fn, *args, **kwargs):
+    """Run one engine store mutation under the cross-process gate.
+
+    AGENTS.md: every code-index call and every delete_project takes the graph gate.
+    A harness indexing a throwaway project still writes the shared project list a
+    running MARM is reading, so "it is only a temp project" does not exempt it.
+
+    Raises GraphIndexBusy when another index holds the lease. Never waits, matching
+    the gate's contract: a benchmark has something better to do than block, and a
+    run that silently queued behind a 40s index would report that wait as its own
+    index time.
+    """
+    from marm_mcp_server.core.graph_index_lock import run_exclusive
+
+    return await run_exclusive(purpose, fn, *args, **kwargs)
+
+
 def succeeded(status: str) -> bool:
     return status.startswith("deleted")
 

--- a/scripts/benchmarking/accuracy/code-graph/store_cleanup.py
+++ b/scripts/benchmarking/accuracy/code-graph/store_cleanup.py
@@ -122,6 +122,27 @@ async def drop_project(project: str) -> str:
         return f"gate busy ({exc}), remove {project} by hand"
 
 
+def git_init(root: Path) -> None:
+    """Initialise a throwaway fixture repo, raising with a reason if it fails.
+
+    The engine reads git state, recording a branch on every project it indexes, so a
+    tree whose init silently failed is not the fixture the run reports on. An
+    unchecked call also hid a missing git executable, which then surfaced as an
+    unexplained difference in the results.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "init", "-q", str(root)], capture_output=True, timeout=120
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("git not found on PATH; the fixture needs a repo") from exc
+    except subprocess.SubprocessError as exc:
+        raise RuntimeError(f"git init failed: {exc}") from exc
+    if proc.returncode:
+        detail = proc.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git init failed (exit {proc.returncode}): {detail}")
+
+
 async def gated(purpose: str, fn, *args, **kwargs):
     """Run one engine store mutation under the cross-process gate.
 

--- a/scripts/benchmarking/accuracy/code-graph/store_cleanup.py
+++ b/scripts/benchmarking/accuracy/code-graph/store_cleanup.py
@@ -1,0 +1,143 @@
+"""Verified teardown of a throwaway project from the shared engine store.
+
+Extracted because two harnesses need it and a second, weaker copy is exactly how
+one of them starts leaking projects. Both pilot.py and repro_awaited.py index into
+`~/.cache/codebase-memory-mcp`, which a running MARM server is also using.
+
+Two things here are load-bearing and neither is obvious:
+
+Deletion goes through run_exclusive, the same cross-process lease every other
+engine store mutation takes. A MARM server on this machine re-indexes watched
+projects on a 30s cycle, and a throwaway project joins that watch set the moment
+it is indexed, so an ungated delete can be undone by the other process.
+
+Deletion is confirmed twice with a pause between. A single check straight after
+the delete reports success it has not earned: the engine child writes its store
+back a moment later, so the project reads as absent and is present again by the
+time the command exits. That was observed reporting "deleted" with the database
+still on disk.
+"""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[4] / "marm-mcp-server"
+if str(_PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_ROOT))
+
+
+def engine_binary() -> Path | None:
+    try:
+        from codebase_memory_mcp import _cli
+
+        return _cli._bin_path(_cli._version())
+    except Exception:
+        return None
+
+
+def engine_cli(binary: Path, *args: str, timeout: float = 120.0) -> str:
+    """Run one engine CLI command. Never raises; a timeout returns a marker.
+
+    Bounded deliberately. Cleanup runs while holding the cross-process lease, and
+    an engine call that blocks on the shared store holds it for as long as the
+    call runs. With a 300s timeout and five attempts, a single teardown wedged the
+    gate for eleven minutes and had to be killed.
+    """
+    try:
+        proc = subprocess.run(
+            [str(binary), "cli", *args], capture_output=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return f"__timeout__ after {timeout}s"
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"__error__ {exc}"
+    if proc.returncode:
+        detail = proc.stderr.decode(errors="replace").strip()
+        return f"__error__ exit {proc.returncode}{f': {detail}' if detail else ''}"
+    return proc.stdout.decode(errors="replace")
+
+
+# Whole teardown budget. The lease is held for this long at worst, so it is kept
+# well inside the lease TTL rather than left to the per-call timeout to bound.
+_CLEANUP_BUDGET_SECONDS = 45.0
+_CALL_TIMEOUT_SECONDS = 20.0
+
+
+def _delete_and_confirm(binary: Path, project: str) -> str:
+    deadline = time.monotonic() + _CLEANUP_BUDGET_SECONDS
+
+    def listing() -> str:
+        return engine_cli(binary, "list_projects", timeout=_CALL_TIMEOUT_SECONDS)
+
+    attempt = 0
+    while time.monotonic() < deadline:
+        attempt += 1
+        out = engine_cli(
+            binary,
+            "delete_project",
+            "--project",
+            project,
+            timeout=_CALL_TIMEOUT_SECONDS,
+        )
+        if out.startswith("__"):
+            return f"delete failed ({out}), remove {project} by hand"
+        time.sleep(1.0)
+        # Confirmed twice with a gap: a single check straight after the delete
+        # reports success it has not earned, because the engine child writes its
+        # store back a moment later.
+        first_listing = listing()
+        if first_listing.startswith("__"):
+            return (
+                f"could not verify deletion ({first_listing}), remove {project} by hand"
+            )
+        if project not in first_listing:
+            time.sleep(0.75)
+            second_listing = listing()
+            if second_listing.startswith("__"):
+                return f"could not verify deletion ({second_listing}), remove {project} by hand"
+            if project not in second_listing:
+                return "deleted" if attempt == 1 else f"deleted after {attempt} tries"
+    return f"still present after {attempt} tries, remove {project} by hand"
+
+
+async def drop_project(project: str) -> str:
+    """Remove a project's store. Returns a status string; "deleted" prefixes mean ok.
+
+    Via the engine CLI because marm_graph_index exposes no delete action: its
+    actions are auto/index/status/list plus the auto_* switches.
+    """
+    binary = engine_binary()
+    if binary is None or not binary.exists():
+        return "could not resolve engine binary"
+
+    from marm_mcp_server.core.graph_index_lock import GraphIndexBusy, run_exclusive
+
+    try:
+        return await run_exclusive(
+            f"cga_cleanup:{project}", _delete_and_confirm, binary, project
+        )
+    except GraphIndexBusy as exc:
+        return f"gate busy ({exc}), remove {project} by hand"
+
+
+def succeeded(status: str) -> bool:
+    return status.startswith("deleted")
+
+
+def report_kept(project: str | None, path: Path) -> None:
+    """Say what --keep left behind, including the part that is not a directory.
+
+    The generated files are obvious; the indexed project is not. It sits in the
+    shared engine store that a running MARM also uses, so leaving it unannounced
+    means it is found later as an unexplained project with a temp-directory name.
+    """
+    print()
+    print(f"kept: files at {path}")
+    if not project:
+        return
+    print(f"kept: graph project {project}")
+    binary = engine_binary()
+    location = binary if binary else "codebase-memory-mcp"
+    print(f'  remove with: "{location}" cli delete_project --project {project}')

--- a/scripts/benchmarking/docs/upstream/issue-c4-empty-route-handlers.md
+++ b/scripts/benchmarking/docs/upstream/issue-c4-empty-route-handlers.md
@@ -1,0 +1,79 @@
+# Upstream issue draft: get_architecture returns empty route handlers
+
+**Repo**: DeusData/codebase-memory-mcp
+**Versions**: fails identically on 0.9.0 and 0.10.5 (Windows 11, `moderate` index mode)
+**Ready to file.** Output below is verbatim from a 24-node project built by `scripts/benchmarking/accuracy/code-graph/repro_routes.py`.
+
+---
+
+## Title
+
+`get_architecture` returns `routes[].handler` empty for every route despite `HANDLES` edges existing in the store
+
+## Summary
+
+`get_architecture` returns a `routes` array shaped `{method, path, handler}`. The `handler` field is an empty string on every entry, including routes whose handler is recorded in the graph.
+
+The information is present. In one repo the store holds **94 `HANDLES` edges** covering 92 distinct `Route` nodes, roughly 98% of the 94 routes declared in source. `get_architecture` reports **0 populated handlers out of the 20 routes it returns.**
+
+## Reproduction
+
+Any FastAPI project. Minimal:
+
+```python
+# server.py
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/api/memories/{memory_id}")
+async def get_memory(memory_id: str):
+    return {"id": memory_id}
+```
+
+```
+codebase-memory-mcp cli index_repository --repo-path <repo> --mode moderate
+codebase-memory-mcp cli get_architecture --project <project>
+```
+
+On 0.10.5 add `--aspects routes`, which prints the same routes as a `method path handler` table with `-` in the handler column.
+
+**Observed**, on a project containing only the file above plus one TypeScript client:
+
+```
+# indexed: 24 nodes, 28 edges
+
+## get_architecture routes[]
+[
+  {
+    "method": "GET",
+    "path": "/api/memories/{memory_id}",
+    "handler": ""
+  }
+]
+
+routes: 1   with non-empty handler: 0
+```
+
+**Expected**: `"handler": "get_memory"`, or the handler's qualified name.
+
+The edge is in the store, queried from the same index:
+
+```
+## HANDLES edges actually in the store
+  get_memory -> __route__GET__/api/memories/{}
+HANDLES edges: 1
+```
+
+So one route, one `HANDLES` edge naming its handler, and `handler` returned empty.
+
+## Impact
+
+This is the only public way to ask which handler serves a route. `trace_path` has no mode that follows `HANDLES` (`calls` follows `CALLS`, `cross_service` follows `HTTP_CALLS` through routes), and symbol search returns routes and functions without any relation between them. So a consumer cannot answer "which code runs for this endpoint" through the tool surface, even though the graph knows.
+
+Because the field is present and empty rather than absent, a consumer reading it concludes the handler is unknown rather than that the field is unimplemented.
+
+## Secondary observation
+
+`routes` appears to cap at 20 entries with no pagination or total count in the response, so a project with more routes cannot enumerate them. Still 20 on 0.10.5, where `trace_path` and `search_graph` gained `limit`/`cursor` pagination but `get_architecture` did not. Worth confirming whether the cap is intended; if so, a `total` field would at least let a caller detect truncation.

--- a/scripts/benchmarking/docs/upstream/issue-c6-route-key-mismatch.md
+++ b/scripts/benchmarking/docs/upstream/issue-c6-route-key-mismatch.md
@@ -1,0 +1,86 @@
+# Upstream issue draft: cross_service reaches the client route node and stops
+
+**Repo**: DeusData/codebase-memory-mcp
+**Versions**: fails identically on 0.9.0 and 0.10.5 (Windows 11, `moderate` index mode)
+**Ready to file.** The dead end is visible in 0.10.5's own output. The minimal reproduction covers only the server half, and that limitation is stated below rather than hidden.
+
+---
+
+## Title
+
+`trace_path --mode cross_service` reaches the client's `__route__ANY__` node and stops: client and server route nodes are keyed differently and never join
+
+## Summary
+
+A TypeScript client calling an HTTP endpoint and the Python handler that serves it are both indexed, and the graph never connects them. The trace is not failing to find the client side. It reaches a client route node at hop 1 and stops there, because that node is keyed with method `ANY` while the server's is keyed with the concrete verb.
+
+`--include-evidence` in 0.10.5 makes this legible: the route node comes back with an empty strategy and an empty confidence, unlike every other hop in the same response.
+
+## Evidence
+
+`trace_path --function-name getMemory --mode cross_service --depth 4 --include-evidence true`, on a 4,100-node project containing a FastAPI server and a TypeScript client:
+
+```
+function: getMemory
+direction: both
+mode: cross_service
+callees_total: 4
+callees: 4  (rows: name hop strategy confidence; qn = group prefix + "." + name)
+  __route__ANY__/memories/{} 1 - -
+<project>.marm-console.src.lib.marm-api:
+  MarmApiError 2 heuristic 0.90
+  buildQuery  2 lsp       0.95
+  request     1 heuristic 0.90
+callers_total: 0
+```
+
+The route node is reached. Three sibling hops in the same trace resolve with a strategy and a confidence; the route node has neither. Traversal continues sideways into other client functions and never crosses to Python.
+
+The expected continuation is `get_memory`, the FastAPI handler for `GET /api/memories/{memory_id}`, which is indexed in the same project and carries a `HANDLES` edge.
+
+## The key difference
+
+Both sides exist in the store under different qualified names:
+
+| Side | Qualified name |
+|---|---|
+| Server declaration (FastAPI `@router.get`) | `__route__GET__/api/memories/{}` |
+| Client call (TypeScript, via a `request()` wrapper) | `__route__ANY__/memories/{}` |
+
+Two differences, in the order we think they matter:
+
+1. **Method.** The client route records `ANY`. If traversal matches route keys exactly, `ANY` can never match a concrete `GET`/`POST`/`PUT`/`DELETE`. `/api/logs` appears three times in one store as `__route__GET__`, `__route__DELETE__` and `__route__ANY__`, with every `HANDLES` edge on the first two and every `HTTP_CALLS` edge on the third. The two sets do not intersect anywhere in the project: of 149 `Route` nodes, 73 carry `HANDLES` and 33 carry `HTTP_CALLS`, with zero overlap.
+2. **Base path.** The client's configured baseURL strips the prefix, so it emits `/memories/{}` against the server's `/api/memories/{}`.
+
+Parameter shape is not implicated. The client's `:id` and the server's `{memory_id}` both normalize to `{}`.
+
+## Reproduction
+
+The behaviour above is from a real project. It reproduces by indexing any repository that contains a FastAPI server and a TypeScript client which calls it through a shared request wrapper, then running the `trace_path` command above and inspecting `SELECT qualified_name FROM nodes WHERE label='Route'`.
+
+A minimal reproduction is available as `scripts/benchmarking/accuracy/code-graph/repro_routes.py` in https://github.com/Lyellr88/marm-memory, but **it only reproduces half the problem, and we would rather say so than overstate it.** With nine lines of FastAPI and eight of TypeScript, only the server's route node is created:
+
+```
+## Route node keys
+  __route__GET__/api/memories/{}
+```
+
+No client route node, no `HTTP_CALLS` edge, so there is nothing to mismatch. Tried with an interpolated template URL, with literal path strings, and with `package.json` plus `tsconfig.json` present. Same result each time.
+
+In the real project the client nodes **are** created, 33 of them, and that client calls through a shared `request()` helper rather than `fetch` directly. So detection appears to require a narrower or different shape than a bare `fetch` call, which is a second question worth answering:
+
+**What client call shape is recognised as an HTTP call?** A direct `fetch("/api/memories/:id", { method: "GET" })` in a `.ts` file inside a project with `tsconfig.json` produced no client route node at all.
+
+## Impact
+
+Silent and confidently wrong. `cross_service` is documented as following HTTP boundaries for impact analysis, and it returns an empty result rather than an error, so a consumer cannot distinguish "nothing calls this endpoint" from "the two halves were never joined". Anything asking "what breaks if I change this endpoint" gets an answer that looks complete and is empty.
+
+0.10.5 improves this materially without fixing it: the empty strategy and confidence on the route node are now a signal a careful consumer can read. A consumer that only reads names still cannot tell.
+
+## Suggested direction
+
+Recover the HTTP method at the client call site wherever it is statically visible, a `method:` literal or the verb in an axios/fetch wrapper, and fall back to matching any method only when it genuinely is not determinable. Matching an `ANY` client key against concrete server verbs would also work and is probably cheaper than method recovery.
+
+Base-path normalization is the harder half, since the prefix lives in configuration rather than at the call site, and matching on a path suffix may be more robust than trying to resolve the baseURL.
+
+Independently of either: emitting a resolution strategy for route hops the way other hops already get one would let a consumer see that the join was attempted and failed.

--- a/scripts/benchmarking/docs/upstream/retired/issue-wna3-relative-imports-at-scale.md
+++ b/scripts/benchmarking/docs/upstream/retired/issue-wna3-relative-imports-at-scale.md
@@ -1,0 +1,104 @@
+# RETIRED, never filed: import-resolved call edges vanish above a project-size threshold
+
+**Retired 2026-08-16.** Fixed upstream in engine 0.10.5 before this draft was sent. Kept as a record of the investigation and as the reproduction's specification, not as a pending action.
+
+Verified fixed: the sweep in `scripts/benchmarking/accuracy/code-graph/repro_awaited.py` records the edge at every size and layout on 0.10.5, where 0.9.0 lost it from 565 nodes upward when nested. On MARM itself, `notebook_dispatch` resolves both production callers from the repository root with `strategy=lsp, confidence=0.97`.
+
+Two things worth carrying forward:
+
+The behaviour described below was also reported by someone else as upstream issue #1237 on 2026-07-23, against a 240k-node Django monorepo, labelled `priority/high`. Their report predates this draft by three weeks. Searching the tracker before building a reproduction would have cost minutes and saved the whole exercise.
+
+The draft was written against a pin six minor versions behind the current release, and nothing in it was wrong except that it no longer applied. Check the dependency's latest version before writing down its behaviour.
+
+---
+
+**Repo**: DeusData/codebase-memory-mcp
+**Version measured**: 0.9.0 (Windows 11, `moderate` index mode). Fixed in 0.10.5.
+
+---
+
+## Title
+
+CALLS edges for imported functions are silently dropped above roughly 450 nodes, and a nested package root widens it to absolute imports
+
+## Summary
+
+A call to a function brought in by an import is recorded as a `CALLS` edge in a small project and silently dropped in a larger one. The call site is byte-identical between runs; only the number of unrelated modules changes.
+
+There is one threshold, between 432 and 476 nodes, and two failure classes on the far side of it:
+
+- Relative imports (`from .targets import target`) lose their call edges regardless of where the package sits.
+- Absolute imports (`from pkg.targets import target`) lose theirs as well once the package root is one directory below the repository root, which is the layout of any project using `src/` or a packaging subdirectory.
+
+Imports written inside a function body survive every configuration we tested.
+
+## Reproduction
+
+Generator: `scripts/benchmarking/accuracy/code-graph/repro_awaited.py` in https://github.com/Lyellr88/marm-memory. It writes a package, indexes it through the CLI, and reports which `CALLS` edges exist. `--filler N` adds N unrelated modules that never reference the probes. `--nest DIR` puts the package under `DIR` instead of at the repository root.
+
+```
+python repro_awaited.py --filler 40            # 432 nodes, flat
+python repro_awaited.py --filler 45            # 476 nodes, flat
+python repro_awaited.py --filler 45 --nest src # 477 nodes, nested
+```
+
+Minimal shape of one probe:
+
+```python
+# pkg/targets.py
+async def target_absolute_top(*args, **kwargs):
+    return 1
+
+
+# pkg/imp_absolute_top.py
+from pkg.targets import target_absolute_top
+
+
+async def call_absolute_top():
+    return await target_absolute_top(action=1)
+```
+
+Index, then query:
+
+```
+codebase-memory-mcp cli index_repository --repo-path <repo> --mode moderate
+```
+
+```sql
+SELECT s.name, t.name FROM edges e
+JOIN nodes s ON s.id = e.source_id
+JOIN nodes t ON t.id = e.target_id
+WHERE e.type = 'CALLS' AND s.name = 'call_absolute_top';
+```
+
+## Results
+
+Eighteen call shapes were tested at each size: sync and awaited, assigned and returned, positional and keyword arguments, single-line and multi-line, inside `try`, under one and two decorators, and imported relatively, absolutely, after module-level code, and inside a function body.
+
+| Nodes | Layout | Relative | Absolute | Function-body |
+|---|---|---|---|---|
+| 69 | flat | recorded | recorded | recorded |
+| 70 | nested | recorded | recorded | recorded |
+| 432 | nested | recorded | recorded | recorded |
+| 476 | flat | **dropped** | recorded | recorded |
+| 477 | nested | **dropped** | **dropped** | recorded |
+| 3,671 | flat | **dropped** | recorded | recorded |
+| 3,672 | nested | **dropped** | **dropped** | recorded |
+
+A cliff, not a gradient. The 476-node flat run and the 477-node nested run differ only by one directory level, so the layout effect is isolated. Using a hyphenated nesting directory, which Python itself could not import as a package, changes nothing, so the trigger is the extra level rather than the name.
+
+Call shape makes no difference at any size: sync and awaited probes fail together, which rules out `await` and coroutines.
+
+## Impact
+
+Silent, which is the part that matters. The edges are absent rather than wrong, so `trace_path --direction inbound` returns an empty caller list for a function that is genuinely called. A consumer cannot distinguish "nothing calls this" from "the import was not resolved", and an automated consumer will act on the first reading.
+
+The threshold is low enough that most real repositories are past it, and the nested-root case means a conventional `src/` layout is affected from a few hundred nodes upward. We hit this on a 4,058-node Python project whose package lives at `<repo>/marm-mcp-server/marm_mcp_server/`: hand-verified callers of a function returned as zero callers.
+
+## Guess at the cause
+
+The small-project behaviour looks like a name-uniqueness fallback: with few symbols, an unresolved import can still be matched by target name. Past some candidate budget or symbol count that fallback stops applying, and whatever the import resolver could not resolve is then lost outright rather than degraded.
+
+That would explain the pattern if the resolver never resolves `.`/`..` against the importing module's own package, and infers the source root for absolute imports only when it equals the repository root. Function-body imports surviving suggests they take a different path that does resolve. If that is right, resolving relative imports against the importing package, and inferring source roots from package markers rather than assuming the repository root, would fix both classes independently of size.
+
+Independently of the cause, it would help a great deal if an unresolved import were recorded rather than discarded, so a consumer can tell a missing edge from a resolution failure.

--- a/scripts/benchmarking/performance/bench_graph_scale.py
+++ b/scripts/benchmarking/performance/bench_graph_scale.py
@@ -39,7 +39,7 @@ _HERE = Path(__file__).resolve()
 sys.path.insert(0, str(_HERE.parents[3] / "marm-mcp-server"))
 sys.path.insert(0, str(_HERE.parents[1] / "accuracy" / "code-graph"))
 
-from store_cleanup import gated  # noqa: E402
+from store_cleanup import gated, git_init  # noqa: E402
 
 STORE_DIR = Path.home() / ".cache" / "codebase-memory-mcp"
 
@@ -111,7 +111,7 @@ def generate(
         (pkg / f"mod_{i:05d}.py").write_text(src, encoding="utf-8")
         lines += src.count("\n")
 
-    subprocess.run(["git", "init", "-q", str(root)], capture_output=True, timeout=120)
+    git_init(root)
 
     # Each probe carries the two peers its module actually calls, so verification
     # can demand those exact edges. Accepting any entry_* target passes on a wrong
@@ -299,18 +299,24 @@ def main() -> int:
 
     work = Path(tempfile.mkdtemp(prefix="cga-scale-"))
     repo = work / "bigrepo"
-    print("\ngenerating ...")
-    t0 = time.monotonic()
-    modules, lines, probes = generate(repo, args.target_lines, args.nest)
-    gen_s = time.monotonic() - t0
-    src_bytes = sum(f.stat().st_size for f in repo.rglob("*.py"))
-    print(
-        f"  {modules:,} modules   {lines:,} lines   "
-        f"{src_bytes / 1e6:.0f} MB source   in {gen_s:.0f}s"
-    )
-
     project = None
+    # Generation is inside the cleanup scope: it writes thousands of files and can
+    # fail partway, and a failed setup used to leave the whole tree behind.
     try:
+        print("\ngenerating ...")
+        t0 = time.monotonic()
+        try:
+            modules, lines, probes = generate(repo, args.target_lines, args.nest)
+        except (OSError, RuntimeError) as exc:
+            print(f"  SETUP FAILED: {exc}")
+            return 2
+        gen_s = time.monotonic() - t0
+        src_bytes = sum(f.stat().st_size for f in repo.rglob("*.py"))
+        print(
+            f"  {modules:,} modules   {lines:,} lines   "
+            f"{src_bytes / 1e6:.0f} MB source   in {gen_s:.0f}s"
+        )
+
         print("\nindexing (cold) ...")
         # Gated. AGENTS.md: every code-index call takes the graph gate, and this
         # writes the shared project list a running MARM is reading.

--- a/scripts/benchmarking/performance/bench_graph_scale.py
+++ b/scripts/benchmarking/performance/bench_graph_scale.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Throughput and correctness of a cold graph index on a ~1M-line synthetic tree.
+
+The 1M-line figure quoted in docs/current/code-graph-accuracy-benchmark.md was
+measured ad hoc and had no harness, so it could not be re-run against a new engine
+build. This is that harness.
+
+Two things are measured together on purpose. Throughput alone is what made the
+original number misleading: it was taken on a tree whose calls were all
+intra-module, so every edge resolved trivially and the resolver was never
+exercised. Here each module also calls into two others through absolute imports,
+and the run asserts those cross-module edges exist before reporting a rate. A fast
+index of a tree the resolver silently gave up on is not a result.
+
+The package is generated one directory below the repository root, which is the
+layout that lost absolute-import edges entirely on engine 0.9.0. Keeping it nested
+means a regression there shows up as a correctness failure at scale rather than
+passing unnoticed.
+
+    python bench_graph_scale.py --binary <path-to-engine.exe>
+    python bench_graph_scale.py --binary <path> --target-lines 250000   # quick pass
+
+Takes a binary path rather than resolving the installed package, so two engine
+versions can be compared in one sitting without touching the project's pin.
+"""
+
+import argparse
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+STORE_DIR = Path.home() / ".cache" / "codebase-memory-mcp"
+
+# Functions per module, and how many lines each generated function costs. Kept
+# explicit because the line target is met by module count, so both feed the
+# arithmetic below.
+FUNCS_PER_MODULE = 30
+LINES_PER_FUNC = 7
+LINES_PER_MODULE_OVERHEAD = 4
+
+PROBE_COUNT = 12
+
+
+def _module_source(pkg: str, index: int, peers: tuple[int, int]) -> str:
+    """One module: local helpers, intra-module calls, and calls into two peers."""
+    a, b = peers
+    lines = [
+        f"from {pkg}.mod_{a:05d} import entry_{a:05d}",
+        f"from {pkg}.mod_{b:05d} import entry_{b:05d}",
+        "",
+        "",
+        f"def helper_{index:05d}(x):",
+        f"    return x + {index}",
+        "",
+        "",
+        f"async def entry_{index:05d}(x):",
+        f"    y = helper_{index:05d}(x)",
+        f"    z = await entry_{a:05d}(y) if y else y",
+        f"    w = await entry_{b:05d}(z) if z else z",
+        "    return w",
+        "",
+    ]
+    for j in range(FUNCS_PER_MODULE):
+        lines += [
+            "",
+            f"async def work_{index:05d}_{j:02d}(x, flag=False):",
+            f"    total = helper_{index:05d}(x)",
+            "    if flag:",
+            f"        total = await entry_{a:05d}(total)",
+            "    return total",
+            "",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def generate(root: Path, target_lines: int, nest: str) -> tuple[int, int, list[str]]:
+    """Write the tree. Returns (modules, lines, probe module names)."""
+    pkg_name = "bigpkg"
+    base = root / nest if nest else root
+    pkg = base / pkg_name
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+
+    per_module = (
+        FUNCS_PER_MODULE * LINES_PER_FUNC
+        + LINES_PER_MODULE_OVERHEAD
+        + LINES_PER_FUNC * 2
+    )
+    modules = max(8, target_lines // per_module)
+
+    lines = 0
+    for i in range(modules):
+        peers = ((i + 1) % modules, (i + 7) % modules)
+        src = _module_source(pkg_name, i, peers)
+        (pkg / f"mod_{i:05d}.py").write_text(src, encoding="utf-8")
+        lines += src.count("\n")
+
+    subprocess.run(["git", "init", "-q", str(root)], capture_output=True, timeout=120)
+
+    step = max(1, modules // PROBE_COUNT)
+    probes = [f"{i:05d}" for i in range(0, modules, step)][:PROBE_COUNT]
+    return modules, lines, probes
+
+
+def cli(binary: Path, *args: str, timeout: float) -> tuple[str, float]:
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            [str(binary), "cli", *args], capture_output=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return f"__timeout__ after {timeout}s", time.monotonic() - start
+    elapsed = time.monotonic() - start
+    if proc.returncode:
+        tail = proc.stderr.decode(errors="replace").strip()[-500:]
+        return f"__error__ exit {proc.returncode}: {tail}", elapsed
+    return proc.stdout.decode(errors="replace"), elapsed
+
+
+def _json(raw: str) -> dict:
+    return json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
+
+
+def cross_module_edges(store: Path, probes: list[str]) -> tuple[int, int]:
+    """How many probe modules kept the call edge into their first peer."""
+    if not store.exists():
+        return 0, len(probes)
+    conn = sqlite3.connect(str(store))
+    try:
+        found = 0
+        for p in probes:
+            caller = f"entry_{p}"
+            row = conn.execute(
+                """SELECT count(*) FROM edges e
+                   JOIN nodes s ON s.id = e.source_id
+                   JOIN nodes t ON t.id = e.target_id
+                   WHERE e.type = 'CALLS' AND s.name = ?
+                     AND t.name LIKE 'entry_%' AND t.name != ?""",
+                (caller, caller),
+            ).fetchone()
+            if row and row[0]:
+                found += 1
+        return found, len(probes)
+    except sqlite3.Error:
+        return -1, len(probes)
+    finally:
+        conn.close()
+
+
+def drop(binary: Path, project: str) -> str:
+    for attempt in range(4):
+        cli(binary, "delete_project", "--project", project, timeout=300.0)
+        time.sleep(1.0)
+        listing, _ = cli(binary, "list_projects", timeout=120.0)
+        if listing.startswith("__"):
+            return f"could not verify: {listing}"
+        if project not in listing:
+            time.sleep(0.75)
+            again, _ = cli(binary, "list_projects", timeout=120.0)
+            if project not in again:
+                return "deleted" if attempt == 0 else f"deleted after {attempt + 1}"
+    return "STILL PRESENT, remove by hand"
+
+
+def report_query_latency(binary: Path, project: str, probes: list[str]) -> None:
+    """Time queries over one persistent stdio child, which is MARM's real path.
+
+    A fresh `cli` invocation per query spawns and tears down a daemon each time,
+    which measures process startup rather than the query: three different calls all
+    came back at 5.0s. MARM holds one child open for the process lifetime, so this
+    reuses that client and reports first-call and warm timings separately.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "marm-mcp-server"))
+    try:
+        from marm_graph.core.cbm_client import CbmClient
+    except ImportError as exc:
+        print(f"\nquery latency: skipped, marm_graph not importable ({exc})")
+        return
+
+    client = CbmClient([str(binary)])
+    calls = [
+        ("search_graph", {"query": "entry_00000", "project": project}),
+        (
+            "trace_path",
+            {
+                "function_name": f"entry_{probes[len(probes) // 2]}",
+                "project": project,
+                "direction": "inbound",
+                "depth": 2,
+            },
+        ),
+        ("get_architecture", {"project": project, "aspects": ["overview"]}),
+    ]
+    print("\nquery latency (persistent stdio child, as MARM uses it):")
+    try:
+        t0 = time.monotonic()
+        client.start()
+        print(f"  {'child startup':22} {time.monotonic() - t0:6.3f}s")
+        for name, params in calls:
+            timings = []
+            status = "ok"
+            for _ in range(3):
+                t1 = time.monotonic()
+                try:
+                    client.call_tool(name, params, timeout=300.0)
+                except Exception as exc:
+                    status = f"error: {type(exc).__name__}: {exc}"[:120]
+                    break
+                timings.append(time.monotonic() - t1)
+            if timings:
+                print(
+                    f"  {name:22} first={timings[0]:6.3f}s  "
+                    f"best={min(timings):6.3f}s  {status}"
+                )
+            else:
+                print(f"  {name:22} {status}")
+    except Exception as exc:
+        print(f"  client failed: {type(exc).__name__}: {exc}")
+    finally:
+        client.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--binary", required=True, type=Path)
+    ap.add_argument("--target-lines", type=int, default=1_000_000)
+    ap.add_argument("--mode", default="moderate", choices=["fast", "moderate", "full"])
+    ap.add_argument(
+        "--nest",
+        default="src",
+        help="subdirectory for the package; empty string puts it at the repo root",
+    )
+    ap.add_argument("--index-timeout", type=float, default=3600.0)
+    ap.add_argument("--keep", action="store_true")
+    args = ap.parse_args()
+
+    if not args.binary.exists():
+        print(f"binary not found: {args.binary}")
+        return 2
+
+    # Warm-up. Each CLI invocation spawns a temporary daemon, and that startup
+    # cost lands in whichever call pays it first. The query timings below still
+    # include it, so read them as upper bounds rather than server-side latency.
+    cli(args.binary, "list_projects", timeout=180.0)
+    print(f"engine: {args.binary}")
+    print(f"mode: {args.mode}   nest: {args.nest or '<repo root>'}")
+
+    work = Path(tempfile.mkdtemp(prefix="cga-scale-"))
+    repo = work / "bigrepo"
+    print("\ngenerating ...")
+    t0 = time.monotonic()
+    modules, lines, probes = generate(repo, args.target_lines, args.nest)
+    gen_s = time.monotonic() - t0
+    src_bytes = sum(f.stat().st_size for f in repo.rglob("*.py"))
+    print(
+        f"  {modules:,} modules   {lines:,} lines   "
+        f"{src_bytes / 1e6:.0f} MB source   in {gen_s:.0f}s"
+    )
+
+    project = None
+    try:
+        print("\nindexing (cold) ...")
+        raw, index_s = cli(
+            args.binary,
+            "index_repository",
+            "--repo-path",
+            str(repo),
+            "--mode",
+            args.mode,
+            timeout=args.index_timeout,
+        )
+        if raw.startswith("__"):
+            print(f"  INDEX FAILED after {index_s:.0f}s")
+            print(f"  {raw}")
+            return 1
+
+        d = _json(raw)
+        project = d.get("project")
+        nodes, edges = d.get("nodes", 0), d.get("edges", 0)
+        store = STORE_DIR / f"{project}.db"
+        store_mb = store.stat().st_size / 1e6 if store.exists() else 0.0
+
+        print(f"  indexed in {index_s:.1f}s")
+        print(f"  nodes={nodes:,}  edges={edges:,}  skipped={d.get('skipped_count')}")
+        print(f"  store={store_mb:,.0f} MB")
+        print(f"  rate={lines / index_s:,.0f} lines/s   {nodes / index_s:,.0f} nodes/s")
+
+        found, total = cross_module_edges(store, probes)
+        print("\ncorrectness at scale:")
+        if found < 0:
+            print("  cross-module edges: store schema not readable")
+        else:
+            print(f"  cross-module call edges present: {found}/{total} probes")
+            if found < total:
+                print("  RESOLVER DEGRADED AT SCALE, throughput figure is not usable")
+
+        report_query_latency(args.binary, project, probes)
+        return 0
+    finally:
+        if project and not args.keep:
+            print(f"\ncleanup: {drop(args.binary, project)}")
+        if not args.keep:
+            shutil.rmtree(work, ignore_errors=True)
+        else:
+            print(f"\nkept: {repo}")
+            if project:
+                print(f"kept: graph project {project}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmarking/performance/bench_graph_scale.py
+++ b/scripts/benchmarking/performance/bench_graph_scale.py
@@ -25,6 +25,7 @@ versions can be compared in one sitting without touching the project's pin.
 """
 
 import argparse
+import asyncio
 import json
 import shutil
 import sqlite3
@@ -33,6 +34,12 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[3] / "marm-mcp-server"))
+sys.path.insert(0, str(_HERE.parents[1] / "accuracy" / "code-graph"))
+
+from store_cleanup import gated  # noqa: E402
 
 STORE_DIR = Path.home() / ".cache" / "codebase-memory-mcp"
 
@@ -78,8 +85,10 @@ def _module_source(pkg: str, index: int, peers: tuple[int, int]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def generate(root: Path, target_lines: int, nest: str) -> tuple[int, int, list[str]]:
-    """Write the tree. Returns (modules, lines, probe module names)."""
+def generate(
+    root: Path, target_lines: int, nest: str
+) -> tuple[int, int, list[tuple[int, int, int]]]:
+    """Write the tree. Returns (modules, lines, probes as (index, peer_a, peer_b))."""
     pkg_name = "bigpkg"
     base = root / nest if nest else root
     pkg = base / pkg_name
@@ -94,16 +103,21 @@ def generate(root: Path, target_lines: int, nest: str) -> tuple[int, int, list[s
     modules = max(8, target_lines // per_module)
 
     lines = 0
+    peers_by_index: dict[int, tuple[int, int]] = {}
     for i in range(modules):
         peers = ((i + 1) % modules, (i + 7) % modules)
+        peers_by_index[i] = peers
         src = _module_source(pkg_name, i, peers)
         (pkg / f"mod_{i:05d}.py").write_text(src, encoding="utf-8")
         lines += src.count("\n")
 
     subprocess.run(["git", "init", "-q", str(root)], capture_output=True, timeout=120)
 
+    # Each probe carries the two peers its module actually calls, so verification
+    # can demand those exact edges. Accepting any entry_* target passes on a wrong
+    # edge, which is the failure this whole harness exists to refuse.
     step = max(1, modules // PROBE_COUNT)
-    probes = [f"{i:05d}" for i in range(0, modules, step)][:PROBE_COUNT]
+    probes = [(i, *peers_by_index[i]) for i in range(0, modules, step)][:PROBE_COUNT]
     return modules, lines, probes
 
 
@@ -126,33 +140,48 @@ def _json(raw: str) -> dict:
     return json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
 
 
-def cross_module_edges(store: Path, probes: list[str]) -> tuple[int, int]:
-    """How many probe modules kept the call edge into their first peer."""
+def cross_module_edges(
+    store: Path, probes: list[tuple[int, int, int]]
+) -> tuple[int, int, list[str], str | None]:
+    """Verify each probe's two exact peer edges.
+
+    Returns (probes fully satisfied, probes checked, missing edge descriptions,
+    error). Both peers must be present: a probe module calls exactly entry_<a> and
+    entry_<b>, so demanding those names is the difference between proving the
+    resolver worked and proving it produced some edge.
+    """
     if not store.exists():
-        return 0, len(probes)
+        return 0, len(probes), [], f"no store at {store}"
     conn = sqlite3.connect(str(store))
     try:
-        found = 0
-        for p in probes:
-            caller = f"entry_{p}"
-            row = conn.execute(
-                """SELECT count(*) FROM edges e
-                   JOIN nodes s ON s.id = e.source_id
-                   JOIN nodes t ON t.id = e.target_id
-                   WHERE e.type = 'CALLS' AND s.name = ?
-                     AND t.name LIKE 'entry_%' AND t.name != ?""",
-                (caller, caller),
-            ).fetchone()
-            if row and row[0]:
-                found += 1
-        return found, len(probes)
-    except sqlite3.Error:
-        return -1, len(probes)
+        satisfied = 0
+        missing: list[str] = []
+        for index, peer_a, peer_b in probes:
+            caller = f"entry_{index:05d}"
+            absent = [
+                f"{caller} -> entry_{peer:05d}"
+                for peer in (peer_a, peer_b)
+                if not conn.execute(
+                    """SELECT 1 FROM edges e
+                       JOIN nodes s ON s.id = e.source_id
+                       JOIN nodes t ON t.id = e.target_id
+                       WHERE e.type = 'CALLS' AND s.name = ? AND t.name = ?
+                       LIMIT 1""",
+                    (caller, f"entry_{peer:05d}"),
+                ).fetchone()
+            ]
+            if absent:
+                missing.extend(absent)
+            else:
+                satisfied += 1
+        return satisfied, len(probes), missing, None
+    except sqlite3.Error as exc:
+        return 0, len(probes), [], f"store not readable: {exc}"
     finally:
         conn.close()
 
 
-def drop(binary: Path, project: str) -> str:
+def _delete_and_confirm(binary: Path, project: str) -> str:
     for attempt in range(4):
         cli(binary, "delete_project", "--project", project, timeout=300.0)
         time.sleep(1.0)
@@ -167,7 +196,25 @@ def drop(binary: Path, project: str) -> str:
     return "STILL PRESENT, remove by hand"
 
 
-def report_query_latency(binary: Path, project: str, probes: list[str]) -> None:
+def drop(binary: Path, project: str) -> str:
+    """Delete under the gate, same as every other store mutation.
+
+    A delete landing while a poller is inside index_repository is undone when that
+    index writes the project back, which is why the gate covers deletes too.
+    """
+    from marm_mcp_server.core.graph_index_lock import GraphIndexBusy
+
+    try:
+        return asyncio.run(
+            gated(f"cga_scale_cleanup:{project}", _delete_and_confirm, binary, project)
+        )
+    except GraphIndexBusy as exc:
+        return f"gate busy ({exc}), remove {project} by hand"
+
+
+def report_query_latency(
+    binary: Path, project: str, probes: list[tuple[int, int, int]]
+) -> None:
     """Time queries over one persistent stdio child, which is MARM's real path.
 
     A fresh `cli` invocation per query spawns and tears down a daemon each time,
@@ -188,7 +235,7 @@ def report_query_latency(binary: Path, project: str, probes: list[str]) -> None:
         (
             "trace_path",
             {
-                "function_name": f"entry_{probes[len(probes) // 2]}",
+                "function_name": f"entry_{probes[len(probes) // 2][0]:05d}",
                 "project": project,
                 "direction": "inbound",
                 "depth": 2,
@@ -265,14 +312,20 @@ def main() -> int:
     project = None
     try:
         print("\nindexing (cold) ...")
-        raw, index_s = cli(
-            args.binary,
-            "index_repository",
-            "--repo-path",
-            str(repo),
-            "--mode",
-            args.mode,
-            timeout=args.index_timeout,
+        # Gated. AGENTS.md: every code-index call takes the graph gate, and this
+        # writes the shared project list a running MARM is reading.
+        raw, index_s = asyncio.run(
+            gated(
+                f"cga_scale_index:{repo.name}",
+                cli,
+                args.binary,
+                "index_repository",
+                "--repo-path",
+                str(repo),
+                "--mode",
+                args.mode,
+                timeout=args.index_timeout,
+            )
         )
         if raw.startswith("__"):
             print(f"  INDEX FAILED after {index_s:.0f}s")
@@ -288,17 +341,31 @@ def main() -> int:
         print(f"  indexed in {index_s:.1f}s")
         print(f"  nodes={nodes:,}  edges={edges:,}  skipped={d.get('skipped_count')}")
         print(f"  store={store_mb:,.0f} MB")
-        print(f"  rate={lines / index_s:,.0f} lines/s   {nodes / index_s:,.0f} nodes/s")
 
-        found, total = cross_module_edges(store, probes)
+        # Correctness first, and no performance number before it passes. A rate
+        # earned by skipping resolution is the exact result this harness exists to
+        # refuse: engine 0.9.0 indexed this tree twice as fast as 0.10.5 while
+        # resolving none of these edges.
+        satisfied, total, missing, err = cross_module_edges(store, probes)
         print("\ncorrectness at scale:")
-        if found < 0:
-            print("  cross-module edges: store schema not readable")
+        if err:
+            print(f"  cannot verify: {err}")
         else:
-            print(f"  cross-module call edges present: {found}/{total} probes")
-            if found < total:
-                print("  RESOLVER DEGRADED AT SCALE, throughput figure is not usable")
+            print(f"  probes with both peer call edges: {satisfied}/{total}")
+            for line in missing[:10]:
+                print(f"    MISSING {line}")
+            if len(missing) > 10:
+                print(f"    ... and {len(missing) - 10} more")
 
+        if err or satisfied < total:
+            print(
+                "\nRESOLVER DEGRADED AT SCALE. Throughput and latency are withheld:\n"
+                "  a rate measured on a graph missing its cross-module edges is not a\n"
+                "  performance result. Fix resolution, then re-run for a usable number."
+            )
+            return 1
+
+        print(f"\nrate={lines / index_s:,.0f} lines/s   {nodes / index_s:,.0f} nodes/s")
         report_query_latency(args.binary, project, probes)
         return 0
     finally:

--- a/scripts/unwrap-md.py
+++ b/scripts/unwrap-md.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Join hard-wrapped paragraph lines in Markdown back into single lines.
+
+Usage:
+    python scripts/unwrap-md.py docs/current/some-spec.md
+    python scripts/unwrap-md.py --dry-run docs/current/*.md
+    python scripts/unwrap-md.py docs/current            # recurses for *.md
+
+A bare `re.sub(r'(?<!\n)\n(?!\n)', ' ', text)` destroys Markdown: it flattens
+every table into one row, joins list items together, merges headings into the
+following sentence, and silently eats trailing-two-space hard breaks, which
+this repo's .claude/rules files use deliberately. Only lines that are plain
+prose on both sides are joined here.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+FENCE = re.compile(r"^\s*(```|~~~)")
+
+# Lines that start a construct where a newline is significant. Joining one of
+# these into a neighbour changes how it renders.
+BLOCK = re.compile(
+    r"""^\s*(
+      \#{1,6}\s                    # heading
+    | [-*+][ \t]                   # bullet
+    | \d+[.)][ \t]                 # ordered item
+    | >                            # blockquote
+    | \|                           # table row
+    | (-{3,}|\*{3,}|_{3,})\s*$     # thematic break
+    | <                            # html block
+    | \[[^\]]+\]:                  # link reference definition
+    | \|?[:-]{3,}                  # table delimiter row
+    )""",
+    re.VERBOSE,
+)
+
+# A block that owns the wrapped lines beneath it, so those get pulled up into it.
+# Headings, table rows, and rules do not: nothing following them is a
+# continuation, and joining would move text into the wrong construct.
+ABSORBING = re.compile(r"^\s*([-*+][ \t]|\d+[.)][ \t]|>)")
+
+
+def _is_prose(line: str) -> bool:
+    if not line.strip():
+        return False
+    if line.startswith(("    ", "\t")):
+        # Indented code block, or a list continuation. Either way, leave it.
+        return False
+    return not BLOCK.match(line)
+
+
+def _hard_break(line: str) -> bool:
+    """Trailing two spaces or a backslash is an intentional line break."""
+    return line.endswith("  ") or line.rstrip().endswith("\\")
+
+
+# How far under `width` a line can stop and still count as full. Wrapping done by
+# hand or by a model is not perfectly greedy, so an exact "would the next word
+# have fit" test misses real wraps that stopped a few characters early.
+SLACK = 10
+
+
+def _was_wrapped(prev: str, nxt: str, width: int) -> bool:
+    """Whether `prev` ran out of room, rather than ending where the author chose.
+
+    This is what separates a wrapped paragraph from consecutive short statements.
+    Two independent signals, either of which is enough:
+
+    - `prev` is near full, so a wrapper broke it.
+    - the next word would not have fit. This catches a line that stopped well
+      short because what followed was one long unbreakable token, such as a
+      backticked path, which the fullness test alone reads as a deliberate break.
+
+    Without both, either deliberate short statements get merged (no fullness
+    floor) or real wraps before a long token stay broken (no fit test).
+    """
+    if len(prev) >= width - SLACK:
+        return True
+    word = nxt.strip().split(" ", 1)[0]
+    return len(prev) + 1 + len(word) > width
+
+
+def _starts_own_line(line: str) -> bool:
+    """A bold-led line opens its own line and is never joined into the one above.
+
+    This repo's rules files list one statement per line with no bullet marker and
+    no trailing hard break (`**Cut Losses Quickly** - Good instincts about ...`).
+    Those read as prose on both sides, so without this the whole block collapses
+    into one paragraph. A bold-led line still absorbs its own wrapped
+    continuations, which is what makes `**Note.** wrapped text...` join correctly.
+    """
+    return line.lstrip().startswith("**")
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """YAML frontmatter is `key: value` lines that read as prose. Pass it through."""
+    if not text.startswith("---\n"):
+        return "", text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return "", text
+    cut = end + len("\n---\n")
+    return text[:cut], text[cut:]
+
+
+def unwrap(text: str, width: int = 80) -> str:
+    front, body = _split_frontmatter(text)
+    out: list[str] = []
+    buf: str | None = None
+    in_fence = False
+
+    for line in body.split("\n"):
+        if FENCE.match(line):
+            if buf is not None:
+                out.append(buf)
+                buf = None
+            in_fence = not in_fence
+            out.append(line)
+            continue
+
+        if in_fence or not _is_prose(line):
+            if buf is not None:
+                out.append(buf)
+                buf = None
+            if not in_fence and ABSORBING.match(line) and not _hard_break(line):
+                # Stays open so its own wrapped continuation lines join into it.
+                # Indent is kept verbatim, which is what holds nested lists together.
+                buf = line.rstrip()
+            else:
+                out.append(line)
+            continue
+
+        stripped = line.strip()
+        if buf is not None and (
+            _starts_own_line(line) or not _was_wrapped(buf, stripped, width)
+        ):
+            out.append(buf)
+            buf = None
+        # rstrip, not strip, when opening: an indented prose block keeps its indent.
+        buf = line.rstrip() if buf is None else f"{buf} {stripped}"
+        if _hard_break(line):
+            out.append(buf + "  " if line.endswith("  ") else buf)
+            buf = None
+
+    if buf is not None:
+        out.append(buf)
+    return front + "\n".join(out)
+
+
+def _targets(paths: list[str]) -> list[Path]:
+    found: list[Path] = []
+    for raw in paths:
+        p = Path(raw)
+        found.extend(sorted(p.rglob("*.md")) if p.is_dir() else [p])
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("paths", nargs="+", help="Markdown files or directories")
+    ap.add_argument("--dry-run", action="store_true", help="report, do not write")
+    ap.add_argument(
+        "--width", type=int, default=80, help="wrap column the file was written at"
+    )
+    args = ap.parse_args()
+
+    changed = 0
+    for path in _targets(args.paths):
+        if not path.is_file():
+            print(f"skip (not a file): {path}")
+            continue
+        original = path.read_text(encoding="utf-8")
+        fixed = unwrap(original, args.width)
+        if fixed == original:
+            continue
+        changed += 1
+        before = len(original.splitlines())
+        after = len(fixed.splitlines())
+        print(
+            f"{'would fix' if args.dry_run else 'fixed'}: {path} ({before} -> {after} lines)"
+        )
+        if not args.dry_run:
+            path.write_text(fixed, encoding="utf-8", newline="\n")
+
+    print(f"{changed} file(s) {'would change' if args.dry_run else 'changed'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/unwrap-md.py
+++ b/scripts/unwrap-md.py
@@ -18,7 +18,12 @@ import re
 import sys
 from pathlib import Path
 
-FENCE = re.compile(r"^\s*(```|~~~)")
+# The full delimiter run is captured, not just its first three characters, because
+# a fence closes only on the same character at the same length or longer. A
+# four-backtick block quoting a three-backtick one is how this repo's skill files
+# document Markdown, and a plain open/closed toggle ends the outer block early and
+# then treats the rest of it as prose.
+FENCE = re.compile(r"^\s*(`{3,}|~{3,})")
 
 # Lines that start a construct where a newline is significant. Joining one of
 # these into a neighbour changes how it renders.
@@ -29,13 +34,18 @@ BLOCK = re.compile(
     | \d+[.)][ \t]                 # ordered item
     | >                            # blockquote
     | \|                           # table row
-    | (-{3,}|\*{3,}|_{3,})\s*$     # thematic break
     | <                            # html block
     | \[[^\]]+\]:                  # link reference definition
     | \|?[:-]{3,}                  # table delimiter row
     )""",
     re.VERBOSE,
 )
+
+# Three or more of the same marker, optionally separated by spaces, and nothing
+# else. Checked apart from BLOCK because `- - -` and `* * *` also match the bullet
+# pattern, so a break would otherwise be treated as a list item and absorb the
+# lines under it.
+THEMATIC = re.compile(r"^ {0,3}([-*_])(?:[ \t]*\1){2,}[ \t]*$")
 
 # A block that owns the wrapped lines beneath it, so those get pulled up into it.
 # Headings, table rows, and rules do not: nothing following them is a
@@ -49,7 +59,7 @@ def _is_prose(line: str) -> bool:
     if line.startswith(("    ", "\t")):
         # Indented code block, or a list continuation. Either way, leave it.
         return False
-    return not BLOCK.match(line)
+    return not BLOCK.match(line) and not THEMATIC.match(line)
 
 
 def _hard_break(line: str) -> bool:
@@ -95,6 +105,11 @@ def _starts_own_line(line: str) -> bool:
     return line.lstrip().startswith("**")
 
 
+def _closes(opening: str, candidate: str) -> bool:
+    """A fence closes only on its own marker, at its own length or longer."""
+    return candidate[0] == opening[0] and len(candidate) >= len(opening)
+
+
 def _split_frontmatter(text: str) -> tuple[str, str]:
     """YAML frontmatter is `key: value` lines that read as prose. Pass it through."""
     if not text.startswith("---\n"):
@@ -110,22 +125,29 @@ def unwrap(text: str, width: int = 80) -> str:
     front, body = _split_frontmatter(text)
     out: list[str] = []
     buf: str | None = None
-    in_fence = False
+    open_fence: str | None = None
 
     for line in body.split("\n"):
-        if FENCE.match(line):
+        fence = FENCE.match(line)
+        if fence and (open_fence is None or _closes(open_fence, fence.group(1))):
             if buf is not None:
                 out.append(buf)
                 buf = None
-            in_fence = not in_fence
+            open_fence = None if open_fence else fence.group(1)
             out.append(line)
             continue
 
+        in_fence = open_fence is not None
         if in_fence or not _is_prose(line):
             if buf is not None:
                 out.append(buf)
                 buf = None
-            if not in_fence and ABSORBING.match(line) and not _hard_break(line):
+            if (
+                not in_fence
+                and ABSORBING.match(line)
+                and not THEMATIC.match(line)
+                and not _hard_break(line)
+            ):
                 # Stays open so its own wrapped continuation lines join into it.
                 # Indent is kept verbatim, which is what holds nested lists together.
                 buf = line.rstrip()
@@ -166,6 +188,12 @@ def main() -> int:
         "--width", type=int, default=80, help="wrap column the file was written at"
     )
     args = ap.parse_args()
+
+    # Below this the fullness test in _was_wrapped is true for every line, so every
+    # prose line reads as wrapped and deliberate breaks get merged. --width 0 joined
+    # three unrelated short lines into one.
+    if args.width <= SLACK * 2:
+        ap.error(f"--width must be greater than {SLACK * 2}, got {args.width}")
 
     changed = 0
     for path in _targets(args.paths):

--- a/scripts/unwrap-md.py
+++ b/scripts/unwrap-md.py
@@ -105,9 +105,19 @@ def _starts_own_line(line: str) -> bool:
     return line.lstrip().startswith("**")
 
 
-def _closes(opening: str, candidate: str) -> bool:
-    """A fence closes only on its own marker, at its own length or longer."""
-    return candidate[0] == opening[0] and len(candidate) >= len(opening)
+def _closes(opening: str, candidate: str, rest: str) -> bool:
+    """A fence closes only on its own marker, at its own length or longer, and bare.
+
+    An info string is allowed when opening a fence and not when closing one, so a
+    ```bash line inside a ```markdown block is content rather than the end of it.
+    Without the bare check that inner line closed the outer block and the rest of it
+    was treated as prose.
+    """
+    return (
+        candidate[0] == opening[0]
+        and len(candidate) >= len(opening)
+        and not rest.strip()
+    )
 
 
 def _split_frontmatter(text: str) -> tuple[str, str]:
@@ -129,7 +139,10 @@ def unwrap(text: str, width: int = 80) -> str:
 
     for line in body.split("\n"):
         fence = FENCE.match(line)
-        if fence and (open_fence is None or _closes(open_fence, fence.group(1))):
+        if fence and (
+            open_fence is None
+            or _closes(open_fence, fence.group(1), line[fence.end(1) :])
+        ):
             if buf is not None:
                 out.append(buf)
                 buf = None


### PR DESCRIPTION
Code Graph Accuracy Benchmark

Measures the bundled code graph for the first time and corrects a tool contract that promised a capability it does not deliver. The graph's call-edge resolution turned out to be broken in the pinned engine version, silently, and the investigation traced it to an upstream defect that is now fixed in a release we have not yet adopted.

- cross_service no longer claims to do impact analysis. Four tool docstrings told agents the mode "crosses HTTP/async boundaries" and to "use for impact analysis". It reaches the client route node and stops on every engine version tested. The docstrings now say an empty result means unknown rather than "nothing calls this".
- Adds five benchmark harnesses under scripts/benchmarking/. pilot.py scores three metrics through MARM's own tool functions in a throwaway git worktree; awaited_calls.py measures call-edge recall by call shape; repro_awaited.py and repro_routes.py are minimal reproductions that run against the engine CLI with MARM out of the picture; bench_graph_scale.py measures cold-index throughput and cross-module correctness together.
- Identified why "who calls this" returned nothing on this repository. Engine 0.9.0 stops resolving imports above roughly 450 nodes, and extends that to absolute imports whenever the package root sits below the repository root, which is this repo's layout. Isolated to a single variable: 476 nodes flat keeps the call edge; 477 nested loses it. Fixed upstream in engine 0.10.5, verified, and the pin is deliberately unchanged in this PR.
- The existing throughput claim was measuring skipped work. On an identical 982,240-line tree, engine 0.9.0 indexes in 18.3s and resolves 0 of 12 cross-module call probes; 0.10.5 takes 38.8s and resolves 12 of 12. 0.9.0 was missing 131,550 edges, 27% of the graph, and its 1ms trace_path was an empty result rather than a fast query. bench_graph_scale.py therefore asserts probe edges before it will report a rate.
- Two defects remain and are upstream, with drafts included. get_architecture returns routes[].handler empty on all 20 routes despite 94 HANDLES edges in the store, and cross_service dead-ends at __route__ANY__. Both fail identically on 0.9.0 and 0.10.5 and reproduce at the engine CLI.

No runtime behavior changes. The engine pin stays at 0.9.0, no request or response shape moves, and no new tool, endpoint, table, or process is added.

Reviewer Notes

The benchmark's main output was retracting its own findings. Five confident results were withdrawn during the work: a route-linkage figure that was a stale-index artifact, an "awaited calls are dropped" mechanism that await had nothing to do with, two recall percentages with bad denominators, and one probe that scored a non-handler as a handler. Any number quoted in the harnesses states its population explicitly for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a native macOS installation and troubleshooting guide covering setup, configuration, connections, updates, diagnostics, and Docker issues.
  - Clarified limitations of cross-service tracing and how to interpret empty results.
  - Added issue records documenting route-handling and tracing limitations.

- **Tools**
  - Added utilities for analyzing code-graph accuracy, route tracing, awaited-call coverage, performance, and cleanup.
  - Added benchmark reports for graph completeness and performance.
  - Added a Markdown formatting utility for safely unwrapping prose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->