### PR TITLE
fix(console): render Architecture tab type badges as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 <details>
+<summary><strong>August 18th, 2026: Console Architecture Tab Renders Again (v2.39.3)</strong></summary>
+
+### Fixed: Opening A Project's Architecture Tab In The Console No Longer Breaks The View
+
+- The Console handed the browser the graph engine's counted rows where the interface expects plain type names: `{"label": "Function", "count": 2028}` for node types and `{"type": "CALLS", "count": 6632}` for edge types. React raises on an object child, so the first badge took down the panel and the tab with it. Both lists are now reduced to names before they leave the server, which means the Console you already have starts working with no rebuild or reinstall.
+- The fallback path was broken the same way and more heavily. When the architecture response omits those sections the endpoint falls back to the graph schema, which returns the same counted rows plus a property list for every type, 34 entries for `Function` alone. That path is normalized too, so it is a working fallback rather than a decorative one.
+- This was not caused by the 0.10.5 engine upgrade in v2.39.0, although reviewing that release is what surfaced it. Both engine versions return byte-identical values for the keys this endpoint reads, so the tab has been failing for as long as it has existed.
+- The module table on the same tab still reads "No module summary available." on an indexed project. That is now a deliberate, tested decision rather than a second symptom: the engine aspect that looked like its missing data source turned out to report third-party dependency names and Python builtins with zero coupling on every row, never the project's own packages. Filling the table from that would have replaced an honest empty state with a table of builtins. A real source is being proven separately before the table is wired to anything.
+- The graph tools agents call are untouched and still return the engine's counts, which a test now enforces. The normalization lives at the last hop before the browser precisely so the model-facing surface keeps the data the counts carry.
+
+</details>
+
+<details>
 <summary><strong>August 17th, 2026: Config Settings Module Split (v2.39.2)</strong></summary>
 
 ### Fixed: An Auto-Generated API Key Containing "#" No Longer Gets Truncated on the Next Start

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -313,7 +313,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.39.2",
+  "version": "2.39.3",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -287,7 +287,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.39.2",
+  "version": "2.39.3",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -73,7 +73,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.39.2"
+LABEL org.opencontainers.image.version="2.39.3"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     # :latest is the all-in-one MCP image (memory + graph, one port).
     # Pin :memory-only instead if you need the pre-unification image shape.
-    image: lyellr88/marm-mcp-server:2.39.2
+    image: lyellr88/marm-mcp-server:2.39.3
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -18,7 +18,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.39.2
+      - SERVER_VERSION=2.39.3
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,12 +14,12 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.39.2
+Version: 2.39.3
 """
 
 from typing import Any
 
-__version__ = "2.39.2"
+__version__ = "2.39.3"
 __author__ = "Ryan Lyell"
 __email__ = "ryanlyell@marmemory.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -115,7 +115,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.39.2"
+SERVER_VERSION = "2.39.3"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 

--- a/marm-mcp-server/marm_mcp_server/console/endpoints/projects.py
+++ b/marm-mcp-server/marm_mcp_server/console/endpoints/projects.py
@@ -63,6 +63,30 @@ def get_project_status(project: str) -> dict:
     }
 
 
+def _type_names(rows: object, key: str) -> list[str]:
+    """Reduce the graph engine's label aspects to the bare names the UI declares.
+
+    The engine reports these as counted rows, `{"label": "Function", "count": 2028}`
+    for nodes and `{"type": "CALLS", "count": 6632}` for edges, and the
+    get_graph_schema fallback adds a `properties` array to each. React raises on an
+    object child, so an unreduced row fails the whole Architecture tab on its first
+    badge rather than rendering oddly.
+    """
+    if not isinstance(rows, list):
+        return []
+    names: list[str] = []
+    for row in rows:
+        if isinstance(row, str):
+            candidate: object = row
+        elif isinstance(row, dict):
+            candidate = row.get(key) or row.get("label") or row.get("type")
+        else:
+            continue
+        if isinstance(candidate, str) and candidate:
+            names.append(candidate)
+    return names
+
+
 @router.get("/api/projects/{project}/architecture")
 def get_project_architecture(project: str) -> dict:
     result = _project_operation("internal/projects/architecture", {"project": project})
@@ -74,13 +98,19 @@ def get_project_architecture(project: str) -> dict:
         "name": project,
         "modules": modules if isinstance(modules, list) else [],
         "schema": {
-            "node_types": result.get("node_labels")
-            or schema.get("node_labels")
-            or schema.get("node_types", []),
-            "edge_types": result.get("edge_types")
-            or schema.get("edge_types")
-            or schema.get("edge_labels")
-            or schema.get("relationship_types", []),
+            "node_types": _type_names(
+                result.get("node_labels")
+                or schema.get("node_labels")
+                or schema.get("node_types", []),
+                "label",
+            ),
+            "edge_types": _type_names(
+                result.get("edge_types")
+                or schema.get("edge_types")
+                or schema.get("edge_labels")
+                or schema.get("relationship_types", []),
+                "type",
+            ),
         },
     }
 

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - marm-memory
-Version: 2.39.2
+Version: 2.39.3
 """
 
 import os

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.39.2"
+version = "2.39.3"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.39.2",
+  "version": "2.39.3",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.39.2",
+      "version": "2.39.3",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.39.2",
+      "identifier": "lyellr88/marm-mcp-server:2.39.3",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_console_graph_endpoints.py
+++ b/marm-mcp-server/tests/test_console_graph_endpoints.py
@@ -1,0 +1,154 @@
+"""Tests for the Console's architecture endpoint contract.
+
+The browser is the only consumer that enforces this contract, and it enforces it
+by throwing: React raises on an object child, so a counted `{"label": ..., "count":
+...}` row reaching a badge takes down the whole Architecture tab. Nothing on the
+server noticed for as long as the tab has existed. These tests put the contract
+where a test run can see it.
+
+Label and schema rows below are verbatim `get_architecture` output from engine
+0.10.5, trimmed to the keys this endpoint reads. The `packages` rows are verbatim
+too, and deliberately so: they are what the aspect really returns, third-party
+dependency names and Python builtins with zero coupling on every row, rather than
+the project's own packages. That is why nothing maps them onto the module table.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marm_mcp_server.console import mcp_client
+from marm_mcp_server.console.app import app
+
+ARCHITECTURE_0105 = {
+    "project": "proj",
+    "packages": [
+        {"name": "apscheduler", "node_count": 1, "fan_in": 0, "fan_out": 0},
+        {"name": "str", "node_count": 3, "fan_in": 0, "fan_out": 0},
+        {"name": "print", "node_count": 1, "fan_in": 0, "fan_out": 0},
+    ],
+    "node_labels": [
+        {"label": "Function", "count": 2028},
+        {"label": "Variable", "count": 611},
+    ],
+    "edge_types": [
+        {"type": "CALLS", "count": 6632},
+        {"type": "DEFINES", "count": 5954},
+    ],
+    "schema": {
+        "node_labels": [
+            {"label": "Function", "count": 2028, "properties": ["name", "file_path"]},
+        ],
+        "edge_types": [{"type": "CALLS", "count": 6632, "properties": ["line"]}],
+        "adr_present": False,
+    },
+}
+
+
+@pytest.fixture
+def architecture(monkeypatch):
+    """Drive the endpoint with a chosen upstream payload."""
+
+    def _run(payload: dict) -> dict:
+        monkeypatch.setattr(mcp_client, "post", lambda *a, **k: payload)
+        with TestClient(app) as client:
+            response = client.get("/api/projects/proj/architecture")
+        assert response.status_code == 200
+        return response.json()
+
+    return _run
+
+
+def test_the_engines_packages_aspect_is_not_used_as_the_module_table(architecture):
+    """`packages` looks like the module table's missing data source and is not.
+
+    On a controlled two-package project it returns Python builtins (`str`, `list`,
+    `print`) and module basenames, never the project's own packages, and its
+    `fan_in`/`fan_out` are 0 on every row of every project measured. Mapping it here
+    would replace an honest empty state with a table of builtins, so the table stays
+    empty until a real source is proven.
+    """
+    body = architecture(ARCHITECTURE_0105)
+
+    assert body["modules"] == []
+
+
+def test_badge_types_reach_the_browser_as_strings(architecture):
+    """The defect itself. A dict here is a render-time crash, not a cosmetic issue."""
+    body = architecture(ARCHITECTURE_0105)
+
+    assert body["schema"]["node_types"] == ["Function", "Variable"]
+    assert body["schema"]["edge_types"] == ["CALLS", "DEFINES"]
+    assert all(isinstance(t, str) for t in body["schema"]["node_types"])
+    assert all(isinstance(t, str) for t in body["schema"]["edge_types"])
+
+
+def test_the_schema_fallback_is_normalized_too(architecture):
+    """The fallback was never a working path: get_graph_schema returns the same
+    counted rows plus a properties array, so reaching it swapped one crash for a
+    heavier one."""
+    payload = {
+        k: v
+        for k, v in ARCHITECTURE_0105.items()
+        if k not in ("node_labels", "edge_types")
+    }
+    body = architecture(payload)
+
+    assert body["schema"]["node_types"] == ["Function"]
+    assert body["schema"]["edge_types"] == ["CALLS"]
+
+
+def test_an_engine_that_returns_plain_strings_passes_through(architecture):
+    """Forward tolerance: the normalizer must not require the counted shape."""
+    payload = {
+        "packages": [],
+        "node_labels": ["Function", "Class"],
+        "edge_types": ["CALLS"],
+    }
+    body = architecture(payload)
+
+    assert body["schema"]["node_types"] == ["Function", "Class"]
+    assert body["schema"]["edge_types"] == ["CALLS"]
+
+
+def test_an_empty_index_reports_an_empty_table(architecture):
+    """The empty state has to stay reachable."""
+    body = architecture({"project": "proj", "packages": [], "node_labels": []})
+
+    assert body["modules"] == []
+    assert body["schema"]["node_types"] == []
+
+
+def test_a_modules_key_from_the_engine_would_still_be_used(architecture):
+    """The key this endpoint has always read keeps working if an engine adds it."""
+    payload = dict(ARCHITECTURE_0105)
+    payload["modules"] = [{"name": "real.module", "node_count": 7}]
+    body = architecture(payload)
+
+    assert [m["name"] for m in body["modules"]] == ["real.module"]
+
+
+def test_a_non_dict_schema_does_not_break_the_response(architecture):
+    body = architecture({"packages": [], "schema": "unavailable"})
+
+    assert body["schema"] == {"node_types": [], "edge_types": []}
+
+
+def test_normalization_did_not_leak_into_the_agent_facing_tool():
+    """The counts are the useful part for a model, and `tool_router` is shared.
+    Reducing labels there to satisfy one UI table would strip data from every
+    agent, so the normalization belongs at the last hop before the browser."""
+    from marm_graph.core import tool_router as R
+    from marm_graph.core.models import GraphArchitectureRequest
+
+    class FakeClient:
+        def call_tool(self, name, args):
+            if name == "get_architecture":
+                return {k: v for k, v in ARCHITECTURE_0105.items() if k != "schema"}
+            if name == "get_graph_schema":
+                return ARCHITECTURE_0105["schema"]
+            raise AssertionError(f"unexpected upstream call: {name}")
+
+    result = R.do_architecture(FakeClient(), GraphArchitectureRequest(project="proj"))
+
+    assert result["node_labels"][0] == {"label": "Function", "count": 2028}
+    assert result["edge_types"][0] == {"type": "CALLS", "count": 6632}


### PR DESCRIPTION
## Console Architecture Tab Renders Again (v2.39.3)

Opening a project's Architecture tab in the Console showed a broken view. The tab now renders, and the fix is server-side, so the Console you already have starts working without a rebuild or reinstall.

- The architecture endpoint passed the graph engine's counted label rows straight to the browser, `{"label": "Function", "count": 2028}` for node types and `{"type": "CALLS", "count": 6632}` for edge types, where the interface expects plain names. React raises on an object child, so the first badge took down the panel and the tab with it. Both lists are reduced to names before they leave the server.
- The fallback path was broken the same way and more heavily. When the architecture response omits those sections the endpoint falls back to the graph schema, which returns the same rows plus a property list per type, 34 entries for `Function` alone. That path is normalized too, so it is a working fallback rather than a decorative one.
- Not caused by the 0.10.5 engine upgrade in v2.39.0, although reviewing that release surfaced it. Both engine versions return byte-identical values for the keys this endpoint reads, so the tab has been failing for as long as it has existed.
- The module table on the same tab still reads "No module summary available." on an indexed project, and that is now a tested decision rather than a second symptom. The engine aspect that looked like its missing data source reports third-party dependency names and Python builtins with zero coupling on every row, never the project's own packages, so filling the table from it would replace an honest empty state with a table of builtins. A real source is being proven separately before the table is wired to anything.
- The graph tools agents call are untouched and still return the engine's counts. Normalization lives at the last hop before the browser precisely so the model-facing surface keeps that data, and a test enforces it.

### Validation

- 8 endpoint-contract tests driven with verbatim engine payloads. Two fail against the pre-fix endpoint, measured by reverting the helper: the badge assertion and the schema-fallback assertion. The other six are tolerance and scope guards that pass either way by design.
- Verified end to end against a live 4,108-node index through the real endpoint: `node_types` and `edge_types` both return all strings.
- `scripts/typecheck.py` at 0 errors, unchanged from baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Console Architecture view so graph node and edge types display as readable names, including fallback and malformed data scenarios.
  * Preserved counted graph data for agent-facing tools.
  * Improved handling of empty architecture summaries and module-specific responses.

* **Documentation**
  * Updated installation health-check documentation for version 2.39.3.

* **Chores**
  * Released version 2.39.3 across application, package, and container metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->