### PR TITLE
feat(graph): event-driven code graph auto-indexing (v2.44.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 <details>
+<summary><strong>August 24th, 2026: Event-Driven Code Graph Auto-Indexing (v2.44.0)</strong></summary>
+
+### Added: Code Graph Auto-Indexing Is Now Event-Driven
+
+- MARM now indexes a changed repository within seconds of a save, commit, branch switch, or merge instead of on a fixed poll. A bundled filesystem watcher wakes the worker on the actual change, debounced so a burst of edits becomes one re-index instead of one per file.
+- A git repository's re-index trigger is now content-sensitive: the signature hashes the diff against `HEAD` plus a fingerprint of non-ignored untracked files, so two different edits to an already-modified file are recognized as two different changes instead of being read as identical.
+- A periodic reconciliation pass catches a missed watcher event, covers a filesystem that cannot be watched, and remains the only trigger for a directory that is not a git repo. A watcher thread that dies after starting is now detected and automatically rebuilt on the next cycle.
+
+### Changed: Restart-Safe, Cross-Process-Safe Scheduling
+
+- The last successful index state now survives a restart in a durable table, so a freshly started process, or the other transport enrolling a project first, does not blindly re-index everything just because its in-memory state was recreated.
+- A worker refused the cross-process indexing lease no longer records the repository state as current; the change is retried at the next reconciliation pass instead of being silently forgotten.
+- `GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS` and `GRAPH_AUTO_INDEX_RECONCILE_SECONDS` replace the fixed 30-second poll interval. The deprecated `GRAPH_AUTO_INDEX_INTERVAL` and `GRAPH_AUTO_INDEX_FULL_INTERVAL` environment variables still work as compatibility inputs; the latter's value carries over automatically.
+
+### Internal
+
+- New `graph_index_watcher.py` adapter around the bundled `watchdog` dependency, and a `graph_watch_state` table added to the memory database for the durable baseline.
+- Added 20 tests covering debounce coalescing, in-flight catch-up passes, watcher fallback and recovery, cross-process lease-loss safety, and restart-baseline persistence.
+
+</details>
+
+<details>
 <summary><strong>August 23rd, 2026: Evidence-Based Memory ↔ Code Links (v2.43.0)</strong></summary>
 
 ### Added: Trustworthy Links Between MARM's Two Graphs

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="900"
      height="250">
 </picture>
-<h1 align="center">marm-memory v2.43.0 - Give your AI Agents a permanent memory in 60 seconds</h1>
+<h1 align="center">marm-memory v2.44.0 - Give your AI Agents a permanent memory in 60 seconds</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -861,7 +861,7 @@ Use marm_graph_trace for call paths, marm_graph_architecture for an overview, an
 
 The recommended agent workflow: index once, then `marm_code_lookup` before broad file reads, `marm_graph_trace` when callers/callees or data-flow context matters, `marm_graph_architecture` for orientation, and `marm_graph_impact` before risky refactors. One graph query replaces dozens of grep/read cycles, which is where the token savings come from.
 
-Once a repository is indexed, MARM keeps it current on its own. A background poller notices when the repo has changed and re-indexes it, so there is no need to re-index by hand after a commit. While you have uncommitted work it refreshes every cycle, since no cheap check can see repeated edits to a file that is already modified. To index only on request instead:
+Once a repository is indexed, MARM keeps it current on its own. A filesystem watcher notices a save, a commit, a branch switch, or a merge and re-indexes shortly after, debounced so a burst of changes becomes one pass rather than one per file. A periodic reconciliation pass catches anything a watcher event missed and is the only trigger for a directory that is not a git repo. To index only on request instead:
 
 ```text
 marm-mcp-server projects auto off
@@ -934,9 +934,9 @@ The bundled graph engine runs as a supervised child process, not an import:
 - **Envelope care**: responses are scanned for the first JSON-parseable content item rather than assuming index 0, because the upstream binary can prepend an update notice. Tool errors arrive as `result.isError`, not JSON-RPC errors, and are converted to clean `{"status": "error"}` dicts with the upstream's own remediation hint attached.
 - **Serialization**: one lock guards each write+read round trip on the single stdin pipe; async callers go through `asyncio.to_thread` so the event loop never blocks on subprocess IO.
 - **Crash recovery**: stderr is drained on a background thread, child EOF/crash is detected, and the process is transparently respawned on the next call. Timeouts are deliberately *not* treated as crashes; a long index run may still be working, and killing it would destroy in-flight work.
-- **Supervision**: a lazy singleton supervisor owns the client for the process lifetime. Startup is triggered by the first graph-tool call or by the auto-index poller if the engine binary is already downloaded, never raises into the MCP layer, and verifies the pinned binary's tool schema so upstream drift is caught at startup instead of mid-call.
-- **Auto re-indexing is git-signature polled, not filesystem watched**: a background task compares each indexed repo's `HEAD` and dirty state, computed by running `git` outside the engine so an idle check costs no engine lock. A commit triggers a re-index. While the tree is dirty the repo is re-indexed every cycle, because `git status` reports which files changed and not what is in them, so repeated edits to one already-modified file produce byte-identical output that no cheaper fingerprint can distinguish. Git runs with `core.fsmonitor` disabled and a scrubbed environment, since that setting names a program git would otherwise execute from a watched repository on a timer.
-- **One gate for every store mutation**: manual indexes on all three surfaces, the poller, and project deletion all pass through a single leased row in the memory database. HTTP and STDIO are separate processes with separate engine children over one shared engine store, so an in-process lock cannot span them. The lease is released when the engine call actually returns rather than when its caller stops waiting: a cancelled request cannot hand the store to another process while the engine is still writing to it.
+- **Supervision**: a lazy singleton supervisor owns the client for the process lifetime. Startup is triggered by the first graph-tool call or by the auto-index worker if the engine binary is already downloaded, never raises into the MCP layer, and verifies the pinned binary's tool schema so upstream drift is caught at startup instead of mid-call.
+- **Auto re-indexing is filesystem watched, with a git content signature and a reconciliation fallback**: a bundled watcher wakes the worker on a save, commit, branch switch, or merge; matching events are debounced so a burst becomes one re-index. For a git repository, the trigger is confirmed by hashing the diff against `HEAD` plus a fingerprint of non-ignored untracked files, computed outside the engine so an idle check costs no engine lock and two different edits to the same already-modified file are told apart instead of read as identical. A periodic reconciliation pass catches a missed watcher event, covers a filesystem that cannot be watched, and is the only trigger for a directory that is not a git repo. Git runs with `core.fsmonitor` disabled and a scrubbed environment, since that setting names a program git would otherwise execute from a watched repository.
+- **One gate for every store mutation**: manual indexes on all three surfaces, the auto-index worker, and project deletion all pass through a single leased row in the memory database. HTTP and STDIO are separate processes with separate engine children over one shared engine store, so an in-process lock cannot span them. The lease is released when the engine call actually returns rather than when its caller stops waiting: a cancelled request cannot hand the store to another process while the engine is still writing to it.
 
 ### Security & rate limiting
 
@@ -992,8 +992,8 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `COMPACTION_STAGING_TTL_HOURS` | `168` | How long staged summaries wait before expiring |
 | `GRAPH_ENABLED` | `true` | Kill switch for the 5 code-graph tools |
 | `GRAPH_AUTO_INDEX` | `true` | Automatic re-indexing of repos already in the code graph. A saved switch from `projects auto off` or `marm_graph_index(action="auto_off")` overrides this, so a value set here cannot re-enable what a user turned off |
-| `GRAPH_AUTO_INDEX_INTERVAL` | `30` | Seconds between git-signature checks per repo. Minimum 5 |
-| `GRAPH_AUTO_INDEX_FULL_INTERVAL` | `300` | Seconds between re-indexes for a directory that is not a git repo, where no cheap change check exists. Minimum 60 |
+| `GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS` | `2` | Quiet period after a watcher event before a repo is evaluated, so a burst of saves becomes one re-index. Minimum 0.5 |
+| `GRAPH_AUTO_INDEX_RECONCILE_SECONDS` | `300` | Fallback pass that catches a missed watcher event, covers a filesystem that cannot be watched, and is the only trigger for a directory that is not a git repo. Minimum 60. Replaces the deprecated `GRAPH_AUTO_INDEX_FULL_INTERVAL`, whose value carries over automatically if this is unset. `GRAPH_AUTO_INDEX_INTERVAL` (the old fixed poll) is deprecated and no longer read for anything but a warning |
 | `GRAPH_AUTO_INDEX_MODE` | `moderate` | Index depth for automatic re-indexes: `full`, `moderate`, or `fast`. Anything else warns and falls back |
 | `GRAPH_AUTO_INDEX_LEASE_SECONDS` | `120` | How long the indexing gate stays owned once nothing is renewing it. A running index renews its own lease, so this bounds how long a *killed* process blocks indexing, not how long an index may take |
 | `GRAPH_AUTO_INDEX_PROJECT_TTL` | `300` | How long the list of watched projects is trusted before it is re-read from the engine |
@@ -1093,7 +1093,7 @@ It re-splits stale chunks, fills in any lost to an interrupted write, and drops 
 
 - Run `marm-memory projects auto status`. `enabled: false` means automatic re-indexing is switched off; `source: override` means a saved switch is what turned it off, not the environment.
 - The repo has to be indexed once before it is watched. `marm-memory projects list` shows what is enrolled.
-- Give it the interval (30 seconds by default) plus index time. A commit is picked up on the next check.
+- Give it the debounce window (2 seconds by default) plus index time. If nothing happens after that, the reconciliation pass (5 minutes by default) is the backstop.
 - A project deleted from the Console stays suppressed on purpose, so a stale watch list cannot recreate it. Indexing it explicitly re-enrolls it.
 - Automatic indexing needs the graph engine, which stays dormant until the engine binary has been downloaded. Any graph tool call downloads it once.
 

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -313,7 +313,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -287,7 +287,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -73,7 +73,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.43.0"
+LABEL org.opencontainers.image.version="2.44.0"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -7,7 +7,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="900"
      height="250">
 </picture>
-<h1 align="center">marm-memory v2.43.0 - Give your AI Agents a permanent memory in 60 seconds</h1>
+<h1 align="center">marm-memory v2.44.0 - Give your AI Agents a permanent memory in 60 seconds</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -863,7 +863,7 @@ Use marm_graph_trace for call paths, marm_graph_architecture for an overview, an
 
 The recommended agent workflow: index once, then `marm_code_lookup` before broad file reads, `marm_graph_trace` when callers/callees or data-flow context matters, `marm_graph_architecture` for orientation, and `marm_graph_impact` before risky refactors. One graph query replaces dozens of grep/read cycles, which is where the token savings come from.
 
-Once a repository is indexed, MARM keeps it current on its own. A background poller notices when the repo has changed and re-indexes it, so there is no need to re-index by hand after a commit. While you have uncommitted work it refreshes every cycle, since no cheap check can see repeated edits to a file that is already modified. To index only on request instead:
+Once a repository is indexed, MARM keeps it current on its own. A filesystem watcher notices a save, a commit, a branch switch, or a merge and re-indexes shortly after, debounced so a burst of changes becomes one pass rather than one per file. A periodic reconciliation pass catches anything a watcher event missed and is the only trigger for a directory that is not a git repo. To index only on request instead:
 
 ```text
 marm-mcp-server projects auto off
@@ -936,9 +936,9 @@ The bundled graph engine runs as a supervised child process, not an import:
 - **Envelope care**: responses are scanned for the first JSON-parseable content item rather than assuming index 0, because the upstream binary can prepend an update notice. Tool errors arrive as `result.isError`, not JSON-RPC errors, and are converted to clean `{"status": "error"}` dicts with the upstream's own remediation hint attached.
 - **Serialization**: one lock guards each write+read round trip on the single stdin pipe; async callers go through `asyncio.to_thread` so the event loop never blocks on subprocess IO.
 - **Crash recovery**: stderr is drained on a background thread, child EOF/crash is detected, and the process is transparently respawned on the next call. Timeouts are deliberately *not* treated as crashes; a long index run may still be working, and killing it would destroy in-flight work.
-- **Supervision**: a lazy singleton supervisor owns the client for the process lifetime. Startup is triggered by the first graph-tool call or by the auto-index poller if the engine binary is already downloaded, never raises into the MCP layer, and verifies the pinned binary's tool schema so upstream drift is caught at startup instead of mid-call.
-- **Auto re-indexing is git-signature polled, not filesystem watched**: a background task compares each indexed repo's `HEAD` and dirty state, computed by running `git` outside the engine so an idle check costs no engine lock. A commit triggers a re-index. While the tree is dirty the repo is re-indexed every cycle, because `git status` reports which files changed and not what is in them, so repeated edits to one already-modified file produce byte-identical output that no cheaper fingerprint can distinguish. Git runs with `core.fsmonitor` disabled and a scrubbed environment, since that setting names a program git would otherwise execute from a watched repository on a timer.
-- **One gate for every store mutation**: manual indexes on all three surfaces, the poller, and project deletion all pass through a single leased row in the memory database. HTTP and STDIO are separate processes with separate engine children over one shared engine store, so an in-process lock cannot span them. The lease is released when the engine call actually returns rather than when its caller stops waiting: a cancelled request cannot hand the store to another process while the engine is still writing to it.
+- **Supervision**: a lazy singleton supervisor owns the client for the process lifetime. Startup is triggered by the first graph-tool call or by the auto-index worker if the engine binary is already downloaded, never raises into the MCP layer, and verifies the pinned binary's tool schema so upstream drift is caught at startup instead of mid-call.
+- **Auto re-indexing is filesystem watched, with a git content signature and a reconciliation fallback**: a bundled watcher wakes the worker on a save, commit, branch switch, or merge; matching events are debounced so a burst becomes one re-index. For a git repository, the trigger is confirmed by hashing the diff against `HEAD` plus a fingerprint of non-ignored untracked files, computed outside the engine so an idle check costs no engine lock and two different edits to the same already-modified file are told apart instead of read as identical. A periodic reconciliation pass catches a missed watcher event, covers a filesystem that cannot be watched, and is the only trigger for a directory that is not a git repo. Git runs with `core.fsmonitor` disabled and a scrubbed environment, since that setting names a program git would otherwise execute from a watched repository.
+- **One gate for every store mutation**: manual indexes on all three surfaces, the auto-index worker, and project deletion all pass through a single leased row in the memory database. HTTP and STDIO are separate processes with separate engine children over one shared engine store, so an in-process lock cannot span them. The lease is released when the engine call actually returns rather than when its caller stops waiting: a cancelled request cannot hand the store to another process while the engine is still writing to it.
 
 ### Security & rate limiting
 
@@ -994,8 +994,8 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `COMPACTION_STAGING_TTL_HOURS` | `168` | How long staged summaries wait before expiring |
 | `GRAPH_ENABLED` | `true` | Kill switch for the 5 code-graph tools |
 | `GRAPH_AUTO_INDEX` | `true` | Automatic re-indexing of repos already in the code graph. A saved switch from `projects auto off` or `marm_graph_index(action="auto_off")` overrides this, so a value set here cannot re-enable what a user turned off |
-| `GRAPH_AUTO_INDEX_INTERVAL` | `30` | Seconds between git-signature checks per repo. Minimum 5 |
-| `GRAPH_AUTO_INDEX_FULL_INTERVAL` | `300` | Seconds between re-indexes for a directory that is not a git repo, where no cheap change check exists. Minimum 60 |
+| `GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS` | `2` | Quiet period after a watcher event before a repo is evaluated, so a burst of saves becomes one re-index. Minimum 0.5 |
+| `GRAPH_AUTO_INDEX_RECONCILE_SECONDS` | `300` | Fallback pass that catches a missed watcher event, covers a filesystem that cannot be watched, and is the only trigger for a directory that is not a git repo. Minimum 60. Replaces the deprecated `GRAPH_AUTO_INDEX_FULL_INTERVAL`, whose value carries over automatically if this is unset. `GRAPH_AUTO_INDEX_INTERVAL` (the old fixed poll) is deprecated and no longer read for anything but a warning |
 | `GRAPH_AUTO_INDEX_MODE` | `moderate` | Index depth for automatic re-indexes: `full`, `moderate`, or `fast`. Anything else warns and falls back |
 | `GRAPH_AUTO_INDEX_LEASE_SECONDS` | `120` | How long the indexing gate stays owned once nothing is renewing it. A running index renews its own lease, so this bounds how long a *killed* process blocks indexing, not how long an index may take |
 | `GRAPH_AUTO_INDEX_PROJECT_TTL` | `300` | How long the list of watched projects is trusted before it is re-read from the engine |
@@ -1095,7 +1095,7 @@ It re-splits stale chunks, fills in any lost to an interrupted write, and drops 
 
 - Run `marm-memory projects auto status`. `enabled: false` means automatic re-indexing is switched off; `source: override` means a saved switch is what turned it off, not the environment.
 - The repo has to be indexed once before it is watched. `marm-memory projects list` shows what is enrolled.
-- Give it the interval (30 seconds by default) plus index time. A commit is picked up on the next check.
+- Give it the debounce window (2 seconds by default) plus index time. If nothing happens after that, the reconciliation pass (5 minutes by default) is the backstop.
 - A project deleted from the Console stays suppressed on purpose, so a stale watch list cannot recreate it. Indexing it explicitly re-enrolls it.
 - Automatic indexing needs the graph engine, which stays dormant until the engine binary has been downloaded. Any graph tool call downloads it once.
 

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     # :latest is the all-in-one MCP image (memory + graph, one port).
     # Pin :memory-only instead if you need the pre-unification image shape.
-    image: lyellr88/marm-mcp-server:2.43.0
+    image: lyellr88/marm-mcp-server:2.44.0
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -18,7 +18,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.43.0
+      - SERVER_VERSION=2.44.0
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,12 +14,12 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.43.0
+Version: 2.44.0
 """
 
 from typing import Any
 
-__version__ = "2.43.0"
+__version__ = "2.44.0"
 __author__ = "Ryan Lyell"
 __email__ = "ryanlyell@marmemory.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -115,7 +115,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.43.0"
+SERVER_VERSION = "2.44.0"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 
@@ -282,26 +282,56 @@ if _raw_cima < 1:
 # A saved override in runtime_flags beats this; see core/runtime_flags.py.
 GRAPH_AUTO_INDEX = _safe_bool("GRAPH_AUTO_INDEX", True)
 
-# Git-signature cycle. 30s rather than the engine's own 5s base: a git signature
-# costs ~100ms per project on Windows, where process spawn dominates, and a code
-# graph does not need sub-minute freshness.
-_raw_gaii = _safe_int("GRAPH_AUTO_INDEX_INTERVAL", 30)
-GRAPH_AUTO_INDEX_INTERVAL = max(5, _raw_gaii)
-if _raw_gaii < 5:
+# How long the worker waits after the last relevant filesystem/git event before
+# it evaluates source state. Coalesces a burst of saves, a rebase touching many
+# files, or an IDE's multi-file write into one re-index instead of several.
+_raw_gads = _safe_float("GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS", 2.0)
+GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS = max(0.5, _raw_gads)
+if _raw_gads < 0.5:
     print(
-        f"WARNING: GRAPH_AUTO_INDEX_INTERVAL={_raw_gaii} below minimum 5, "
-        f"clamped to {GRAPH_AUTO_INDEX_INTERVAL}",
+        f"WARNING: GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS={_raw_gads} below minimum 0.5, "
+        f"clamped to {GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS}",
         file=sys.stderr,
     )
 
-# Non-git projects have no cheap signature, so their only option is an
-# unconditional re-index. That holds the engine lock, so it gets a slow lane.
-_raw_gaifi = _safe_int("GRAPH_AUTO_INDEX_FULL_INTERVAL", 300)
-GRAPH_AUTO_INDEX_FULL_INTERVAL = max(60, _raw_gaifi)
-if _raw_gaifi < 60:
+# The fallback pass: catches a missed watcher event, covers a filesystem that
+# cannot be watched, and is the only trigger for a non-git root. Not the primary
+# schedule any more -- that is watcher events, debounced above.
+_raw_gars = _safe_int("GRAPH_AUTO_INDEX_RECONCILE_SECONDS", 300)
+GRAPH_AUTO_INDEX_RECONCILE_SECONDS = max(60, _raw_gars)
+if _raw_gars < 60:
     print(
-        f"WARNING: GRAPH_AUTO_INDEX_FULL_INTERVAL={_raw_gaifi} below minimum 60, "
-        f"clamped to {GRAPH_AUTO_INDEX_FULL_INTERVAL}",
+        f"WARNING: GRAPH_AUTO_INDEX_RECONCILE_SECONDS={_raw_gars} below minimum 60, "
+        f"clamped to {GRAPH_AUTO_INDEX_RECONCILE_SECONDS}",
+        file=sys.stderr,
+    )
+
+# Names from the fixed-poll scheduler this replaces. Auto-indexing is
+# event-driven now, so GRAPH_AUTO_INDEX_INTERVAL has nothing left to control --
+# read only to warn instead of erroring on an existing environment.
+# GRAPH_AUTO_INDEX_FULL_INTERVAL's role (the slow re-index cadence) survives as
+# GRAPH_AUTO_INDEX_RECONCILE_SECONDS, so an explicit legacy value carries over
+# instead of silently changing cadence, as long as the new name was not also set.
+if "GRAPH_AUTO_INDEX_INTERVAL" in os.environ:
+    print(
+        "WARNING: GRAPH_AUTO_INDEX_INTERVAL is deprecated and no longer read. "
+        "Auto-indexing is event-driven; set GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS "
+        "instead. This variable will be removed in a future release.",
+        file=sys.stderr,
+    )
+if (
+    "GRAPH_AUTO_INDEX_FULL_INTERVAL" in os.environ
+    and "GRAPH_AUTO_INDEX_RECONCILE_SECONDS" not in os.environ
+):
+    _raw_legacy_full = _safe_int(
+        "GRAPH_AUTO_INDEX_FULL_INTERVAL", GRAPH_AUTO_INDEX_RECONCILE_SECONDS
+    )
+    GRAPH_AUTO_INDEX_RECONCILE_SECONDS = max(60, _raw_legacy_full)
+    print(
+        "WARNING: GRAPH_AUTO_INDEX_FULL_INTERVAL is deprecated, renamed to "
+        "GRAPH_AUTO_INDEX_RECONCILE_SECONDS. Using its value "
+        f"({GRAPH_AUTO_INDEX_RECONCILE_SECONDS}s) for now; update the "
+        "environment variable name before it is removed.",
         file=sys.stderr,
     )
 

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_watcher.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_watcher.py
@@ -11,13 +11,36 @@ import asyncio
 from typing import Callable, Optional
 
 import structlog
-from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.events import (
+    EVENT_TYPE_CLOSED,
+    EVENT_TYPE_CREATED,
+    EVENT_TYPE_DELETED,
+    EVENT_TYPE_MODIFIED,
+    EVENT_TYPE_MOVED,
+    FileSystemEvent,
+    FileSystemEventHandler,
+)
 from watchdog.observers import Observer
 from watchdog.observers.api import BaseObserver, ObservedWatch
 
 logger = structlog.get_logger(__name__)
 
 Callback = Callable[[str], None]
+
+# Linux's inotify backend also emits "opened" and "closed_no_write" for a
+# plain read, with no content change. Forwarding those would make the graph
+# engine's own read of source files while indexing re-trigger itself: a
+# non-git root has no signature check, so any watcher wake reindexes it
+# unconditionally (see _evaluate in graph_index_worker.py).
+_CHANGE_EVENT_TYPES = frozenset(
+    {
+        EVENT_TYPE_CREATED,
+        EVENT_TYPE_MODIFIED,
+        EVENT_TYPE_DELETED,
+        EVENT_TYPE_MOVED,
+        EVENT_TYPE_CLOSED,
+    }
+)
 
 
 class _RootHandler(FileSystemEventHandler):
@@ -34,6 +57,8 @@ class _RootHandler(FileSystemEventHandler):
         # Runs on watchdog's own thread. call_soon_threadsafe is the only safe
         # way to reach the owning loop from here; touching worker state
         # directly from this thread would race the coordinator's own reads.
+        if event.event_type not in _CHANGE_EVENT_TYPES:
+            return
         try:
             self._loop.call_soon_threadsafe(self._callback, self._root)
         except RuntimeError:

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_watcher.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_watcher.py
@@ -1,0 +1,132 @@
+"""Cross-platform filesystem watcher adapter for the graph auto-index worker.
+
+Pure delivery: reports "something changed under this root" to the owning event
+loop. It has no opinion about git, source state, durable baselines, or whether
+a change matters -- that judgment belongs to GraphIndexWorker. This module must
+never import graph_supervisor, tool_router, runtime_flags, or a database class;
+doing so would make it a second indexing worker instead of a delivery mechanism.
+"""
+
+import asyncio
+from typing import Callable, Optional
+
+import structlog
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+from watchdog.observers.api import BaseObserver, ObservedWatch
+
+logger = structlog.get_logger(__name__)
+
+Callback = Callable[[str], None]
+
+
+class _RootHandler(FileSystemEventHandler):
+    """Forwards every event under one watched root back to the owning loop."""
+
+    def __init__(
+        self, root: str, loop: asyncio.AbstractEventLoop, callback: Callback
+    ) -> None:
+        self._root = root
+        self._loop = loop
+        self._callback = callback
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        # Runs on watchdog's own thread. call_soon_threadsafe is the only safe
+        # way to reach the owning loop from here; touching worker state
+        # directly from this thread would race the coordinator's own reads.
+        try:
+            self._loop.call_soon_threadsafe(self._callback, self._root)
+        except RuntimeError:
+            # The loop is already closed (a shutdown race). Nothing to notify.
+            pass
+
+
+class GraphIndexWatcher:
+    """One process-wide observer, multiplexed per watched root.
+
+    watch() failing, for one root or for the whole process, is an expected
+    outcome (network shares, containers, inotify limits) and not an error: the
+    caller falls back to reconciliation. Nothing here decides that fallback
+    cadence; it only reports what watching itself could or could not do.
+    """
+
+    def __init__(self) -> None:
+        self._observer: Optional[BaseObserver] = None
+        self._watches: dict[str, ObservedWatch] = {}
+        self._globally_unavailable = False
+
+    @property
+    def available(self) -> bool:
+        return not self._globally_unavailable
+
+    def healthy(self) -> bool:
+        """False only for an observer that started and then died -- not for
+        one that was never created, or was deliberately stopped, since both
+        of those already read as `_observer is None` and are not failures.
+        The caller decides what a dead observer means for the roots relying
+        on it; this only reports the thread's own state."""
+        return self._observer is None or self._observer.is_alive()
+
+    def _ensure_observer(self) -> Optional[BaseObserver]:
+        if self._observer is not None:
+            return self._observer
+        try:
+            observer = Observer()
+            observer.start()
+        except Exception as exc:
+            self._globally_unavailable = True
+            logger.warning("graph_index_watcher.unavailable", error=str(exc))
+            return None
+        self._observer = observer
+        return observer
+
+    def watch(self, root: str, callback: Callback) -> bool:
+        """Start watching `root`. Returns whether watching is now active.
+
+        False means the caller should rely on reconciliation alone for this
+        root -- an unsupported filesystem, a permissions error, a watch-count
+        limit, or (if `available` is also False) no working observer at all.
+        """
+        if root in self._watches:
+            return True
+        if self._globally_unavailable:
+            return False
+        loop = asyncio.get_running_loop()
+        observer = self._ensure_observer()
+        if observer is None:
+            return False
+        handler = _RootHandler(root, loop, callback)
+        try:
+            watch = observer.schedule(handler, root, recursive=True)
+        except Exception as exc:
+            logger.warning(
+                "graph_index_watcher.watch_failed", root=root, error=str(exc)
+            )
+            return False
+        self._watches[root] = watch
+        return True
+
+    def unwatch(self, root: str) -> None:
+        watch = self._watches.pop(root, None)
+        if watch is None or self._observer is None:
+            return
+        try:
+            self._observer.unschedule(watch)
+        except Exception as exc:
+            logger.warning(
+                "graph_index_watcher.unwatch_failed", root=root, error=str(exc)
+            )
+
+    def stop(self) -> None:
+        """Tear down the observer thread entirely. Safe to call repeatedly;
+        a later watch() call recreates it lazily."""
+        observer = self._observer
+        self._observer = None
+        self._watches.clear()
+        if observer is None:
+            return
+        try:
+            observer.stop()
+            observer.join(timeout=5)
+        except Exception as exc:
+            logger.warning("graph_index_watcher.stop_failed", error=str(exc))

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
@@ -100,6 +100,8 @@ def _git(root: str, *args: str) -> Optional[str]:
             ["git", "-c", "core.fsmonitor=false", "-C", root, *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
             timeout=_GIT_TIMEOUT_SECONDS,
             env=_git_env(),
             creationflags=creationflags,
@@ -150,6 +152,9 @@ def git_source_state(root: str) -> Optional[tuple[str, str]]:
     else:
         unborn = False
 
+    # --no-ext-diff/--no-textconv: same threat model as core.fsmonitor above --
+    # a repo's own .gitattributes plus its config can point either at an
+    # arbitrary command, and MARM watches repos it does not control.
     diff_output: str
     if unborn:
         # `--cached` diffs the index against the empty tree, which git
@@ -159,15 +164,15 @@ def git_source_state(root: str) -> Optional[tuple[str, str]]:
         # "untracked" for the ls-files fingerprint below either. A second,
         # plain `git diff` (working tree against the index) is what a born
         # repo gets for free from `git diff HEAD` comparing straight to HEAD.
-        diff_cached = _git(root, "diff", "--cached")
+        diff_cached = _git(root, "diff", "--no-ext-diff", "--no-textconv", "--cached")
         if diff_cached is None:
             return None
-        diff_unstaged = _git(root, "diff")
+        diff_unstaged = _git(root, "diff", "--no-ext-diff", "--no-textconv")
         if diff_unstaged is None:
             return None
         diff_output = diff_cached + "\x1e" + diff_unstaged
     else:
-        diff_head = _git(root, "diff", "HEAD")
+        diff_head = _git(root, "diff", "--no-ext-diff", "--no-textconv", "HEAD")
         if diff_head is None:
             return None
         diff_output = diff_head

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
@@ -432,10 +432,31 @@ class GraphIndexWorker:
         if not self._watched:
             return min(_IDLE_POLL_SECONDS, GRAPH_AUTO_INDEX_PROJECT_TTL)
         now = time.monotonic()
-        deadlines = [state.reconcile_deadline for state in self._watched.values()]
+        # A failed root never reaches _evaluate again, so its deadline is
+        # never advanced past the -inf it starts at. Left in this list, one
+        # such root would pin the whole coordinator's sleep at 0.0 forever.
+        live = [state for state in self._watched.values() if not state.failed]
+        if not live:
+            return min(_IDLE_POLL_SECONDS, GRAPH_AUTO_INDEX_PROJECT_TTL)
+        # A root that runtime_flags.index_block keeps skipping (suppressed,
+        # marked unindexable, or an unreadable flag DB) also never reaches
+        # _evaluate, so it stays at -inf too -- but _tick() must still
+        # re-check it on every real tick, which is how a manual index
+        # clearing the block is noticed without a restart. So an -inf
+        # deadline only bounds how long the coordinator may sleep past it
+        # (the idle-poll floor below); it must not become a literal 0.0
+        # wake, or the coordinator spins forever re-reading the same block.
+        idle_floor = now + min(_IDLE_POLL_SECONDS, GRAPH_AUTO_INDEX_PROJECT_TTL)
+        never_evaluated = float("-inf")
+        deadlines = [
+            idle_floor
+            if state.reconcile_deadline == never_evaluated
+            else state.reconcile_deadline
+            for state in live
+        ]
         deadlines.extend(
             state.debounce_deadline
-            for state in self._watched.values()
+            for state in live
             if state.debounce_deadline is not None
         )
         return max(0.0, min(deadlines) - now)
@@ -552,6 +573,15 @@ class GraphIndexWorker:
             # until this read, and the watch set is only reloaded once per TTL,
             # so anything keyed to that reload lags by up to the TTL.
             if await asyncio.to_thread(runtime_flags.index_block, state.root):
+                # _on_watch_event sets debounce_deadline independent of the
+                # block -- the watch stays live on a blocked root -- so a
+                # consumed one must not linger here once past. Left in
+                # place it is just as sharp an -inf as reconcile_deadline
+                # once elapsed: _next_wake_delay's min(deadlines) would pick
+                # it up and pin the coordinator at 0.0 again. reconcile_deadline
+                # itself stays untouched: it is still -inf, which is exactly
+                # what keeps this root's block re-checked on every real tick.
+                state.debounce_deadline = None
                 continue
             try:
                 await self._evaluate(state)

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
@@ -121,10 +121,10 @@ def git_source_state(root: str) -> Optional[tuple[str, str]]:
 
     content_hash is sensitive to the bytes that changed, not just which paths
     are dirty. It combines the diff against HEAD -- covers staged and unstaged
-    changes to tracked files in one command -- with a size/mtime fingerprint of
-    every non-ignored untracked path, so a second edit to an already-dirty file,
-    or a new byte in an untracked one, produces a new signature. Nothing here is
-    logged; only the digest is ever kept.
+    changes to tracked files in one command -- with a content hash of every
+    non-ignored untracked path, so a second edit to an already-dirty file, or
+    a same-length edit to an untracked one, produces a new signature. Nothing
+    here is logged; only the digest is ever kept.
 
     A None result must be treated as "no change". Re-indexing on a git error
     would turn a broken repo into a re-index on every single evaluation.
@@ -174,7 +174,7 @@ def git_source_state(root: str) -> Optional[tuple[str, str]]:
 
     # `-z` NUL-terminates so a path with unusual characters is not quoted;
     # quoting would make the reported string diverge from the real filesystem
-    # path and break the stat() below.
+    # path and break the read below.
     untracked_raw = _git(root, "ls-files", "--others", "--exclude-standard", "-z")
     if untracked_raw is None:
         return None
@@ -182,11 +182,31 @@ def git_source_state(root: str) -> Optional[tuple[str, str]]:
     for path in untracked_raw.split("\x00"):
         if not path:
             continue
+        # Content, not size/mtime: a same-length edit landing on an unchanged
+        # mtime -- a coarse filesystem clock, a tool that restores timestamps
+        # -- would otherwise fingerprint identically to the version before it,
+        # which is exactly the staleness class the diff above already fixed
+        # for tracked files.
+        full_path = os.path.join(root, path)
         try:
-            st = os.stat(os.path.join(root, path))
+            if os.path.islink(full_path):
+                # A symlink's own content is its target text, exactly how
+                # git itself stores a tracked one: never open it, which would
+                # follow the link outside the repo, onto a device or pipe
+                # that reads forever, or onto an arbitrarily large file.
+                target_text = os.readlink(full_path)
+                digest = hashlib.sha256(
+                    target_text.encode("utf-8", "surrogateescape")
+                ).hexdigest()
+            else:
+                hasher = hashlib.sha256()
+                with open(full_path, "rb") as fh:
+                    for chunk in iter(lambda: fh.read(1 << 20), b""):
+                        hasher.update(chunk)
+                digest = hasher.hexdigest()
         except OSError:
             continue
-        fingerprints.append(f"{path}:{st.st_size}:{st.st_mtime_ns}")
+        fingerprints.append(f"{path}:{digest}")
 
     digest_input = "\x1f".join([diff_output, *sorted(fingerprints)])
     content_hash = hashlib.sha256(
@@ -575,13 +595,24 @@ class GraphIndexWorker:
             if await asyncio.to_thread(runtime_flags.index_block, state.root):
                 # _on_watch_event sets debounce_deadline independent of the
                 # block -- the watch stays live on a blocked root -- so a
-                # consumed one must not linger here once past. Left in
-                # place it is just as sharp an -inf as reconcile_deadline
-                # once elapsed: _next_wake_delay's min(deadlines) would pick
-                # it up and pin the coordinator at 0.0 again. reconcile_deadline
-                # itself stays untouched: it is still -inf, which is exactly
-                # what keeps this root's block re-checked on every real tick.
-                state.debounce_deadline = None
+                # consumed one (already due when `now` was captured, above)
+                # must not linger here once past: left in place it is just as
+                # sharp an -inf as reconcile_deadline once elapsed, and
+                # _next_wake_delay's min(deadlines) would pick it up and pin
+                # the coordinator at 0.0 again. But index_block is a real
+                # await, and a fresh event can land on this exact state while
+                # it runs -- clearing unconditionally would drop that one too,
+                # and for a root indexed before it became blocked,
+                # reconcile_deadline is a real future timestamp rather than
+                # -inf, so nothing else would notice the loss until the next
+                # reconcile pass, minutes later. Only a deadline already due
+                # for `now` is safe to drop; one set during the await is
+                # strictly later than `now` and must survive.
+                if (
+                    state.debounce_deadline is not None
+                    and state.debounce_deadline <= now
+                ):
+                    state.debounce_deadline = None
                 continue
             try:
                 await self._evaluate(state)

--- a/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
+++ b/marm-mcp-server/marm_mcp_server/core/graph_index_worker.py
@@ -1,23 +1,30 @@
-"""Background poller that keeps indexed code graphs current.
+"""Event-driven worker that keeps indexed code graphs current.
 
 A graph is otherwise only as fresh as the last manual `marm_graph_index` call,
-and a stale graph does not fail loudly: it answers confidently from deleted code.
+and a stale graph does not fail loudly: it answers confidently from deleted
+code. A filesystem watcher (graph_index_watcher.py) wakes this worker after a
+real change instead of it polling blind on a fixed interval; a reconciliation
+pass on GRAPH_AUTO_INDEX_RECONCILE_SECONDS covers a missed watcher event, a
+filesystem that cannot be watched, and is the only trigger a non-git root has.
 
-Detection is a git signature computed outside the engine, so an idle cycle costs
-no engine lock. It is deliberately NOT the engine's own `detect_changes`, which
-reports the dirty working tree relative to HEAD rather than drift between the
-repo and the index: commit your work and it reports clean while the graph still
-lacks every symbol in that commit. See docs/current/graph-auto-index.md.
+Detection for a git root is a signature computed outside the engine, so an
+idle wake costs no engine lock. It is deliberately NOT the engine's own
+`detect_changes`, which reports the dirty working tree relative to HEAD rather
+than drift between the repo and the index: commit your work and it reports
+clean while the graph still lacks every symbol in that commit.
 
-While a repo is dirty the signature is useless, because `git status --porcelain`
-names which files changed and not what is in them, so the second and every later
-edit to one file produce byte-identical output. A dirty repo is therefore
-re-indexed every cycle instead. `index_repository` is incremental, so an
-unchanged dirty repo costs a few hundred milliseconds and a changed one does
-exactly the work that was needed.
+The signature has to be sensitive to what changed, not just that something
+did: `git status --porcelain` names which files changed and not what is in
+them, so a second edit to an already-dirty file produces byte-identical
+status output. git_source_state hashes the actual diff against HEAD plus a
+fingerprint of non-ignored untracked content instead, so two different edits
+to the same file produce two different signatures.
+
+See docs/current/index/graph/event-driven-graph-auto-indexing.md.
 """
 
 import asyncio
+import hashlib
 import os
 import subprocess
 import sys
@@ -35,13 +42,14 @@ from marm_graph.core.models import GraphIndexRequest
 
 from ..config.settings import (
     GRAPH_AUTO_INDEX,
-    GRAPH_AUTO_INDEX_FULL_INTERVAL,
-    GRAPH_AUTO_INDEX_INTERVAL,
+    GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS,
     GRAPH_AUTO_INDEX_MODE,
     GRAPH_AUTO_INDEX_PROJECT_TTL,
+    GRAPH_AUTO_INDEX_RECONCILE_SECONDS,
 )
 from . import code_link_queue, code_project_bindings, runtime_flags
 from .graph_index_lock import GraphIndexBusy, run_exclusive
+from .graph_index_watcher import GraphIndexWatcher
 from .graph_supervisor import graph_supervisor
 
 logger = structlog.get_logger(__name__)
@@ -51,6 +59,12 @@ _GIT_TIMEOUT_SECONDS = 15
 # Stands in for HEAD in a repository with no commits yet.
 _UNBORN_HEAD = ""
 
+# How often a disabled worker re-checks the on/off flag, and how long a fresh
+# worker with nothing watched yet waits before looking again. Not
+# user-configurable: it only governs noticing a cross-process auto_on or a
+# newly-listed project, never indexing cadence.
+_IDLE_POLL_SECONDS = 15.0
+
 
 def _git_env() -> dict[str, str]:
     """A scrubbed environment for a git call on a user-chosen repository.
@@ -58,7 +72,9 @@ def _git_env() -> dict[str, str]:
     Inherited GIT_* variables belong to whatever launched the server, not to the
     repo being polled, and GIT_DIR or GIT_WORK_TREE would point our -C somewhere
     else entirely. GIT_OPTIONAL_LOCKS=0 keeps a status check from taking
-    .git/index.lock and rewriting the index on a timer.
+    .git/index.lock and rewriting the index -- which matters even more now than
+    it used to: a watcher would see that rewrite as a change and re-trigger the
+    very check that caused it.
     """
     env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
     env["GIT_OPTIONAL_LOCKS"] = "0"
@@ -70,7 +86,7 @@ def _git(root: str, *args: str) -> Optional[str]:
 
     core.fsmonitor names a program git will execute, and it is read from the
     polled repository's own config: honoring it would let any repo MARM watches
-    run a program of its choosing on a 30 second timer.
+    run a program of its choosing whenever this fires.
     """
     # An `if` statement, not a conditional expression: mypy applies its
     # sys.platform narrowing to statements only, so the expression form reports
@@ -100,34 +116,83 @@ def is_git_repo(root: str) -> bool:
     return (Path(root) / ".git").exists()
 
 
-def git_signature(root: str) -> Optional[tuple[str, bool]]:
-    """(HEAD, dirty) for the repo AT `root`, or None if git could not answer.
+def git_source_state(root: str) -> Optional[tuple[str, str]]:
+    """(HEAD, content_hash) for the repo AT `root`, or None if git could not answer.
+
+    content_hash is sensitive to the bytes that changed, not just which paths
+    are dirty. It combines the diff against HEAD -- covers staged and unstaged
+    changes to tracked files in one command -- with a size/mtime fingerprint of
+    every non-ignored untracked path, so a second edit to an already-dirty file,
+    or a new byte in an untracked one, produces a new signature. Nothing here is
+    logged; only the digest is ever kept.
 
     A None result must be treated as "no change". Re-indexing on a git error
-    would turn a broken repo into a re-index on every single cycle.
+    would turn a broken repo into a re-index on every single evaluation.
 
     The `.git` check is not redundant with the caller's. Git's repository
     discovery walks upward from `-C`, so on a directory that is not itself a
-    repo this would report an ancestor's HEAD and dirty state: an indexed
-    subdirectory of some other repo would then re-index whenever anything
-    anywhere in that parent changed.
+    repo this would report an ancestor's state: an indexed subdirectory of some
+    other repo would then re-index whenever anything anywhere in that parent
+    changed.
     """
     if not is_git_repo(root):
         return None
     head = _git(root, "rev-parse", "HEAD")
     if head is None:
         # A repository with no commits yet. `rev-parse HEAD` fails on an unborn
-        # HEAD, and _poll_one has already classified this as git, so returning
-        # None here meant such a repo returned early on every cycle and was
-        # never refreshed at all. A stable sentinel puts it on the dirty lane
-        # instead, which is the only signal it has until its first commit.
+        # HEAD; the sentinel keeps such a repo on the same signature path as
+        # any other instead of falling out of change detection until its first
+        # commit.
         if _git(root, "rev-parse", "--is-inside-work-tree") != "true":
             return None
         head = _UNBORN_HEAD
-    status = _git(root, "status", "--porcelain")
-    if status is None:
+        unborn = True
+    else:
+        unborn = False
+
+    diff_output: str
+    if unborn:
+        # `--cached` diffs the index against the empty tree, which git
+        # supports directly -- there is no HEAD commit to diff against. On
+        # its own this misses an unstaged edit to a file already staged: it
+        # reads the index, not the working tree, and that file is no longer
+        # "untracked" for the ls-files fingerprint below either. A second,
+        # plain `git diff` (working tree against the index) is what a born
+        # repo gets for free from `git diff HEAD` comparing straight to HEAD.
+        diff_cached = _git(root, "diff", "--cached")
+        if diff_cached is None:
+            return None
+        diff_unstaged = _git(root, "diff")
+        if diff_unstaged is None:
+            return None
+        diff_output = diff_cached + "\x1e" + diff_unstaged
+    else:
+        diff_head = _git(root, "diff", "HEAD")
+        if diff_head is None:
+            return None
+        diff_output = diff_head
+
+    # `-z` NUL-terminates so a path with unusual characters is not quoted;
+    # quoting would make the reported string diverge from the real filesystem
+    # path and break the stat() below.
+    untracked_raw = _git(root, "ls-files", "--others", "--exclude-standard", "-z")
+    if untracked_raw is None:
         return None
-    return (head, bool(status))
+    fingerprints = []
+    for path in untracked_raw.split("\x00"):
+        if not path:
+            continue
+        try:
+            st = os.stat(os.path.join(root, path))
+        except OSError:
+            continue
+        fingerprints.append(f"{path}:{st.st_size}:{st.st_mtime_ns}")
+
+    digest_input = "\x1f".join([diff_output, *sorted(fingerprints)])
+    content_hash = hashlib.sha256(
+        digest_input.encode("utf-8", "surrogateescape")
+    ).hexdigest()
+    return (head, content_hash)
 
 
 def index_repository(client: "CbmClient", req: GraphIndexRequest) -> dict:
@@ -179,32 +244,53 @@ def index_repository(client: "CbmClient", req: GraphIndexRequest) -> dict:
 
 
 class _Watched:
-    """Per-project poll state. Disposable: losing it costs one extra re-index."""
+    """Per-project watch state. Disposable in memory: the durable baseline
+    lives in graph_watch_state, so losing this costs at most one extra
+    re-index rather than a wrong "unchanged" verdict."""
 
     __slots__ = (
+        "content_hash",
+        "debounce_deadline",
+        "evaluated_generation",
         "failed",
-        "last_full",
+        "generation",
+        "git_head",
+        "is_git",
+        "last_index_reason",
         "last_indexed",
+        "reconcile_deadline",
         "retry_after",
         "root",
-        "signature",
+        "watch_mode",
     )
 
     def __init__(self, root: str) -> None:
         self.root = root
-        self.signature: Optional[tuple[str, bool]] = None
-        # -inf, not 0.0: this is compared as `monotonic() - last_full < interval`,
-        # and monotonic() counts from boot. At 0.0 a never-indexed project reads as
-        # "indexed at boot", so on a machine up for less than the interval its
-        # first index waited the interval out instead of running immediately.
-        self.last_full: float = float("-inf")
+        self.is_git = is_git_repo(root)
+        self.git_head: Optional[str] = None
+        self.content_hash: Optional[str] = None
         self.last_indexed: Optional[str] = None
+        self.last_index_reason: Optional[str] = None
         # Set after a failure so the next attempt waits out a backoff instead of
-        # retrying on the next cycle. Cleared by a success.
+        # retrying on the next evaluation. Cleared by a success.
         self.retry_after: float = 0.0
         # Terminal for this session: a failure that cannot resolve itself, so
         # retrying only costs the engine gate.
         self.failed = False
+        # Bumped by the watcher callback; compared against evaluated_generation
+        # to answer "is a debounced event or catch-up pass still waiting".
+        self.generation = 0
+        self.evaluated_generation = 0
+        self.debounce_deadline: Optional[float] = None
+        # -inf, not 0.0: this is compared as `monotonic() >= reconcile_deadline`,
+        # and monotonic() counts from boot. At 0.0 a never-evaluated project
+        # reads as due immediately on most machines, but not on one that has
+        # been up longer than the reconcile interval, where it would wait a
+        # full interval before its first check.
+        self.reconcile_deadline: float = float("-inf")
+        # Placeholder; _enroll_watch sets the real value immediately after
+        # construction, before this is ever read externally.
+        self.watch_mode = "disabled"
 
 
 class GraphIndexWorker:
@@ -214,8 +300,18 @@ class GraphIndexWorker:
     def __init__(self) -> None:
         self._task: Optional[asyncio.Task] = None
         self._stop = asyncio.Event()
+        self._wake = asyncio.Event()
+        self._watcher = GraphIndexWatcher()
         self._watched: dict[str, _Watched] = {}
         self._projects_loaded_at: Optional[float] = None
+        # True the moment _tick is entered even once, regardless of outcome.
+        # _next_wake_delay uses this, not _projects_loaded_at, to decide
+        # whether an immediate first tick is still owed: the engine can stay
+        # unavailable forever (binary not downloaded, no graph tool ever
+        # called), in which case _refresh_projects never runs and
+        # _projects_loaded_at never gets set -- checking that instead would
+        # wake with a 0.0 delay on every single iteration forever.
+        self._ticked_once = False
         self._cycles = 0
         self._indexed = 0
 
@@ -225,7 +321,7 @@ class GraphIndexWorker:
 
     @staticmethod
     def enabled() -> bool:
-        """Re-read on every cycle, never cached. An off switch that needed a
+        """Re-read on every wake, never cached. An off switch that needed a
         restart would not be an off switch."""
         return runtime_flags.get_bool(runtime_flags.AUTO_INDEX_GRAPH, GRAPH_AUTO_INDEX)
 
@@ -246,47 +342,49 @@ class GraphIndexWorker:
             return False
 
     def start(self) -> None:
-        """Never raises. A poller that cannot run leaves graphs as stale as they
-        are today, which is recoverable; breaking startup is not."""
+        """Never raises. A worker that cannot run leaves graphs as stale as
+        they are today, which is recoverable; breaking startup is not."""
         if self.running:
             return
         if not self.enabled():
-            # The loop still starts and each cycle re-checks the flag. That is
-            # what lets `projects auto on` work without a restart: the CLI writes
-            # the switch to the database from another process and cannot create a
-            # task in this one. An idle cycle is one indexed SELECT.
+            # The loop still starts and re-checks the flag on every wake. That
+            # is what lets `projects auto on` work without a restart: the CLI
+            # writes the switch to the database from another process and
+            # cannot create a task in this one. An idle wake costs one
+            # indexed SELECT.
             logger.info("graph_auto_index.idle", reason="auto_index_off")
         try:
             self._stop.clear()
             self._task = asyncio.get_running_loop().create_task(self._run())
             logger.info(
                 "graph_auto_index.started",
-                interval_seconds=GRAPH_AUTO_INDEX_INTERVAL,
+                debounce_seconds=GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS,
+                reconcile_seconds=GRAPH_AUTO_INDEX_RECONCILE_SECONDS,
                 mode=GRAPH_AUTO_INDEX_MODE,
             )
         except RuntimeError as exc:
             logger.warning("graph_auto_index.start_failed", error=str(exc))
 
     async def stop(self) -> None:
-        """Stop scheduling and return.
+        """Stop scheduling, tear down any active filesystem watches, and return.
 
         Deliberately does not wait for an in-flight index and deliberately does
         not release its lease. The index call owns its own lease through
-        run_exclusive and finishes on its own; there is no durable task to protect
-        here, and the next cycle recomputes the signature from scratch anyway.
+        run_exclusive and finishes on its own; there is no durable task to
+        protect here, and the next start recomputes everything from scratch.
         """
         self._stop.set()
         task = self._task
         self._task = None
-        if task is None or task.done():
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        except Exception as exc:
-            logger.warning("graph_auto_index.stop_error", error=str(exc))
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.warning("graph_auto_index.stop_error", error=str(exc))
+        self._watcher.stop()
         logger.info(
             "graph_auto_index.stopped", cycles=self._cycles, indexed=self._indexed
         )
@@ -294,10 +392,11 @@ class GraphIndexWorker:
     async def _run(self) -> None:
         primed = False
         while not self._stop.is_set():
-            await self._wait(GRAPH_AUTO_INDEX_INTERVAL)
-            if self._stop.is_set():
+            delay = self._next_wake_delay()
+            if await self._wait(delay):
                 return
             if not self.enabled():
+                self._deactivate()
                 continue
             if not primed:
                 # Once, and only after the flag says yes: priming spawns the
@@ -306,19 +405,72 @@ class GraphIndexWorker:
                 await self._prime_engine()
             self._cycles += 1
             try:
-                await self._cycle()
+                await self._tick()
             except Exception as exc:
-                # One bad cycle must never end the loop. Nothing here is
-                # durable, so the next signature check recovers whatever
-                # this one missed.
+                # One bad tick must never end the loop. Nothing here is
+                # durable beyond graph_watch_state, so the next evaluation
+                # recovers whatever this one missed.
                 logger.warning("graph_auto_index.cycle_failed", error=str(exc))
+
+    def _next_wake_delay(self) -> float:
+        """Seconds until the next thing needing attention: a debounce
+        deadline, a reconcile deadline, or -- while disabled or with nothing
+        watched yet -- a short idle poll, so a cross-process auto_on or a
+        freshly-listed project is noticed promptly instead of after a full
+        reconcile wait."""
+        if not self.enabled():
+            return min(_IDLE_POLL_SECONDS, GRAPH_AUTO_INDEX_PROJECT_TTL)
+        if not self._ticked_once:
+            # Enabled and never ticked yet -- discover projects immediately
+            # rather than waiting out an idle poll on a freshly started
+            # worker. Gated on _ticked_once rather than _projects_loaded_at:
+            # the latter never gets set while the engine is unavailable, and
+            # this must fire at most once regardless of whether the engine
+            # ever becomes available, or an unavailable engine busy-loops
+            # this at 0.0 forever.
+            return 0.0
+        if not self._watched:
+            return min(_IDLE_POLL_SECONDS, GRAPH_AUTO_INDEX_PROJECT_TTL)
+        now = time.monotonic()
+        deadlines = [state.reconcile_deadline for state in self._watched.values()]
+        deadlines.extend(
+            state.debounce_deadline
+            for state in self._watched.values()
+            if state.debounce_deadline is not None
+        )
+        return max(0.0, min(deadlines) - now)
+
+    async def _wait(self, seconds: float) -> bool:
+        """Sleep until `seconds` elapse, a wake is requested, or stopped.
+        Returns whether a stop arrived."""
+        stop_wait = asyncio.ensure_future(self._stop.wait())
+        wake_wait = asyncio.ensure_future(self._wake.wait())
+        try:
+            await asyncio.wait(
+                {stop_wait, wake_wait},
+                timeout=max(0.0, seconds),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in (stop_wait, wake_wait):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(stop_wait, wake_wait, return_exceptions=True)
+        self._wake.clear()
+        return self._stop.is_set()
+
+    def wake(self) -> None:
+        """Wake the coordinator promptly instead of waiting out its current
+        sleep. Only reaches a coordinator in this process; a flag flipped
+        from another process is still picked up on the next idle poll."""
+        self._wake.set()
 
     async def _prime_engine(self) -> None:
         """Start the engine once, off the lifespan path, if it is already on disk.
 
         _ensure_started() is synchronous and can spend CBM_STARTUP_TIMEOUT (60s)
         spawning and handshaking, so it must never run inline in lifespan and
-        never inside a poll cycle.
+        never inside a scheduling tick.
         """
         if not self.binary_present():
             logger.info("graph_auto_index.dormant", reason="engine_binary_absent")
@@ -328,39 +480,84 @@ class GraphIndexWorker:
         except Exception as exc:
             logger.warning("graph_auto_index.prime_failed", error=str(exc))
 
-    async def _wait(self, seconds: float) -> bool:
-        """Sleep unless stopped first. Returns whether a stop arrived."""
-        try:
-            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
-            return True
-        except (asyncio.TimeoutError, TimeoutError):
-            return False
+    def _deactivate(self) -> None:
+        """Stop all filesystem watching without forgetting per-project
+        history, so `auto_status` still shows the last known state while
+        off. Re-enrolled by _tick the moment auto-index is turned back on."""
+        self._watcher.stop()
+        for state in self._watched.values():
+            if state.watch_mode != "disabled":
+                state.watch_mode = "disabled"
+                state.debounce_deadline = None
 
-    async def _cycle(self) -> None:
+    def _recover_dead_watcher(self) -> None:
+        """The one shared observer thread died after successfully starting --
+        not a setup failure, which watch() already handles per root by
+        falling back to reconcile_fallback. One Observer backs every root, so
+        all of them lose event delivery at once here; reconciliation still
+        protects correctness, but freshness silently degrades to it until
+        something notices. Rebuild a fresh observer and re-enroll exactly the
+        roots that were relying on the dead one, leaving alone any root
+        already on reconcile_fallback for its own reason (a permission
+        error, a watch-count limit) rather than retrying that every tick.
+        """
+        affected = [
+            state
+            for state in self._watched.values()
+            if state.watch_mode in ("git_events", "filesystem_events")
+        ]
+        logger.warning(
+            "graph_index_watcher.observer_died", affected_roots=len(affected)
+        )
+        self._watcher.stop()
+        for state in affected:
+            self._enroll_watch(state)
+
+    async def _tick(self) -> None:
+        # Set before any early return, including the engine-unavailable one
+        # below: this is what stops _next_wake_delay from busy-looping at
+        # 0.0 when the engine never becomes available.
+        self._ticked_once = True
+        # Guarded here too, not only in _run: off must mean off before
+        # anything reads engine state, even for a caller that reaches this
+        # directly instead of through the coordination loop.
         if not self.enabled():
             return
         # snapshot(), never is_available(): the latter calls _ensure_started()
-        # and would spawn the engine from inside a poll cycle.
+        # and would spawn the engine from inside a scheduling tick.
         if not graph_supervisor.snapshot()["available"]:
             return
 
         await self._refresh_projects()
+        if self._watched and not self._watcher.healthy():
+            self._recover_dead_watcher()
+        for state in self._watched.values():
+            if state.watch_mode == "disabled":
+                self._enroll_watch(state)
+
+        now = time.monotonic()
         for state in list(self._watched.values()):
             if self._stop.is_set():
                 return
             if state.failed:
                 # In-process and genuinely terminal: the root is gone.
                 continue
-            # Read per cycle rather than cached in the state. A delete or a
+            due = now >= state.reconcile_deadline or (
+                state.debounce_deadline is not None and now >= state.debounce_deadline
+            )
+            if not due:
+                continue
+            # Read per tick rather than cached in the state. A delete or a
             # successful manual index in the OTHER transport is invisible here
             # until this read, and the watch set is only reloaded once per TTL,
-            # so anything keyed to that reload lags by up to five minutes.
+            # so anything keyed to that reload lags by up to the TTL.
             if await asyncio.to_thread(runtime_flags.index_block, state.root):
                 continue
             try:
-                await self._poll_one(state)
+                await self._evaluate(state)
             except GraphIndexBusy:
-                # Someone else is indexing. Skip; the next cycle recomputes.
+                # Someone else is indexing. The deadlines _evaluate already
+                # reset mean the next wake tries again.
                 continue
             except Exception as exc:
                 logger.warning(
@@ -371,13 +568,13 @@ class GraphIndexWorker:
         """Reload the watch set when its TTL expires.
 
         list_projects costs ~265ms and holds the engine lock, so this is cached
-        rather than called every cycle.
+        rather than called every tick.
 
         Freshness is the load timestamp alone, never whether the watch set came
         back non-empty. An empty result is a real answer: a fresh install with no
         projects, or an install where every project is suppressed. Treating empty
-        as "not loaded yet" put list_projects back on every 30s cycle for exactly
-        the users who have no indexing to do.
+        as "not loaded yet" would put list_projects back on every tick for
+        exactly the users who have no indexing to do.
         """
         now = time.monotonic()
         if (
@@ -408,55 +605,116 @@ class GraphIndexWorker:
                 continue
             if runtime_flags.is_watch_suppressed(root):
                 continue
-            self._watched[root] = _Watched(root)
+            state = _Watched(root)
+            # Seed from the durable baseline so a restart, or the other
+            # transport enrolling this root first, does not read as "never
+            # indexed" and force a redundant re-index.
+            durable = await asyncio.to_thread(runtime_flags.get_watch_state, root)
+            if durable is not None:
+                state.last_indexed = durable.get("last_indexed")
+                state.last_index_reason = durable.get("last_index_reason")
+                stored = durable.get("last_source_state") or ""
+                if durable.get("source_kind") == "git" and ":" in stored:
+                    state.git_head, state.content_hash = stored.split(":", 1)
+            self._watched[root] = state
+            self._enroll_watch(state)
         for root in list(self._watched):
             if root not in roots or runtime_flags.is_watch_suppressed(root):
-                self._watched.pop(root, None)
+                self._detach(root)
 
-    async def _poll_one(self, state: _Watched) -> None:
+    def _enroll_watch(self, state: _Watched) -> None:
+        ok = self._watcher.watch(state.root, self._on_watch_event)
+        if ok:
+            state.watch_mode = "git_events" if state.is_git else "filesystem_events"
+        elif self._watcher.available:
+            state.watch_mode = "reconcile_fallback"
+        else:
+            state.watch_mode = "unavailable"
+
+    def _on_watch_event(self, root: str) -> None:
+        """The watcher's callback, invoked on this process's event loop via
+        call_soon_threadsafe. Bumps a counter, pushes the debounce deadline
+        out, and wakes the coordinator. All judgment -- whether the change is
+        real, whether to re-index -- happens in _evaluate, on a later tick.
+
+        The wake is not optional: the coordinator may already be sleeping
+        toward a reconcile deadline minutes away, computed before this event
+        existed. Without waking it, the event sits recorded but unexamined
+        until that old deadline arrives, which is worse than the fixed poll
+        this design replaced.
+        """
+        state = self._watched.get(root)
+        if state is None:
+            return
+        state.generation += 1
+        state.debounce_deadline = time.monotonic() + GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS
+        self.wake()
+
+    async def _evaluate(self, state: _Watched) -> None:
         root = state.root
         if not os.path.isdir(root):
-            # Moved or deleted. index_repository would error on every cycle.
+            # Moved or deleted. index_repository would error on every attempt.
             logger.info("graph_auto_index.root_missing", root=root)
             state.failed = True
+            self._watcher.unwatch(root)
             return
 
-        if not is_git_repo(root):
-            # No cheap signature exists, so the only option is an unconditional
-            # re-index. That holds the engine lock, so it gets the slow lane.
-            if time.monotonic() - state.last_full < GRAPH_AUTO_INDEX_FULL_INTERVAL:
-                return
-            await self._reindex(state, reason="non_git_interval")
-            return
+        generation_at_start = state.generation
+        state.debounce_deadline = None
 
-        signature = await asyncio.to_thread(git_signature, root)
-        if signature is None:
-            return
+        reason: Optional[str] = None
+        # Candidate baseline: computed now, but must not land on `state`
+        # until an index built from it actually succeeds. Recording it early
+        # made a losing cross-process lease refusal look like "nothing to
+        # do" forever afterward, because the next evaluation would compare
+        # the real repo against a baseline this process never indexed.
+        candidate_git_state: Optional[tuple[str, str]] = None
+        if state.is_git:
+            result = await asyncio.to_thread(git_source_state, root)
+            if result is not None:
+                candidate_git_state = result
+                head, content_hash = result
+                previous_head = state.git_head
+                previous_hash = state.content_hash
+                first_observation = previous_head is None
+                changed = first_observation or (previous_head, previous_hash) != (
+                    head,
+                    content_hash,
+                )
+                if changed:
+                    # New information, so it is retried at once regardless of
+                    # any pending backoff.
+                    reason = (
+                        "head_moved"
+                        if not first_observation and head != previous_head
+                        else "worktree_changed"
+                    )
+                elif state.retry_after and time.monotonic() >= state.retry_after:
+                    # Nothing new, but a previous failure's backoff expired.
+                    reason = "reconcile"
+        else:
+            # No cheap signature exists for a non-git root, so any trigger --
+            # a debounced event or the reconcile deadline -- means reindex.
+            reason = (
+                "filesystem_changed"
+                if state.watch_mode != "reconcile_fallback"
+                else "reconcile"
+            )
 
-        previous = state.signature
-        state.signature = signature
-        _, dirty = signature
-        changed = previous is None or previous != signature
+        state.evaluated_generation = generation_at_start
+        state.reconcile_deadline = time.monotonic() + GRAPH_AUTO_INDEX_RECONCILE_SECONDS
 
-        # A repo that changed carries new information, so it is retried at once.
-        # Otherwise a failure waits out its backoff: the signature is recorded
-        # before the index runs, so without this a failed index would either never
-        # be retried (clean repo) or be retried every single cycle (dirty repo).
-        if state.retry_after and not changed and time.monotonic() < state.retry_after:
-            return
+        if reason is not None:
+            await self._reindex(
+                state, reason=reason, candidate_git_state=candidate_git_state
+            )
 
-        if dirty:
-            await self._reindex(state, reason="dirty")
-        elif changed and previous is not None and previous[1]:
-            # Was dirty last cycle, clean now with the same HEAD: the edits were
-            # reverted or stashed, and the graph still holds what they contained.
-            await self._reindex(state, reason="went_clean")
-        elif changed:
-            await self._reindex(state, reason="head_moved")
-        elif state.retry_after:
-            await self._reindex(state, reason="retry_after_failure")
-
-    async def _reindex(self, state: _Watched, reason: str) -> None:
+    async def _reindex(
+        self,
+        state: _Watched,
+        reason: str,
+        candidate_git_state: Optional[tuple[str, str]] = None,
+    ) -> None:
         client = graph_supervisor.get_client()
         if client is None:
             return
@@ -469,11 +727,18 @@ class GraphIndexWorker:
                 action="index", repo_path=state.root, mode=GRAPH_AUTO_INDEX_MODE
             ),
         )
+        # A result came back -- success or failure -- so the repo state this
+        # process just observed was genuinely acted on and becomes the new
+        # comparison baseline either way; that is what makes the backoff
+        # below mean anything; without it, a chronically failing repo whose
+        # baseline never advances would always look like the first
+        # observation and retry immediately, bypassing the backoff entirely.
+        # Only GraphIndexBusy, raised by run_exclusive above before any
+        # result exists, must leave the old baseline in place: that attempt
+        # never happened, so this process has no information to advance on.
+        if candidate_git_state is not None:
+            state.git_head, state.content_hash = candidate_git_state
         elapsed_ms = int((time.monotonic() - started) * 1000)
-        # Recorded on failure too. A non-git project's only gate is this timer, so
-        # leaving it at its old value on error made a failing one retry on the fast
-        # interval and take the engine gate every cycle.
-        state.last_full = time.monotonic()
         if result.get("status") == "error":
             if result.get("error_code") == "windows_path_too_long":
                 # Marked by index_repository, inside the gate.
@@ -484,18 +749,19 @@ class GraphIndexWorker:
                     hint=result.get("hint"),
                 )
                 return
-            state.retry_after = time.monotonic() + GRAPH_AUTO_INDEX_FULL_INTERVAL
+            state.retry_after = time.monotonic() + GRAPH_AUTO_INDEX_RECONCILE_SECONDS
             logger.warning(
                 "graph_auto_index.index_failed",
                 root=state.root,
                 reason=reason,
                 message=result.get("message"),
-                retry_in_seconds=GRAPH_AUTO_INDEX_FULL_INTERVAL,
+                retry_in_seconds=GRAPH_AUTO_INDEX_RECONCILE_SECONDS,
             )
             return
         state.retry_after = 0.0
         self._indexed += 1
         state.last_indexed = _iso_now()
+        state.last_index_reason = reason
         logger.info(
             "graph_auto_index.reindexed",
             root=state.root,
@@ -503,9 +769,32 @@ class GraphIndexWorker:
             reason=reason,
             duration_ms=elapsed_ms,
         )
+        try:
+            await asyncio.to_thread(
+                runtime_flags.save_watch_state,
+                state.root,
+                source_kind="git" if state.is_git else "non_git",
+                last_source_state=(
+                    f"{state.git_head}:{state.content_hash}" if state.is_git else None
+                ),
+                last_indexed=state.last_indexed,
+                last_index_reason=reason,
+                watch_status=state.watch_mode,
+            )
+        except Exception as exc:
+            logger.warning(
+                "graph_auto_index.watch_state_save_failed",
+                root=state.root,
+                error=str(exc),
+            )
+
+    def _detach(self, root: str) -> None:
+        self._watcher.unwatch(root)
+        self._watched.pop(root, None)
 
     def drop_watch(self, root: str) -> None:
-        """Forget a root immediately, ahead of the next cache refresh.
+        """Forget a root immediately, ahead of the next cache refresh, and
+        stop watching it at the OS level.
 
         Only covers this process. The durable suppression in runtime_flags is
         what stops the other transport's poller, and what survives a restart.
@@ -517,14 +806,15 @@ class GraphIndexWorker:
         for key in [
             key for key in self._watched if runtime_flags.canonical_root(key) == target
         ]:
-            self._watched.pop(key, None)
+            self._detach(key)
 
     def status(self) -> dict:
         return {
             "enabled": self.enabled(),
             "flag_source": runtime_flags.source(runtime_flags.AUTO_INDEX_GRAPH),
             "running": self.running,
-            "interval_seconds": GRAPH_AUTO_INDEX_INTERVAL,
+            "debounce_seconds": GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS,
+            "reconcile_seconds": GRAPH_AUTO_INDEX_RECONCILE_SECONDS,
             "cycles": self._cycles,
             "indexed": self._indexed,
             "engine_binary_present": self.binary_present(),
@@ -532,7 +822,15 @@ class GraphIndexWorker:
                 {
                     "root_path": state.root,
                     "last_indexed": state.last_indexed,
+                    "last_index_reason": state.last_index_reason,
                     "dropped": state.failed,
+                    "watch_mode": state.watch_mode,
+                    "last_source_state": (
+                        f"{state.git_head}:{state.content_hash}"
+                        if state.git_head is not None
+                        else None
+                    ),
+                    "pending": state.generation != state.evaluated_generation,
                 }
                 for state in self._watched.values()
             ],
@@ -568,13 +866,16 @@ def auto_action(action: str) -> dict:
     runtime_flags.set_bool(runtime_flags.AUTO_INDEX_GRAPH, turning_on)
     if turning_on:
         graph_index_worker.start()
+    # Either direction needs this: on must not wait out an idle poll to start
+    # watching, and off must not leave observers running -- detached only in
+    # _deactivate, reached only on the coordinator's next wake -- for however
+    # long its current sleep happens to be.
+    graph_index_worker.wake()
     return {
         "status": "success",
         "auto_index": {
             "enabled": turning_on,
             "flag_source": runtime_flags.source(runtime_flags.AUTO_INDEX_GRAPH),
-            # The loop reads the flag per cycle, so turning it off takes effect
-            # on the next one without a restart.
             "effective": "next cycle" if not turning_on else "now",
         },
     }

--- a/marm-mcp-server/marm_mcp_server/core/memory_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_db.py
@@ -479,6 +479,23 @@ def init_database(db_path: str) -> None:
             )
             """)
 
+        # The event-driven graph worker's durable baseline, one row per watched
+        # root. Without this a restart (or the other transport starting up) has
+        # no memory of the last successful index and re-indexes every project
+        # once just because its in-memory state was recreated. last_source_state
+        # is opaque -- a digest, never source text or a diff.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS graph_watch_state (
+                root_path         TEXT PRIMARY KEY,
+                source_kind       TEXT NOT NULL,
+                last_source_state TEXT,
+                last_indexed      TEXT,
+                last_index_reason TEXT,
+                watch_status      TEXT NOT NULL DEFAULT 'unknown',
+                updated_at        TEXT NOT NULL
+            )
+            """)
+
         conn.execute("DROP TABLE IF EXISTS session_summary_chunks")
 
         conn.execute("""

--- a/marm-mcp-server/marm_mcp_server/core/runtime_flags.py
+++ b/marm-mcp-server/marm_mcp_server/core/runtime_flags.py
@@ -232,3 +232,87 @@ def _keys_with_prefix(prefix: str) -> list[str]:
 
 def suppressed_watches() -> list[str]:
     return _keys_with_prefix(_SUPPRESS_PREFIX)
+
+
+# ── Durable watch state ────────────────────────────────────────────
+# The event-driven graph worker's baseline: what a root looked like at its last
+# successful index. Lives in its own table (graph_watch_state), not the generic
+# key/value one above, because it is a row of related fields rather than a
+# single flag. Keyed through canonical_root() for the same reason the
+# suppressions are: the engine and MARM do not always spell the same directory
+# the same way.
+
+
+def get_watch_state(root_path: str) -> Optional[dict]:
+    """Durable baseline for a root, or None if never recorded or unreadable.
+
+    Never raises and never fabricates a baseline: a database that cannot be
+    read must read as "unknown", not as "nothing has changed since the last
+    index", or a restart could skip a re-index a project genuinely needs.
+    """
+    root = canonical_root(root_path)
+    try:
+        with _connection() as conn:
+            row = conn.execute(
+                "SELECT source_kind, last_source_state, last_indexed,"
+                " last_index_reason, watch_status"
+                " FROM graph_watch_state WHERE root_path = ?",
+                (root,),
+            ).fetchone()
+    except Exception as exc:
+        logger.warning(
+            "runtime_flags.watch_state_read_failed", root=root, error=str(exc)
+        )
+        return None
+    if row is None:
+        return None
+    return {
+        "source_kind": row[0],
+        "last_source_state": row[1],
+        "last_indexed": row[2],
+        "last_index_reason": row[3],
+        "watch_status": row[4],
+    }
+
+
+def save_watch_state(
+    root_path: str,
+    *,
+    source_kind: str,
+    last_source_state: Optional[str],
+    last_indexed: str,
+    last_index_reason: str,
+    watch_status: str,
+) -> None:
+    root = canonical_root(root_path)
+    with _connection() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute(
+                """
+                INSERT INTO graph_watch_state
+                    (root_path, source_kind, last_source_state, last_indexed,
+                     last_index_reason, watch_status, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(root_path) DO UPDATE SET
+                    source_kind = excluded.source_kind,
+                    last_source_state = excluded.last_source_state,
+                    last_indexed = excluded.last_indexed,
+                    last_index_reason = excluded.last_index_reason,
+                    watch_status = excluded.watch_status,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    root,
+                    source_kind,
+                    last_source_state,
+                    last_indexed,
+                    last_index_reason,
+                    watch_status,
+                    _now(),
+                ),
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM Memory v2.43.0 — Give your AI Agents a permanent memory in 60 seconds
+# MARM Memory v2.44.0 - Give your AI Agents a permanent memory in 60 seconds
 
 ## Table of Contents
 
@@ -13,7 +13,6 @@
 - [Knowledge Graphs: Code & Concepts](#knowledge-graphs-code--concepts)
 - [Architecture & Internals](#architecture--internals)
 - [Troubleshooting](#troubleshooting)
-
 
 ## Quick Start
 
@@ -836,7 +835,7 @@ Use marm_graph_trace for call paths, marm_graph_architecture for an overview, an
 
 The recommended agent workflow: index once, then `marm_code_lookup` before broad file reads, `marm_graph_trace` when callers/callees or data-flow context matters, `marm_graph_architecture` for orientation, and `marm_graph_impact` before risky refactors. One graph query replaces dozens of grep/read cycles, which is where the token savings come from.
 
-Once a repository is indexed, MARM keeps it current on its own. A background poller notices when the repo has changed and re-indexes it, so there is no need to re-index by hand after a commit. While you have uncommitted work it refreshes every cycle, since no cheap check can see repeated edits to a file that is already modified. To index only on request instead:
+Once a repository is indexed, MARM keeps it current on its own. A filesystem watcher notices a save, a commit, a branch switch, or a merge and re-indexes shortly after, debounced so a burst of changes becomes one pass rather than one per file. A periodic reconciliation pass catches anything a watcher event missed and is the only trigger for a directory that is not a git repo. To index only on request instead:
 
 ```text
 marm-mcp-server projects auto off
@@ -909,9 +908,9 @@ The bundled graph engine runs as a supervised child process, not an import:
 - **Envelope care**: responses are scanned for the first JSON-parseable content item rather than assuming index 0, because the upstream binary can prepend an update notice. Tool errors arrive as `result.isError`, not JSON-RPC errors, and are converted to clean `{"status": "error"}` dicts with the upstream's own remediation hint attached.
 - **Serialization**: one lock guards each write+read round trip on the single stdin pipe; async callers go through `asyncio.to_thread` so the event loop never blocks on subprocess IO.
 - **Crash recovery**: stderr is drained on a background thread, child EOF/crash is detected, and the process is transparently respawned on the next call. Timeouts are deliberately *not* treated as crashes; a long index run may still be working, and killing it would destroy in-flight work.
-- **Supervision**: a lazy singleton supervisor owns the client for the process lifetime. Startup is triggered by the first graph-tool call or by the auto-index poller if the engine binary is already downloaded, never raises into the MCP layer, and verifies the pinned binary's tool schema so upstream drift is caught at startup instead of mid-call.
-- **Auto re-indexing is git-signature polled, not filesystem watched**: a background task compares each indexed repo's `HEAD` and dirty state, computed by running `git` outside the engine so an idle check costs no engine lock. A commit triggers a re-index. While the tree is dirty the repo is re-indexed every cycle, because `git status` reports which files changed and not what is in them, so repeated edits to one already-modified file produce byte-identical output that no cheaper fingerprint can distinguish. Git runs with `core.fsmonitor` disabled and a scrubbed environment, since that setting names a program git would otherwise execute from a watched repository on a timer.
-- **One gate for every store mutation**: manual indexes on all three surfaces, the poller, and project deletion all pass through a single leased row in the memory database. HTTP and STDIO are separate processes with separate engine children over one shared engine store, so an in-process lock cannot span them. The lease is released when the engine call actually returns rather than when its caller stops waiting: a cancelled request cannot hand the store to another process while the engine is still writing to it.
+- **Supervision**: a lazy singleton supervisor owns the client for the process lifetime. Startup is triggered by the first graph-tool call or by the auto-index worker if the engine binary is already downloaded, never raises into the MCP layer, and verifies the pinned binary's tool schema so upstream drift is caught at startup instead of mid-call.
+- **Auto re-indexing is filesystem watched, with a git content signature and a reconciliation fallback**: a bundled watcher wakes the worker on a save, commit, branch switch, or merge; matching events are debounced so a burst becomes one re-index. For a git repository, the trigger is confirmed by hashing the diff against `HEAD` plus a fingerprint of non-ignored untracked files, computed outside the engine so an idle check costs no engine lock and two different edits to the same already-modified file are told apart instead of read as identical. A periodic reconciliation pass catches a missed watcher event, covers a filesystem that cannot be watched, and is the only trigger for a directory that is not a git repo. Git runs with `core.fsmonitor` disabled and a scrubbed environment, since that setting names a program git would otherwise execute from a watched repository.
+- **One gate for every store mutation**: manual indexes on all three surfaces, the auto-index worker, and project deletion all pass through a single leased row in the memory database. HTTP and STDIO are separate processes with separate engine children over one shared engine store, so an in-process lock cannot span them. The lease is released when the engine call actually returns rather than when its caller stops waiting: a cancelled request cannot hand the store to another process while the engine is still writing to it.
 
 ### Security & rate limiting
 
@@ -967,8 +966,8 @@ Packaged docs are indexed into the `marm_system` memory namespace on startup and
 | `COMPACTION_STAGING_TTL_HOURS` | `168` | How long staged summaries wait before expiring |
 | `GRAPH_ENABLED` | `true` | Kill switch for the 5 code-graph tools |
 | `GRAPH_AUTO_INDEX` | `true` | Automatic re-indexing of repos already in the code graph. A saved switch from `projects auto off` or `marm_graph_index(action="auto_off")` overrides this, so a value set here cannot re-enable what a user turned off |
-| `GRAPH_AUTO_INDEX_INTERVAL` | `30` | Seconds between git-signature checks per repo. Minimum 5 |
-| `GRAPH_AUTO_INDEX_FULL_INTERVAL` | `300` | Seconds between re-indexes for a directory that is not a git repo, where no cheap change check exists. Minimum 60 |
+| `GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS` | `2` | Quiet period after a watcher event before a repo is evaluated, so a burst of saves becomes one re-index. Minimum 0.5 |
+| `GRAPH_AUTO_INDEX_RECONCILE_SECONDS` | `300` | Fallback pass that catches a missed watcher event, covers a filesystem that cannot be watched, and is the only trigger for a directory that is not a git repo. Minimum 60. Replaces the deprecated `GRAPH_AUTO_INDEX_FULL_INTERVAL`, whose value carries over automatically if this is unset. `GRAPH_AUTO_INDEX_INTERVAL` (the old fixed poll) is deprecated and no longer read for anything but a warning |
 | `GRAPH_AUTO_INDEX_MODE` | `moderate` | Index depth for automatic re-indexes: `full`, `moderate`, or `fast`. Anything else warns and falls back |
 | `GRAPH_AUTO_INDEX_LEASE_SECONDS` | `120` | How long the indexing gate stays owned once nothing is renewing it. A running index renews its own lease, so this bounds how long a *killed* process blocks indexing, not how long an index may take |
 | `GRAPH_AUTO_INDEX_PROJECT_TTL` | `300` | How long the list of watched projects is trusted before it is re-read from the engine |
@@ -1068,7 +1067,7 @@ It re-splits stale chunks, fills in any lost to an interrupted write, and drops 
 
 - Run `marm-memory projects auto status`. `enabled: false` means automatic re-indexing is switched off; `source: override` means a saved switch is what turned it off, not the environment.
 - The repo has to be indexed once before it is watched. `marm-memory projects list` shows what is enrolled.
-- Give it the interval (30 seconds by default) plus index time. A commit is picked up on the next check.
+- Give it the debounce window (2 seconds by default) plus index time. If nothing happens after that, the reconciliation pass (5 minutes by default) is the backstop.
 - A project deleted from the Console stays suppressed on purpose, so a stale watch list cannot recreate it. Indexing it explicitly re-enrolls it.
 - Automatic indexing needs the graph engine, which stays dormant until the engine binary has been downloaded. Any graph tool call downloads it once.
 

--- a/marm-mcp-server/marm_mcp_server/server.py
+++ b/marm-mcp-server/marm_mcp_server/server.py
@@ -5,7 +5,7 @@ This server integrates all modular components of the MARM protocol into a single
 FastAPI application, compliant with the MCP protocol via FastApiMCP.
 
 Author: Lyell - marm-memory
-Version: 2.43.0
+Version: 2.44.0
 """
 
 import os

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.43.0"
+version = "2.44.0"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"
@@ -44,6 +44,7 @@ dependencies = [
     "mcp>=1.26.0,<2.0.0",
     "codebase-memory-mcp==0.10.5",
     "spacy>=3.8.0,<3.9.0",
+    "watchdog>=4.0.0,<7.0.0",
 ]
 
 [project.urls]
@@ -114,6 +115,7 @@ module = [
     "codebase_memory_mcp.*",
     "apscheduler.*",
     "fastapi_mcp",
+    "watchdog.*",
 ]
 ignore_missing_imports = true
 

--- a/marm-mcp-server/requirements-glama.txt
+++ b/marm-mcp-server/requirements-glama.txt
@@ -12,3 +12,4 @@ packaging>=24.0,<27.0
 fastembed>=0.8.0,<1.0.0
 codebase-memory-mcp==0.10.5
 spacy>=3.8.0,<3.9.0
+watchdog>=4.0.0,<7.0.0

--- a/marm-mcp-server/requirements.txt
+++ b/marm-mcp-server/requirements.txt
@@ -13,3 +13,4 @@ httpx>=0.28.1,<1.0.0
 packaging>=24.0,<27.0
 codebase-memory-mcp==0.10.5
 spacy>=3.8.0,<3.9.0
+watchdog>=4.0.0,<7.0.0

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.43.0",
+      "version": "2.44.0",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.43.0",
+      "identifier": "lyellr88/marm-mcp-server:2.44.0",
       "transport": { "type": "stdio" }
     }
   ],

--- a/marm-mcp-server/tests/test_graph_auto_index.py
+++ b/marm-mcp-server/tests/test_graph_auto_index.py
@@ -36,6 +36,28 @@ def shared_db(monkeypatch, tmp_path):
     return memory_module.memory, tmp_path / "marm_memory.db"
 
 
+@pytest.fixture(autouse=True)
+def _stop_leaked_watchers(monkeypatch):
+    """Every GraphIndexWorker built below may start a real watchdog Observer
+    thread: _tick enrolls any watch_mode == "disabled" state on its own, and
+    that is the default for a state constructed directly rather than through
+    _refresh_projects. Track every instance built during the test and stop
+    its watcher afterward, rather than relying on each test to remember to."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    built: list = []
+    original_init = module.GraphIndexWorker.__init__
+
+    def tracking_init(self, *args, **kwargs):
+        built.append(self)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(module.GraphIndexWorker, "__init__", tracking_init)
+    yield
+    for worker in built:
+        worker._watcher.stop()
+
+
 def _git(cwd, *args):
     subprocess.run(
         ["git", *args],
@@ -1137,6 +1159,93 @@ def test_a_vanished_root_is_dropped_and_the_loop_survives(shared_db, tmp_path):
     assert missing.failed is True
 
 
+def test_a_failed_root_does_not_pin_the_coordinator_at_a_zero_second_wake(
+    shared_db, tmp_path
+):
+    """A failed root never reaches _evaluate again, so its reconcile_deadline
+    never advances past the -inf it starts at. Left in _next_wake_delay's
+    aggregation, that -inf would win the min() forever and spin the
+    coordinator at 0.0 with no sleep between ticks."""
+    from marm_mcp_server.core.graph_index_worker import GraphIndexWorker, _Watched
+
+    worker = GraphIndexWorker()
+    missing = _Watched(str(tmp_path / "does-not-exist"))
+    asyncio.run(worker._evaluate(missing))
+    assert missing.failed is True
+
+    worker._watched[missing.root] = missing
+    worker._ticked_once = True
+    assert worker._next_wake_delay() > 0.0, (
+        "a failed root must not pin the coordinator's wake delay at 0.0"
+    )
+
+
+def test_a_blocked_root_does_not_pin_the_coordinator_either(shared_db, tmp_path):
+    """The other never-evaluated path: runtime_flags.index_block keeps
+    skipping _evaluate for a suppressed or unindexable root, so its
+    reconcile_deadline also stays at -inf forever. _tick() must still
+    re-check the block on every real tick -- that is how a manual index
+    clearing it is noticed without a restart -- so the fix must live in
+    _next_wake_delay's aggregation, not in the state itself."""
+    from marm_mcp_server.core import runtime_flags
+    from marm_mcp_server.core.graph_index_worker import GraphIndexWorker, _Watched
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    root = str(plain)
+    runtime_flags.mark_unindexable(root, "windows_path_too_long")
+
+    worker = GraphIndexWorker()
+    state = _Watched(root)
+    worker._watched[state.root] = state
+    worker._ticked_once = True
+    assert state.reconcile_deadline == float("-inf"), (
+        "never evaluated: the block always skips it before _evaluate runs"
+    )
+    assert worker._next_wake_delay() > 0.0, (
+        "a permanently blocked root must not pin the coordinator's wake delay at 0.0"
+    )
+
+
+def test_a_blocked_root_with_an_elapsed_debounce_deadline_still_does_not_pin_the_coordinator(
+    shared_db, tmp_path, monkeypatch
+):
+    """_on_watch_event sets debounce_deadline independent of the block -- the
+    watch stays live on a blocked root, since _enroll_watch does not consult
+    index_block. Once that deadline elapses it is just as sharp an -inf as
+    reconcile_deadline once elapsed, so leaving it in _tick's index_block skip
+    path reopens the exact loop the reconcile_deadline fix closed, just
+    through the other deadline."""
+    from marm_mcp_server.core import graph_index_worker as module
+    from marm_mcp_server.core import runtime_flags
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    root = str(plain)
+    runtime_flags.mark_unindexable(root, "windows_path_too_long")
+
+    worker = module.GraphIndexWorker()
+    state = module._Watched(root)
+    # Stands in for a real watcher event firing on this blocked root: the
+    # deadline it leaves behind has nothing to do with whether the block
+    # is still active.
+    state.debounce_deadline = time.monotonic() - 1
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+
+    asyncio.run(worker._tick())
+    assert state.debounce_deadline is None, (
+        "a consumed debounce event on a blocked root must not linger in the past"
+    )
+    assert worker._next_wake_delay() > 0.0, (
+        "an elapsed debounce deadline on a blocked root must not pin the "
+        "coordinator's wake delay at 0.0 either"
+    )
+
+
 # ── the standalone package ──────────────────────────────────────────
 
 
@@ -1709,6 +1818,40 @@ async def test_an_event_during_an_in_flight_index_leaves_exactly_one_pending_pas
     assert state.debounce_deadline is not None, (
         "exactly one catch-up must be scheduled, not zero and not a busy loop"
     )
+
+
+def test_read_only_watchdog_events_are_not_forwarded(shared_db):
+    """Linux's inotify backend also emits "opened" and "closed_no_write" for a
+    plain read, with no content change. Forwarding those would make a non-git
+    root -- which has no signature check and reindexes unconditionally on any
+    trigger -- re-index itself every debounce window from nothing but reads
+    under the watched root, including the graph engine's own reads while
+    indexing it."""
+    from watchdog.events import (
+        FileClosedNoWriteEvent,
+        FileCreatedEvent,
+        FileModifiedEvent,
+        FileOpenedEvent,
+    )
+
+    from marm_mcp_server.core.graph_index_watcher import _RootHandler
+
+    class _ImmediateLoop:
+        def call_soon_threadsafe(self, callback, *args):
+            callback(*args)
+
+    seen = []
+    handler = _RootHandler(
+        "/some/root", _ImmediateLoop(), lambda root: seen.append(root)
+    )
+
+    handler.on_any_event(FileOpenedEvent("/some/root/a.py"))
+    handler.on_any_event(FileClosedNoWriteEvent("/some/root/a.py"))
+    assert seen == [], "read-only events must not wake the coordinator"
+
+    handler.on_any_event(FileModifiedEvent("/some/root/a.py"))
+    handler.on_any_event(FileCreatedEvent("/some/root/b.py"))
+    assert seen == ["/some/root", "/some/root"], "real changes must still be forwarded"
 
 
 def test_a_watch_failure_for_one_root_falls_back_to_reconcile(

--- a/marm-mcp-server/tests/test_graph_auto_index.py
+++ b/marm-mcp-server/tests/test_graph_auto_index.py
@@ -112,75 +112,139 @@ def _run_in_second_process(db_path: Path, body: str) -> dict:
 
 def test_signature_moves_on_commit_and_on_edit(git_repo):
     """The two changes a code graph must notice. detect_changes sees only the
-    second one, which is why the poller does not use it."""
-    from marm_mcp_server.core.graph_index_worker import git_signature
+    second one, which is why the worker does not use it."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
 
-    base = git_signature(str(git_repo))
-    assert base is not None
-    assert base[1] is False
+    base_head, base_hash = git_source_state(str(git_repo))
 
     (git_repo / "src" / "a.py").write_text("def g_one():\n    return 2\n")
-    dirty = git_signature(str(git_repo))
-    assert dirty[0] == base[0]
-    assert dirty[1] is True
+    dirty_head, dirty_hash = git_source_state(str(git_repo))
+    assert dirty_head == base_head
+    assert dirty_hash != base_hash
 
     _git(git_repo, "commit", "-aqm", "second")
-    committed = git_signature(str(git_repo))
-    assert committed[0] != base[0], "HEAD must move on commit"
-    assert committed[1] is False
+    committed_head, committed_hash = git_source_state(str(git_repo))
+    assert committed_head != base_head, "HEAD must move on commit"
+    assert committed_hash != dirty_hash
 
 
-def test_a_dirty_repo_signature_is_identical_across_repeated_edits(git_repo):
-    """The measurement the whole dirty-path design rests on. If this ever
-    changes, re-indexing every dirty cycle stops being necessary."""
-    from marm_mcp_server.core.graph_index_worker import git_signature
+def test_two_different_edits_to_the_same_dirty_file_produce_different_signatures(
+    git_repo,
+):
+    """The measurement the whole event-driven design rests on. The old (HEAD,
+    dirty) signature could not tell these apart, because `git status
+    --porcelain` reports which files changed and not what changed in them --
+    exactly the gap that forced a dirty repo to re-index on every cycle
+    instead of only when something really changed."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
 
-    signatures = []
+    hashes = []
     for index in range(3):
         # Never the committed body, or one iteration is legitimately clean.
         (git_repo / "src" / "a.py").write_text(f"def g_one():\n    return 10{index}\n")
-        signatures.append(git_signature(str(git_repo)))
+        hashes.append(git_source_state(str(git_repo))[1])
 
-    assert signatures[0] == signatures[1] == signatures[2]
-    assert all(signature[1] is True for signature in signatures)
+    assert len(set(hashes)) == 3, "three different edits must be three different hashes"
+
+
+def test_staged_unstaged_and_untracked_changes_all_move_the_signature(git_repo):
+    """`git diff HEAD` alone covers staged and unstaged changes to tracked
+    files; it never shows untracked files at all, which is why the untracked
+    fingerprint is a separate half of the signature."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
+
+    base = git_source_state(str(git_repo))[1]
+
+    (git_repo / "src" / "a.py").write_text("def g_one():\n    return 2\n")
+    _git(git_repo, "add", "-A")
+    staged = git_source_state(str(git_repo))[1]
+    assert staged != base
+
+    (git_repo / "src" / "a.py").write_text("def g_one():\n    return 3\n")
+    mixed = git_source_state(str(git_repo))[1]
+    assert mixed != staged, "an unstaged edit on top of a staged one must also move it"
+
+    _git(git_repo, "commit", "-aqm", "clean up")
+    clean = git_source_state(str(git_repo))[1]
+
+    (git_repo / "src" / "new_file.py").write_text("x = 1\n")
+    untracked = git_source_state(str(git_repo))[1]
+    assert untracked != clean, "a new untracked file must move the signature too"
+
+
+def test_an_ignored_file_does_not_move_the_signature(git_repo):
+    """The engine remains the ignore-policy owner; this signature must not
+    react to churn in build output or dependency directories."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
+
+    (git_repo / ".gitignore").write_text("ignored/\n")
+    _git(git_repo, "add", ".gitignore")
+    _git(git_repo, "commit", "-qm", "add gitignore")
+    (git_repo / "ignored").mkdir()
+
+    base = git_source_state(str(git_repo))[1]
+    (git_repo / "ignored" / "build.log").write_text("noise\n")
+    after = git_source_state(str(git_repo))[1]
+    assert after == base
+
+
+def test_a_branch_switch_moves_the_signature(git_repo):
+    """A checkout is exactly the kind of change detect_changes cannot see
+    either, since the working tree can end up identical to how it started."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
+
+    base_head = git_source_state(str(git_repo))[0]
+    _git(git_repo, "checkout", "-qb", "other")
+    (git_repo / "src" / "a.py").write_text("def g_one():\n    return 99\n")
+    _git(git_repo, "commit", "-aqm", "on other branch")
+    _git(git_repo, "checkout", "-q", "-")
+
+    back = git_source_state(str(git_repo))[0]
+    assert back == base_head, "back on the original branch, HEAD is unchanged"
+
+    _git(git_repo, "checkout", "-q", "other")
+    switched = git_source_state(str(git_repo))[0]
+    assert switched != base_head
 
 
 def test_git_failure_reads_as_no_change(tmp_path):
-    """A broken or non-repo path must not re-index on every single cycle."""
-    from marm_mcp_server.core.graph_index_worker import git_signature, is_git_repo
+    """A broken or non-repo path must not re-index on every single evaluation."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state, is_git_repo
 
     plain = tmp_path / "plain"
     plain.mkdir()
     assert is_git_repo(str(plain)) is False
-    assert git_signature(str(plain)) is None
+    assert git_source_state(str(plain)) is None
 
 
 def test_a_non_repo_never_reports_an_ancestor_repos_signature(git_repo):
     """Git's repository discovery walks upward from -C. A subdirectory that is
-    not itself a repo must not report the enclosing repo's HEAD and dirty state,
-    or it would re-index whenever anything anywhere in that parent changed.
+    not itself a repo must not report the enclosing repo's HEAD and content
+    state, or it would re-index whenever anything anywhere in that parent
+    changed.
 
     This is also why the assertion above cannot depend on pytest's temp
     directory happening to sit outside every git repository.
     """
-    from marm_mcp_server.core.graph_index_worker import git_signature, is_git_repo
+    from marm_mcp_server.core.graph_index_worker import git_source_state, is_git_repo
 
     nested = git_repo / "src" / "not_a_repo"
     nested.mkdir()
-    assert git_signature(str(git_repo)) is not None, "the real repo still answers"
+    assert git_source_state(str(git_repo)) is not None, "the real repo still answers"
 
     assert is_git_repo(str(nested)) is False
-    assert git_signature(str(nested)) is None
+    assert git_source_state(str(nested)) is None
 
     # And the same for a plain directory whose parent is a repo.
     (git_repo / "src" / "a.py").write_text("def g_one():\n    return 42\n")
-    assert git_signature(str(nested)) is None
+    assert git_source_state(str(nested)) is None
 
 
 def test_core_fsmonitor_from_the_polled_repo_is_never_executed(git_repo, tmp_path):
     """core.fsmonitor names a program git will run, read from the watched repo's
-    own config. Polling a user-chosen repository must not invoke it on a timer."""
-    from marm_mcp_server.core.graph_index_worker import git_signature
+    own config. Evaluating a user-chosen repository must not invoke it, even
+    though a watcher now triggers evaluation far more often than a 30s poll did."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
 
     sentinel = tmp_path / "fsmonitor-ran"
     if sys.platform == "win32":
@@ -193,21 +257,21 @@ def test_core_fsmonitor_from_the_polled_repo_is_never_executed(git_repo, tmp_pat
     _git(git_repo, "config", "core.fsmonitor", str(hook).replace("\\", "/"))
 
     (git_repo / "src" / "a.py").write_text("def g_one():\n    return 9\n")
-    assert git_signature(str(git_repo)) is not None
+    assert git_source_state(str(git_repo)) is not None
     assert not sentinel.exists(), "core.fsmonitor was executed"
 
 
 def test_git_runs_with_a_scrubbed_environment(git_repo, monkeypatch, tmp_path):
     """An inherited GIT_DIR belongs to whatever launched the server, and would
     point our -C at a different repository entirely."""
-    from marm_mcp_server.core.graph_index_worker import git_signature
+    from marm_mcp_server.core.graph_index_worker import git_source_state
 
     other = tmp_path / "other"
     other.mkdir()
     monkeypatch.setenv("GIT_DIR", str(other))
     monkeypatch.setenv("GIT_WORK_TREE", str(other))
 
-    assert git_signature(str(git_repo)) is not None
+    assert git_source_state(str(git_repo)) is not None
 
 
 def test_git_poll_hides_its_windows_child_window(monkeypatch):
@@ -497,7 +561,7 @@ def test_a_disabled_cycle_never_touches_the_engine(shared_db, monkeypatch):
 
     runtime_flags.set_bool(runtime_flags.AUTO_INDEX_GRAPH, False)
     worker = module.GraphIndexWorker()
-    asyncio.run(worker._cycle())
+    asyncio.run(worker._tick())
 
     assert touched == []
     assert worker.status()["enabled"] is False
@@ -549,37 +613,41 @@ def test_a_suppressed_root_is_dropped_from_the_watch_set(shared_db, monkeypatch)
     assert set(worker._watched) == {"/repo/keep", "/repo/gone"}
 
 
-def test_a_non_git_project_polls_only_on_the_slow_interval(
-    shared_db, tmp_path, monkeypatch
-):
-    """Its only detection option is an unconditional re-index, which holds the
-    engine lock. A directory that was never a repo must not do that every 30s."""
+def test_a_non_git_project_reindexes_only_when_due(shared_db, tmp_path, monkeypatch):
+    """A non-git root has no cheap signature, so any trigger -- a debounced
+    watcher event or the reconcile deadline -- means an unconditional
+    reindex. Due-ness itself is _tick's gate, not _evaluate's: a directory
+    that was never a repo must not reindex on every tick regardless."""
     from marm_mcp_server.core import graph_index_worker as module
 
     plain = tmp_path / "plain"
     plain.mkdir()
     worker = module.GraphIndexWorker()
     state = module._Watched(str(plain))
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
 
     reindexed = []
 
-    async def record(target, reason):
+    async def record(target, reason, candidate_git_state=None):
         reindexed.append(reason)
-        target.last_full = time.monotonic()
 
     monkeypatch.setattr(worker, "_reindex", record)
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
 
-    asyncio.run(worker._poll_one(state))
-    assert reindexed == ["non_git_interval"]
+    asyncio.run(worker._tick())
+    assert reindexed == ["filesystem_changed"]
 
-    # Immediately again: inside the slow interval, so nothing.
-    asyncio.run(worker._poll_one(state))
-    assert reindexed == ["non_git_interval"]
+    # Immediately again: not due, so nothing.
+    asyncio.run(worker._tick())
+    assert reindexed == ["filesystem_changed"]
 
-    # Past the slow interval it fires once more.
-    state.last_full = time.monotonic() - module.GRAPH_AUTO_INDEX_FULL_INTERVAL - 1
-    asyncio.run(worker._poll_one(state))
-    assert reindexed == ["non_git_interval", "non_git_interval"]
+    # Past the reconcile deadline it fires once more.
+    state.reconcile_deadline = time.monotonic() - 1
+    asyncio.run(worker._tick())
+    assert reindexed == ["filesystem_changed", "filesystem_changed"]
 
 
 def test_the_poller_stays_dormant_when_the_engine_binary_is_absent(
@@ -826,12 +894,12 @@ def test_a_short_repo_path_keeps_the_engines_own_error():
     assert "crashed on a file" in result["hint"]
 
 
-def test_a_failing_non_git_project_does_not_retry_on_the_fast_interval(
+def test_a_failing_non_git_project_does_not_retry_before_its_deadline(
     shared_db, tmp_path, monkeypatch
 ):
-    """A non-git project's only gate is its last-attempt timer. Leaving that at its
-    old value on failure made a broken one re-index every cycle, taking the engine
-    gate each time."""
+    """A non-git project's only gate is its reconcile deadline. Leaving that at
+    its old value on failure made a broken one re-index every tick, taking the
+    engine gate each time."""
     from marm_mcp_server.core import graph_index_worker as module
 
     plain = tmp_path / "plain"
@@ -846,26 +914,34 @@ def test_a_failing_non_git_project_does_not_retry_on_the_fast_interval(
     monkeypatch.setattr(
         module.graph_supervisor, "get_client", lambda: object(), raising=False
     )
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
 
     worker = module.GraphIndexWorker()
     state = module._Watched(str(plain))
-    asyncio.run(worker._poll_one(state))
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
+
+    asyncio.run(worker._tick())
     assert len(attempts) == 1
 
-    asyncio.run(worker._poll_one(state))
-    asyncio.run(worker._poll_one(state))
+    asyncio.run(worker._tick())
+    asyncio.run(worker._tick())
     assert len(attempts) == 1, "a failure must still occupy the slow lane"
 
-    state.last_full = time.monotonic() - module.GRAPH_AUTO_INDEX_FULL_INTERVAL - 1
-    asyncio.run(worker._poll_one(state))
+    state.reconcile_deadline = time.monotonic() - 1
+    asyncio.run(worker._tick())
     assert len(attempts) == 2
 
 
 def test_a_failed_index_on_a_clean_repo_retries_after_a_backoff(
     shared_db, git_repo, monkeypatch
 ):
-    """The signature is recorded before the index runs, so without a backoff a
-    failure on a clean repo would never be retried until the repo changed."""
+    """retry_after governs whether an unchanged evaluation retries; it never
+    blocks a real change, which is retried the moment something notices it --
+    a debounced watcher event in production, forced here directly since
+    nothing is really watching this call."""
     from marm_mcp_server.core import graph_index_worker as module
 
     attempts = []
@@ -878,27 +954,42 @@ def test_a_failed_index_on_a_clean_repo_retries_after_a_backoff(
     monkeypatch.setattr(
         module.graph_supervisor, "get_client", lambda: object(), raising=False
     )
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
 
     worker = module.GraphIndexWorker()
     state = module._Watched(str(git_repo))
-    asyncio.run(worker._poll_one(state))
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
+
+    asyncio.run(worker._tick())
     assert len(attempts) == 1
     assert state.retry_after > 0
 
-    # Nothing changed and the backoff has not elapsed.
-    asyncio.run(worker._poll_one(state))
+    # Nothing changed and neither deadline has arrived.
+    asyncio.run(worker._tick())
     assert len(attempts) == 1
 
+    # The reconcile deadline arrives, but the backoff has not: still nothing.
+    state.reconcile_deadline = time.monotonic() - 1
+    asyncio.run(worker._tick())
+    assert len(attempts) == 1
+
+    # The backoff itself has now elapsed too.
     state.retry_after = time.monotonic() - 1
-    asyncio.run(worker._poll_one(state))
+    state.reconcile_deadline = time.monotonic() - 1
+    asyncio.run(worker._tick())
     assert len(attempts) == 2
 
-    # A commit is new information and is retried at once, backoff or not.
+    # A commit is new information: retried the moment something notices it,
+    # regardless of an unexpired backoff.
     state.retry_after = time.monotonic() + 10_000
+    state.debounce_deadline = time.monotonic() - 1
     (git_repo / "src" / "b.py").write_text("def g_two():\n    return 2\n")
     _git(git_repo, "add", "-A")
     _git(git_repo, "commit", "-qm", "second")
-    asyncio.run(worker._poll_one(state))
+    asyncio.run(worker._tick())
     assert len(attempts) == 3, "a changed repo must not wait out the backoff"
 
 
@@ -936,18 +1027,18 @@ def test_an_unindexable_path_is_not_retried_at_all(shared_db, tmp_path, monkeypa
 
     worker = module.GraphIndexWorker()
     state = module._Watched(str(plain))
-    asyncio.run(worker._poll_one(state))
+    asyncio.run(worker._evaluate(state))
     assert len(attempts) == 1
     assert runtime_flags.is_unindexable(str(plain)) is True
 
-    # Even past the slow interval, and even through a whole cycle.
-    state.last_full = time.monotonic() - module.GRAPH_AUTO_INDEX_FULL_INTERVAL - 1
+    # Even past the reconcile deadline, and even through a whole tick.
+    state.reconcile_deadline = time.monotonic() - 1
     worker._watched[state.root] = state
     worker._projects_loaded_at = time.monotonic()
     monkeypatch.setattr(
         module.graph_supervisor, "snapshot", lambda: {"available": True}
     )
-    asyncio.run(worker._cycle())
+    asyncio.run(worker._tick())
     assert len(attempts) == 1, "an unindexable project must be left alone"
 
 
@@ -990,8 +1081,8 @@ def test_a_successful_manual_index_re_enables_a_previously_unindexable_root(
     worker._watched[root] = module._Watched(root)
     worker._projects_loaded_at = time.monotonic()
 
-    asyncio.run(worker._cycle())
-    assert attempts == [], "the marker must keep the poller off it"
+    asyncio.run(worker._tick())
+    assert attempts == [], "the marker must keep the worker off it"
 
     # A manual index succeeds, which is the proof the root is indexable again.
     monkeypatch.setattr(endpoint, "run_exclusive", counting_gate)
@@ -1007,9 +1098,9 @@ def test_a_successful_manual_index_re_enables_a_previously_unindexable_root(
     assert runtime_flags.is_unindexable(root) is False
 
     before = len(attempts)
-    asyncio.run(worker._cycle())
+    asyncio.run(worker._tick())
     assert len(attempts) == before + 1, (
-        "polling must resume on the next cycle, with no restart"
+        "polling must resume on the next tick, with no restart"
     )
 
 
@@ -1042,7 +1133,7 @@ def test_a_vanished_root_is_dropped_and_the_loop_survives(shared_db, tmp_path):
 
     worker = GraphIndexWorker()
     missing = _Watched(str(tmp_path / "does-not-exist"))
-    asyncio.run(worker._poll_one(missing))
+    asyncio.run(worker._evaluate(missing))
     assert missing.failed is True
 
 
@@ -1106,9 +1197,10 @@ async def test_a_commit_is_picked_up_by_one_poll_cycle(shared_db, git_repo):
 
     worker = module.GraphIndexWorker()
     state = module._Watched(str(git_repo))
-    # The signature as it was at index time, before the commit moved HEAD.
-    state.signature = (indexed.get("head") or "pre-commit", False)
-    await worker._poll_one(state)
+    # The state as it was at index time, before the commit moved HEAD.
+    state.git_head = indexed.get("head") or "pre-commit"
+    state.content_hash = "pre-commit"
+    await worker._evaluate(state)
     assert worker._indexed == 1, "a commit must trigger exactly one re-index"
 
     found = await asyncio.to_thread(
@@ -1151,7 +1243,6 @@ async def test_the_running_worker_refreshes_a_repo_on_its_own(
     assert indexed.get("status") != "error", f"engine refused to index: {indexed}"
     project = indexed["project"]
 
-    monkeypatch.setattr(module, "GRAPH_AUTO_INDEX_INTERVAL", 1)
     from marm_mcp_server.core import runtime_flags
 
     watched_root = runtime_flags.canonical_root(str(git_repo))
@@ -1234,12 +1325,14 @@ async def test_a_deleted_project_is_skipped_before_the_watch_cache_expires(
     # Loaded and not due to reload: exactly the window the bug lived in.
     worker._projects_loaded_at = time.monotonic()
 
-    await worker._cycle()
+    await worker._tick()
     assert len(attempts) == 1
 
     runtime_flags.suppress_watch(root)
-    worker._watched[root].last_full = 0.0
-    await worker._cycle()
+    # Force due-ness so the tombstone is proven to be what stops it, not
+    # merely that the reconcile deadline had not arrived yet.
+    worker._watched[root].reconcile_deadline = time.monotonic() - 1
+    await worker._tick()
     assert len(attempts) == 1, "the tombstone must stop it with no cache reload"
 
 
@@ -1282,7 +1375,7 @@ async def test_the_gate_outlives_cancellation_of_the_task_that_owns_it(shared_db
 
 def test_a_repository_with_no_commits_is_still_polled(shared_db, tmp_path, monkeypatch):
     """`rev-parse HEAD` fails on an unborn HEAD. Treating that as a git error
-    made _poll_one return on every cycle, so a repo indexed before its first
+    made _evaluate return on every tick, so a repo indexed before its first
     commit was never refreshed again."""
     from marm_mcp_server.core import graph_index_worker as module
 
@@ -1291,17 +1384,19 @@ def test_a_repository_with_no_commits_is_still_polled(shared_db, tmp_path, monke
     _git(root, "init", "-q")
     (root / "a.py").write_text("def a():\n    return 1\n")
 
-    assert module.git_signature(str(root)) == (module._UNBORN_HEAD, True)
+    state = module.git_source_state(str(root))
+    assert state is not None
+    assert state[0] == module._UNBORN_HEAD
 
     reasons = []
 
-    async def fake_reindex(state, reason):
+    async def fake_reindex(state, reason, candidate_git_state=None):
         reasons.append(reason)
 
     worker = module.GraphIndexWorker()
     monkeypatch.setattr(worker, "_reindex", fake_reindex)
-    asyncio.run(worker._poll_one(module._Watched(str(root))))
-    assert reasons == ["dirty"]
+    asyncio.run(worker._evaluate(module._Watched(str(root))))
+    assert reasons == ["worktree_changed"]
 
 
 def test_an_unreadable_flag_database_never_authorizes_background_work(
@@ -1503,3 +1598,594 @@ async def test_an_automatic_failure_cannot_overwrite_a_manual_recovery(shared_db
         assert runtime_flags.is_unindexable(root) is False
     finally:
         module.R.do_index = original
+
+
+# ── event-driven scheduling ───────────────────────────────────────────
+
+
+def test_a_burst_of_watcher_events_coalesces_into_one_debounce_deadline(
+    shared_db, tmp_path
+):
+    """The deadline is only ever pushed forward by each event, never queued
+    separately, so a burst of saves collapses into the single evaluation that
+    runs once the deadline finally holds still."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    worker._watched[state.root] = state
+
+    for _ in range(5):
+        worker._on_watch_event(state.root)
+    assert state.generation == 5
+    first_deadline = state.debounce_deadline
+    assert first_deadline is not None
+
+    worker._on_watch_event(state.root)
+    assert state.generation == 6
+    assert state.debounce_deadline >= first_deadline, (
+        "a later event must not schedule an earlier evaluation"
+    )
+
+
+def test_a_burst_of_events_produces_one_reindex_not_several(
+    shared_db, tmp_path, monkeypatch
+):
+    """Integration-level companion to the coalescing test above: a burst that
+    never lets the debounce deadline settle must not evaluate at all, and
+    settling it must evaluate exactly once."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    monkeypatch.setattr(module, "GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS", 0.3)
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    state.reconcile_deadline = time.monotonic() + 1000  # isolate the debounce path
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
+
+    reindexed = []
+
+    async def record(target, reason, candidate_git_state=None):
+        reindexed.append(reason)
+
+    monkeypatch.setattr(worker, "_reindex", record)
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+
+    for _ in range(5):
+        worker._on_watch_event(state.root)
+        asyncio.run(worker._tick())
+    assert reindexed == [], "the burst must not evaluate before the debounce settles"
+
+    time.sleep(0.35)
+    asyncio.run(worker._tick())
+    assert reindexed == ["filesystem_changed"], (
+        "settling the burst evaluates exactly once"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_event_during_an_in_flight_index_leaves_exactly_one_pending_pass(
+    shared_db, tmp_path, monkeypatch
+):
+    """An event that lands while the engine call is still running must not
+    start a competing index; it must be visible as exactly one pending
+    catch-up once the in-flight call returns."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    worker._watched[state.root] = state
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_reindex(target, reason, candidate_git_state=None):
+        entered.set()
+        await release.wait()
+
+    monkeypatch.setattr(worker, "_reindex", slow_reindex)
+
+    evaluation = asyncio.create_task(worker._evaluate(state))
+    await asyncio.wait_for(entered.wait(), timeout=5)
+
+    # A second event lands while the index is still in flight.
+    worker._on_watch_event(state.root)
+    assert state.generation != state.evaluated_generation
+
+    release.set()
+    await evaluation
+
+    assert state.generation != state.evaluated_generation, (
+        "the late event must still be visible as a pending pass"
+    )
+    assert state.debounce_deadline is not None, (
+        "exactly one catch-up must be scheduled, not zero and not a busy loop"
+    )
+
+
+def test_a_watch_failure_for_one_root_falls_back_to_reconcile(
+    shared_db, tmp_path, monkeypatch
+):
+    """A permissions error or a watch-count limit on a single root must not
+    take the whole worker down with it; that root simply relies on the
+    reconcile deadline instead of events."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    monkeypatch.setattr(worker._watcher, "watch", lambda root, callback: False)
+
+    state = module._Watched(str(plain))
+    worker._enroll_watch(state)
+    assert state.watch_mode == "reconcile_fallback"
+
+
+def test_a_globally_unavailable_watcher_marks_roots_unavailable(shared_db, tmp_path):
+    """When the observer subsystem itself cannot start at all, every root must
+    say so distinctly from a single root's own watch failure."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    worker._watcher._globally_unavailable = True
+
+    state = module._Watched(str(plain))
+    worker._enroll_watch(state)
+    assert state.watch_mode == "unavailable"
+
+
+def test_a_reconcile_fallback_root_still_reindexes_unconditionally(
+    shared_db, tmp_path, monkeypatch
+):
+    """A non-git root that could not be watched has no cheap signature and no
+    events either, so the reconcile deadline is its only trigger -- and it
+    must still fire."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    state.watch_mode = "reconcile_fallback"
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
+
+    reindexed = []
+
+    async def record(target, reason, candidate_git_state=None):
+        reindexed.append(reason)
+
+    monkeypatch.setattr(worker, "_reindex", record)
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+
+    asyncio.run(worker._tick())
+    assert reindexed == ["reconcile"]
+
+
+@pytest.mark.asyncio
+async def test_disabling_detaches_watches_and_the_next_tick_reactivates_them(
+    shared_db, tmp_path, monkeypatch
+):
+    """auto_off must not leave filesystem observers running; the next tick
+    after auto_on brings them back without a restart."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    worker._watched[state.root] = state
+    worker._enroll_watch(state)
+    assert state.watch_mode != "disabled"
+
+    worker._deactivate()
+    assert state.watch_mode == "disabled"
+    assert state.debounce_deadline is None
+
+    worker._projects_loaded_at = time.monotonic()
+    state.reconcile_deadline = time.monotonic() + 1000  # do not also trigger a reindex
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+    await worker._tick()
+    assert state.watch_mode != "disabled", (
+        "the next tick must re-enroll a reactivated root"
+    )
+
+
+@pytest.mark.asyncio
+async def test_wake_cuts_a_long_wait_short(shared_db):
+    """The idle poll and reconcile deadline can be minutes away; wake() must
+    let a caller who just wants prompt action skip the rest of that wait."""
+    from marm_mcp_server.core.graph_index_worker import GraphIndexWorker
+
+    worker = GraphIndexWorker()
+    started = time.monotonic()
+    waiting = asyncio.create_task(worker._wait(60))
+    await asyncio.sleep(0.05)
+
+    worker.wake()
+    stopped = await asyncio.wait_for(waiting, timeout=2)
+    assert stopped is False, "a wake is not a stop"
+    assert time.monotonic() - started < 2
+
+
+def test_auto_on_wakes_the_worker(shared_db, monkeypatch):
+    """auto_on must not leave a caller waiting out the idle poll to see
+    auto-indexing come back to life."""
+    from marm_mcp_server.core.graph_index_worker import auto_action, graph_index_worker
+
+    woken = []
+    monkeypatch.setattr(graph_index_worker, "wake", lambda: woken.append(True))
+    monkeypatch.setattr(graph_index_worker, "start", lambda: None)
+
+    auto_action("auto_on")
+    assert woken == [True]
+
+
+def test_watch_state_round_trips_through_the_database(shared_db):
+    """The durable baseline: source kind, opaque digest, last index time and
+    reason, and watch mode, keyed canonically like the other durable state."""
+    from marm_mcp_server.core import runtime_flags
+
+    root = "C:/repo/round-trip" if os.name == "nt" else "/repo/round-trip"
+    assert runtime_flags.get_watch_state(root) is None
+
+    runtime_flags.save_watch_state(
+        root,
+        source_kind="git",
+        last_source_state="abc123:def456",
+        last_indexed="2026-01-01T00:00:00+00:00",
+        last_index_reason="worktree_changed",
+        watch_status="git_events",
+    )
+    assert runtime_flags.get_watch_state(root) == {
+        "source_kind": "git",
+        "last_source_state": "abc123:def456",
+        "last_indexed": "2026-01-01T00:00:00+00:00",
+        "last_index_reason": "worktree_changed",
+        "watch_status": "git_events",
+    }
+
+    # A second save overwrites rather than duplicating.
+    runtime_flags.save_watch_state(
+        root,
+        source_kind="git",
+        last_source_state="new111:new222",
+        last_indexed="2026-01-02T00:00:00+00:00",
+        last_index_reason="head_moved",
+        watch_status="git_events",
+    )
+    assert runtime_flags.get_watch_state(root)["last_source_state"] == "new111:new222"
+
+    # Keyed canonically, same as suppressions and unindexable markers.
+    other_spelling = "C:\\repo\\round-trip" if os.name == "nt" else "/repo/round-trip/"
+    assert (
+        runtime_flags.get_watch_state(other_spelling)["last_index_reason"]
+        == "head_moved"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_restart_does_not_reindex_an_unchanged_project(
+    shared_db, git_repo, monkeypatch
+):
+    """A durable baseline that already matches the repo's current state must
+    stop a freshly created worker -- standing in for a restart, or the other
+    transport enrolling this root first -- from re-indexing solely because
+    its in-memory state was recreated."""
+    from marm_mcp_server.core import graph_index_worker as module
+    from marm_mcp_server.core import runtime_flags
+
+    root = str(git_repo)
+    head, content_hash = module.git_source_state(root)
+    runtime_flags.save_watch_state(
+        root,
+        source_kind="git",
+        last_source_state=f"{head}:{content_hash}",
+        last_indexed="2026-01-01T00:00:00+00:00",
+        last_index_reason="worktree_changed",
+        watch_status="git_events",
+    )
+
+    listed = {"status": "success", "projects": [{"name": "p", "root_path": root}]}
+    monkeypatch.setattr(module.R, "do_index", lambda client, req: listed)
+    monkeypatch.setattr(
+        module.graph_supervisor, "get_client", lambda: object(), raising=False
+    )
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+
+    reindexed = []
+
+    async def record(target, reason, candidate_git_state=None):
+        reindexed.append(reason)
+
+    worker = module.GraphIndexWorker()  # a fresh instance, standing in for a restart
+    monkeypatch.setattr(worker, "_reindex", record)
+
+    await worker._tick()
+    assert reindexed == [], (
+        "an unchanged project must not be re-indexed after a restart"
+    )
+
+    seeded = worker._watched[root]
+    assert seeded.git_head == head
+    assert seeded.content_hash == content_hash
+
+
+def test_auto_status_reports_the_event_driven_fields_without_starting_the_engine(
+    shared_db, tmp_path
+):
+    """The status an operator actually reads: what mode each project is
+    watched under, its opaque baseline, why it last indexed, and whether a
+    debounced event or catch-up pass is still waiting."""
+    from marm_mcp_server.core import graph_index_worker as module
+    from marm_mcp_server.core.graph_supervisor import graph_supervisor
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    state.watch_mode = "filesystem_events"
+    state.last_indexed = "2026-01-01T00:00:00+00:00"
+    state.last_index_reason = "filesystem_changed"
+    state.generation = 2
+    state.evaluated_generation = 1
+    worker._watched[state.root] = state
+
+    assert graph_supervisor.snapshot()["started"] is False
+    status = worker.status()
+    assert graph_supervisor.snapshot()["started"] is False, (
+        "reading status must not start the engine"
+    )
+
+    assert status["debounce_seconds"] == module.GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS
+    assert status["reconcile_seconds"] == module.GRAPH_AUTO_INDEX_RECONCILE_SECONDS
+    project = status["projects"][0]
+    assert project["watch_mode"] == "filesystem_events"
+    assert project["last_indexed"] == "2026-01-01T00:00:00+00:00"
+    assert project["last_index_reason"] == "filesystem_changed"
+    assert project["pending"] is True, "generation ahead of evaluated_generation"
+
+
+@pytest.mark.asyncio
+async def test_stop_leaves_no_live_observer_thread(shared_db, tmp_path):
+    """A watcher thread that outlives worker.stop() would keep watching a
+    project the worker itself no longer knows about."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    worker._watched[state.root] = state
+    worker._enroll_watch(state)
+    observer = worker._watcher._observer
+    assert observer is not None and observer.is_alive()
+
+    await worker.stop()
+    assert not observer.is_alive(), "stop() must tear down the observer thread"
+
+
+# ── PR review follow-up: coordinator wake-up and lease-loss safety ────
+
+
+def test_the_worker_does_not_busy_loop_when_the_engine_stays_unavailable(
+    shared_db, monkeypatch
+):
+    """_tick must record that it ran even when it bails out immediately, or
+    _next_wake_delay keeps handing back 0.0 forever -- which is what a fresh
+    install with the engine binary not yet downloaded looks like, since
+    _refresh_projects (the only setter of _projects_loaded_at) is never
+    reached while the engine is unavailable."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    worker = module.GraphIndexWorker()
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": False}
+    )
+
+    assert worker._next_wake_delay() == 0.0, (
+        "the very first tick is still owed immediately"
+    )
+    asyncio.run(worker._tick())
+    assert worker._projects_loaded_at is None, (
+        "the engine never became available to list from"
+    )
+    assert worker._next_wake_delay() > 0.0, (
+        "a second tick must not also get a 0.0 delay with the engine still down"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_watcher_event_wakes_a_sleeping_coordinator(shared_db, tmp_path):
+    """A worker asleep toward a five-minute reconcile deadline must not stay
+    asleep through a debounce window that starts well before it -- that is
+    strictly worse than the fixed poll this design replaced."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    state.reconcile_deadline = time.monotonic() + 1000  # asleep for a long time
+    worker._watched[state.root] = state
+
+    started = time.monotonic()
+    waiting = asyncio.create_task(worker._wait(60))
+    await asyncio.sleep(0.05)
+
+    worker._on_watch_event(state.root)
+    stopped = await asyncio.wait_for(waiting, timeout=2)
+    assert stopped is False
+    assert time.monotonic() - started < 2, "the event must cut the sleep short"
+
+
+def test_auto_off_also_wakes_the_worker(shared_db, monkeypatch):
+    """A worker sleeping toward its reconcile deadline must not keep
+    filesystem observers running for however long that sleep still has left;
+    _deactivate is only reached on the coordinator's next wake."""
+    from marm_mcp_server.core.graph_index_worker import auto_action, graph_index_worker
+
+    woken = []
+    monkeypatch.setattr(graph_index_worker, "wake", lambda: woken.append(True))
+
+    auto_action("auto_off")
+    assert woken == [True]
+
+
+def test_an_unborn_repo_sees_an_unstaged_edit_to_an_already_staged_file(tmp_path):
+    """`git diff --cached` alone reflects the index, not the working tree, and
+    the file is no longer "untracked" once staged either -- both halves of the
+    unborn signature miss this without the extra working-tree diff."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
+
+    root = tmp_path / "unborn"
+    root.mkdir()
+    _git(root, "init", "-q")
+    (root / "a.py").write_text("x = 1\n")
+    _git(root, "add", "a.py")
+
+    staged_only = git_source_state(str(root))[1]
+
+    (root / "a.py").write_text("x = 2\n")  # unstaged edit on top of the staged one
+    with_unstaged_edit = git_source_state(str(root))[1]
+
+    assert with_unstaged_edit != staged_only
+
+
+@pytest.mark.asyncio
+async def test_a_refused_lease_does_not_advance_the_in_memory_baseline(
+    shared_db, git_repo, monkeypatch
+):
+    """A GraphIndexBusy refusal means this process never actually indexed
+    anything. It must not be recorded as though it had, or the next
+    evaluation of an unchanged repo reads as "nothing to do" even though this
+    process's own graph may still be stale."""
+    from marm_mcp_server.core import graph_index_worker as module
+    from marm_mcp_server.core.graph_index_lock import GraphIndexBusy
+
+    async def refused(*args, **kwargs):
+        raise GraphIndexBusy("auto_index")
+
+    monkeypatch.setattr(module, "run_exclusive", refused)
+
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(git_repo))
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
+    monkeypatch.setattr(
+        module.graph_supervisor, "get_client", lambda: object(), raising=False
+    )
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+
+    await worker._tick()  # the first evaluation: refused
+    assert state.git_head is None, "a refused lease must not advance the baseline"
+    assert state.content_hash is None
+
+    # The next evaluation must still see this as unindexed and try again.
+    state.reconcile_deadline = time.monotonic() - 1
+    attempts = []
+
+    async def succeeding(purpose, fn, *args, **kwargs):
+        attempts.append(purpose)
+        return {"status": "success", "project": "p"}
+
+    monkeypatch.setattr(module, "run_exclusive", succeeding)
+    await worker._tick()
+    assert len(attempts) == 1, "the repo must still be retried after the refusal"
+    assert state.git_head is not None, "a real success is what advances the baseline"
+
+
+@pytest.mark.asyncio
+async def test_a_dead_observer_thread_is_detected_and_recovered(
+    shared_db, tmp_path, monkeypatch
+):
+    """The one shared observer backs every root. If its thread dies after a
+    successful start -- not a setup failure, which watch() already handles
+    per root -- reconciliation still protects correctness, but nothing
+    previously noticed the silent degradation from event-driven back to
+    poll-only. The next tick must detect it and rebuild a fresh observer."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(plain))
+    worker._watched[state.root] = state
+    worker._enroll_watch(state)
+    assert state.watch_mode == "filesystem_events"
+    dead_observer = worker._watcher._observer
+    assert worker._watcher.healthy() is True
+
+    # Simulate a crash: the thread stops on its own, without going through
+    # GraphIndexWatcher.stop(), so the worker has no idea yet.
+    dead_observer.stop()
+    dead_observer.join(timeout=5)
+    assert not dead_observer.is_alive()
+    assert worker._watcher.healthy() is False
+
+    state.reconcile_deadline = (
+        time.monotonic() + 1000
+    )  # isolate recovery from a reindex
+    worker._projects_loaded_at = time.monotonic()
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+
+    try:
+        await worker._tick()
+        assert worker._watcher.healthy() is True
+        assert worker._watcher._observer is not dead_observer, (
+            "a fresh observer must replace the dead one"
+        )
+        assert state.watch_mode == "filesystem_events", (
+            "the affected root must be re-enrolled"
+        )
+    finally:
+        # _tick's recovery starts a real, fresh observer thread; leaving it
+        # running would outlive the test.
+        await worker.stop()
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_failure_still_advances_the_baseline_for_backoff(
+    shared_db, git_repo, monkeypatch
+):
+    """Unlike a lease refusal, an ordinary engine failure means the attempt
+    genuinely happened. The observed state must still become the comparison
+    baseline, or retry_after's backoff is unreachable: an unchanged repo
+    whose baseline never advances always looks like the first observation
+    and retries immediately regardless of any backoff."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    async def failing(purpose, fn, *args, **kwargs):
+        return {"status": "error", "message": "boom"}
+
+    monkeypatch.setattr(module, "run_exclusive", failing)
+    monkeypatch.setattr(
+        module.graph_supervisor, "get_client", lambda: object(), raising=False
+    )
+
+    worker = module.GraphIndexWorker()
+    state = module._Watched(str(git_repo))
+    await worker._evaluate(state)
+    assert state.git_head is not None, (
+        "an attempted-but-failed index must still record what was observed"
+    )

--- a/marm-mcp-server/tests/test_graph_auto_index.py
+++ b/marm-mcp-server/tests/test_graph_auto_index.py
@@ -194,6 +194,70 @@ def test_staged_unstaged_and_untracked_changes_all_move_the_signature(git_repo):
     assert untracked != clean, "a new untracked file must move the signature too"
 
 
+def test_a_same_length_edit_to_an_untracked_file_moves_the_signature_even_with_a_restored_mtime(
+    git_repo,
+):
+    """The untracked-file fingerprint used to be path:size:mtime, not content.
+    A same-length edit landing on an mtime restored to its original value --
+    a coarse filesystem clock, a tool that preserves timestamps -- would
+    fingerprint identically to the version before it: exactly the staleness
+    class the content-hash diff above already fixed for tracked files."""
+    from marm_mcp_server.core.graph_index_worker import git_source_state
+
+    target = git_repo / "src" / "untracked.py"
+    target.write_text("value = 1\n")
+    original_stat = target.stat()
+    before = git_source_state(str(git_repo))[1]
+
+    target.write_text("value = 2\n")  # same byte length as the original
+    os.utime(target, (original_stat.st_atime, original_stat.st_mtime))
+    after = git_source_state(str(git_repo))[1]
+
+    assert after != before, (
+        "a content change must move the signature even when size and mtime "
+        "are unchanged"
+    )
+
+
+def test_a_same_length_untracked_edit_with_a_restored_mtime_is_not_skipped_by_the_worker(
+    shared_db, git_repo, monkeypatch
+):
+    """The signature moving is necessary but not sufficient: prove the worker
+    itself acts on it. A state seeded with the pre-edit baseline, exactly what
+    an already-running worker would have recorded from its last evaluation,
+    must still trigger a reindex through _evaluate after this exact edit."""
+    from marm_mcp_server.core import graph_index_worker as module
+
+    target = git_repo / "src" / "untracked.py"
+    target.write_text("value = 1\n")
+    original_stat = target.stat()
+    baseline = module.git_source_state(str(git_repo))
+    assert baseline is not None
+
+    target.write_text("value = 2\n")  # same byte length as the original
+    os.utime(target, (original_stat.st_atime, original_stat.st_mtime))
+
+    attempts = []
+
+    async def counting_gate(purpose, fn, *args, **kwargs):
+        attempts.append(purpose)
+        return {"status": "success", "project": "p"}
+
+    monkeypatch.setattr(module, "run_exclusive", counting_gate)
+    monkeypatch.setattr(
+        module.graph_supervisor, "get_client", lambda: object(), raising=False
+    )
+
+    state = module._Watched(str(git_repo))
+    state.git_head, state.content_hash = baseline
+
+    asyncio.run(module.GraphIndexWorker()._evaluate(state))
+    assert len(attempts) == 1, (
+        "a same-length untracked edit with a restored mtime must still "
+        "trigger a reindex, not be skipped as unchanged"
+    )
+
+
 def test_an_ignored_file_does_not_move_the_signature(git_repo):
     """The engine remains the ignore-policy owner; this signature must not
     react to churn in build output or dependency directories."""
@@ -1243,6 +1307,50 @@ def test_a_blocked_root_with_an_elapsed_debounce_deadline_still_does_not_pin_the
     assert worker._next_wake_delay() > 0.0, (
         "an elapsed debounce deadline on a blocked root must not pin the "
         "coordinator's wake delay at 0.0 either"
+    )
+
+
+def test_a_fresh_debounce_event_during_the_block_check_survives(
+    shared_db, tmp_path, monkeypatch
+):
+    """index_block runs behind a real await (asyncio.to_thread), and a
+    watcher event can land on this exact root while it is in flight. This
+    root was indexed once already, so reconcile_deadline is a genuine future
+    timestamp rather than -inf: clobbering the fresh debounce_deadline
+    unconditionally would leave nothing to make it due again until the far-off
+    reconcile pass, minutes later, silently losing the change."""
+    from marm_mcp_server.core import graph_index_worker as module
+    from marm_mcp_server.core import runtime_flags
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    root = str(plain)
+    runtime_flags.mark_unindexable(root, "windows_path_too_long")
+
+    worker = module.GraphIndexWorker()
+    state = module._Watched(root)
+    state.reconcile_deadline = time.monotonic() + 300
+    # The already-elapsed deadline that makes this tick's due-check true.
+    state.debounce_deadline = time.monotonic() - 1
+    worker._watched[state.root] = state
+    worker._projects_loaded_at = time.monotonic()
+    monkeypatch.setattr(
+        module.graph_supervisor, "snapshot", lambda: {"available": True}
+    )
+
+    fresh_deadline = time.monotonic() + 999
+
+    def blocked_with_a_concurrent_event(root_path):
+        # Stands in for a real watcher event landing on this root while
+        # index_block's await is in flight.
+        state.debounce_deadline = fresh_deadline
+        return "unindexable"
+
+    monkeypatch.setattr(runtime_flags, "index_block", blocked_with_a_concurrent_event)
+
+    asyncio.run(worker._tick())
+    assert state.debounce_deadline == fresh_deadline, (
+        "a debounce deadline set while the block check was in flight must survive"
     )
 
 

--- a/scripts/find-versions.py
+++ b/scripts/find-versions.py
@@ -105,8 +105,22 @@ def read_text(path: Path) -> str:
 
 def discover_docs() -> list[Path]:
     paths: list[Path] = []
-    # Root-level .md files
-    paths.extend(sorted(PROJECT_ROOT.glob("*.md"), key=lambda p: str(p).lower()))
+    # Root-level .md files. CONTRIBUTORS.md is excluded for the same reason
+    # CHANGELOG.md is: it intentionally records historical "fixed in vX.Y.Z"
+    # credits that must stay pinned to the release that actually shipped the
+    # fix. Every line links github.com/.../marm-memory, which trips the
+    # "marm" replace-cue on its own, so without this exclusion every sync
+    # run silently rewrites those citations to whatever version is current.
+    paths.extend(
+        sorted(
+            (
+                p
+                for p in PROJECT_ROOT.glob("*.md")
+                if p.name.lower() != "contributors.md"
+            ),
+            key=lambda p: str(p).lower(),
+        )
+    )
     # docs/*.md
     if DOC_ROOT.exists():
         paths.extend(sorted(DOC_ROOT.glob("*.md"), key=lambda p: str(p).lower()))


### PR DESCRIPTION
## Summary

Code graph auto-indexing now reacts to real filesystem events instead of polling every 30 seconds, so a change is picked up within seconds instead of on a fixed timer — and a dirty repo no longer re-indexes every cycle just because the old signature couldn't tell one edit from another.

- Auto-indexing now wakes on a save, commit, branch switch, or merge, detected by a bundled filesystem watcher; matching events are debounced so a burst of changes becomes one re-index instead of one per file. A reconciliation pass remains as the fallback for a missed event, an unwatchable filesystem, or a non-git directory, and a watcher thread that dies after starting is now detected and automatically rebuilt.
- The git change signature is now content-sensitive — a hash of the diff against `HEAD` plus an untracked-file fingerprint — so two different edits to an already-dirty file are recognized as two different changes instead of being treated as identical (the old `(HEAD, dirty)` signature's blind spot).
- The last successful index state now survives a restart in a durable table, so a freshly started process doesn't blindly re-index everything it already knew about. A worker that loses the cross-process indexing lease no longer records the repository as current either — that change is retried at the next reconciliation pass instead of being silently forgotten.
- `GRAPH_AUTO_INDEX_DEBOUNCE_SECONDS` and `GRAPH_AUTO_INDEX_RECONCILE_SECONDS` replace the fixed poll interval. The deprecated `GRAPH_AUTO_INDEX_INTERVAL` and `GRAPH_AUTO_INDEX_FULL_INTERVAL` env vars still work as compatibility inputs; the latter's value carries over automatically.
- Fixed a version-sync script bug along the way: `CONTRIBUTORS.md`'s historical "fixed in vX.Y.Z" credits were getting rewritten to the current version on every sync run.

### Internal

- New `graph_index_watcher.py` adapter around the bundled `watchdog` dependency, and a `graph_watch_state` table added to the memory database for the durable baseline.
- 20 new tests (70 total in the auto-index suite) covering debounce coalescing, in-flight catch-up passes, watcher failure and recovery, cross-process lease-loss safety, and restart-baseline persistence.

### Test plan

- [x] Full fast suite (`scripts/run-tests.py --fast`): 1242+ Python tests, console typecheck/vitest/build — all green
- [x] mypy baseline gate: 0 errors
- [x] `test_graph_auto_index.py`: 70/70 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Code-graph indexing now responds to filesystem changes with configurable debouncing.
  - Git content changes are detected more accurately, including untracked and unborn repositories.
  - Periodic reconciliation provides a fallback for missed or unavailable watcher events.
  - Indexing state persists across restarts, with improved recovery, retry, and lease handling.
  - Renamed auto-indexing settings remain compatible with deprecated configuration names.

- **Documentation**
  - Updated configuration, troubleshooting guidance, installation references, and release metadata for version 2.44.0.

- **Tests**
  - Expanded coverage for event-driven indexing, recovery, persistence, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->