### PR TITLE
v2.44.2: Raw exception text removed from status responses

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -56,7 +56,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r marm-mcp-server/requirements.txt
           pip install -e './marm-mcp-server' --no-deps
-          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil==7.2.2.20260518 ruff==0.16.2
+          pip install pytest pytest-asyncio pytest-cov jsonschema requests mypy==2.1.0 types-psutil==7.2.2.20260518 ruff==0.16.4
 
       - name: Validate server.json
         run: |

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -26,7 +26,7 @@ jobs:
       # changed, while the developer's 0.15.16 reported the file clean.
       # Keep local ruff on this version.
       - name: Install Ruff
-        run: pip install ruff==0.16.2
+        run: pip install ruff==0.16.4
 
       # From the repo root, not marm-mcp-server. scripts/ and marm-console/tests
       # were never linted by CI, so their result depended on whichever ruff a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 <details>
+<summary><strong>August 27th, 2026: Raw Exception Text Removed From Status Responses (v2.44.2)</strong></summary>
+
+### Fixed: Raw Exception Text No Longer Reaches Status Responses
+
+- Database read failures in the runtime status and embedding-state inspectors returned the raw exception message, which reached the console and CLI status payloads and could carry local filesystem paths and SQLite internals (CodeQL `py/stack-trace-exposure`). The exception is now logged with its traceback, which it previously was not, and the payload carries a fixed human-readable message instead.
+
+</details>
+
+<details>
 <summary><strong>August 25th, 2026: Compaction Dry-Run, Dead-Code Cleanup, and Comment Hygiene (v2.44.1)</strong></summary>
 
 ### Added: A Real Compaction Dry-Run Command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed: Raw Exception Text No Longer Reaches Status Responses
 
 - Database read failures in the runtime status and embedding-state inspectors returned the raw exception message, which reached the console and CLI status payloads and could carry local filesystem paths and SQLite internals (CodeQL `py/stack-trace-exposure`). The exception is now logged with its traceback, which it previously was not, and the payload carries a fixed human-readable message instead.
+- Those tracebacks are logged at most once per five minutes per failure. The console polls the status endpoint every five seconds while the Settings dialog is open, so an unreadable database would otherwise have written three tracebacks per request, burying other events in the runtime log for as long as the fault lasted.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="900"
      height="250">
 </picture>
-<h1 align="center">marm-memory v2.44.1 - Give your AI Agents a permanent memory in 60 seconds</h1>
+<h1 align="center">marm-memory v2.44.2 - Give your AI Agents a permanent memory in 60 seconds</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -302,7 +302,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.44.1",
+  "version": "2.44.2",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -287,7 +287,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.44.1",
+  "version": "2.44.2",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -62,7 +62,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.44.1"
+LABEL org.opencontainers.image.version="2.44.2"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -7,7 +7,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="900"
      height="250">
 </picture>
-<h1 align="center">marm-memory v2.44.1 - Give your AI Agents a permanent memory in 60 seconds</h1>
+<h1 align="center">marm-memory v2.44.2 - Give your AI Agents a permanent memory in 60 seconds</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: lyellr88/marm-mcp-server:2.44.1
+    image: lyellr88/marm-mcp-server:2.44.2
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -16,7 +16,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.44.1
+      - SERVER_VERSION=2.44.2
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,12 +14,12 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.44.1
+Version: 2.44.2
 """
 
 from typing import Any
 
-__version__ = "2.44.1"
+__version__ = "2.44.2"
 __author__ = "Ryan Lyell"
 __email__ = "ryanlyell@marmemory.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -99,7 +99,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.44.1"
+SERVER_VERSION = "2.44.2"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM Memory v2.44.1 - Give your AI Agents a permanent memory in 60 seconds
+# MARM Memory v2.44.2 - Give your AI Agents a permanent memory in 60 seconds
 
 ## Table of Contents
 

--- a/marm-mcp-server/marm_mcp_server/services/runtime_status.py
+++ b/marm-mcp-server/marm_mcp_server/services/runtime_status.py
@@ -31,6 +31,7 @@ from ..config.settings import (
 from ..core.concept_db import inspect_concept_schema
 from ..core.runtime_manager import inspect_runtime
 from ..utils.embedding_state import get_default_concept_db_path, inspect_embedding_state
+from ..utils.logging_filters import log_warning_throttled
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,9 @@ def _memory_status(path: Path) -> dict[str, Any]:
                 "WHERE status IN ('pending_summary', 'summary_staged')"
             ).fetchone()[0]
     except (OSError, sqlite3.Error):
-        logger.warning("Memory database status read failed", exc_info=True)
+        log_warning_throttled(
+            logger, "memory_status", "Memory database status read failed"
+        )
         result["error"] = "Could not read the memory database."
     try:
         result["size_bytes"] = path.stat().st_size

--- a/marm-mcp-server/marm_mcp_server/services/runtime_status.py
+++ b/marm-mcp-server/marm_mcp_server/services/runtime_status.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 import os
 import socket
 import sqlite3
@@ -31,6 +32,8 @@ from ..core.concept_db import inspect_concept_schema
 from ..core.runtime_manager import inspect_runtime
 from ..utils.embedding_state import get_default_concept_db_path, inspect_embedding_state
 
+logger = logging.getLogger(__name__)
+
 
 def _read_only(path: Path) -> sqlite3.Connection:
     return sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
@@ -53,8 +56,9 @@ def _memory_status(path: Path) -> dict[str, Any]:
                 "SELECT COUNT(*) FROM compaction_staging "
                 "WHERE status IN ('pending_summary', 'summary_staged')"
             ).fetchone()[0]
-    except (OSError, sqlite3.Error) as exc:
-        result["error"] = str(exc)
+    except (OSError, sqlite3.Error):
+        logger.warning("Memory database status read failed", exc_info=True)
+        result["error"] = "Could not read the memory database."
     try:
         result["size_bytes"] = path.stat().st_size
     except OSError:

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
@@ -14,6 +14,7 @@ from ..config.settings import (
     DEFAULT_SEMANTIC_DIM,
     DEFAULT_SEMANTIC_MODEL,
 )
+from .logging_filters import log_warning_throttled
 
 logger = logging.getLogger(__name__)
 
@@ -128,12 +129,16 @@ def inspect_embedding_state(
     try:
         tables.extend(_inspect_tables(memory_path, "memory", _MEMORY_TABLES))
     except (OSError, sqlite3.Error):
-        logger.warning("Memory database inspection failed", exc_info=True)
+        log_warning_throttled(
+            logger, "embedding_memory_inspect", "Memory database inspection failed"
+        )
         errors.append("Memory database inspection failed.")
     try:
         tables.extend(_inspect_tables(concept_path, "concept", _CONCEPT_TABLES))
     except (OSError, sqlite3.Error):
-        logger.warning("Concept database inspection failed", exc_info=True)
+        log_warning_throttled(
+            logger, "embedding_concept_inspect", "Concept database inspection failed"
+        )
         errors.append("Concept database inspection failed.")
 
     marker = None
@@ -147,7 +152,11 @@ def inspect_embedding_state(
                     ).fetchone()
                     marker = row[0] if row else None
         except (OSError, sqlite3.Error):
-            logger.warning("Memory model marker inspection failed", exc_info=True)
+            log_warning_throttled(
+                logger,
+                "embedding_marker_inspect",
+                "Memory model marker inspection failed",
+            )
             message = "Memory model marker inspection failed."
             if message not in errors:
                 errors.append(message)

--- a/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
+++ b/marm-mcp-server/marm_mcp_server/utils/embedding_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 from contextlib import closing
@@ -13,6 +14,8 @@ from ..config.settings import (
     DEFAULT_SEMANTIC_DIM,
     DEFAULT_SEMANTIC_MODEL,
 )
+
+logger = logging.getLogger(__name__)
 
 EMBEDDING_MODEL_SETTING = "embedding_model"
 _MEMORY_TABLES = (
@@ -124,12 +127,14 @@ def inspect_embedding_state(
     errors = []
     try:
         tables.extend(_inspect_tables(memory_path, "memory", _MEMORY_TABLES))
-    except (OSError, sqlite3.Error) as exc:
-        errors.append(f"memory database inspection failed: {exc}")
+    except (OSError, sqlite3.Error):
+        logger.warning("Memory database inspection failed", exc_info=True)
+        errors.append("Memory database inspection failed.")
     try:
         tables.extend(_inspect_tables(concept_path, "concept", _CONCEPT_TABLES))
-    except (OSError, sqlite3.Error) as exc:
-        errors.append(f"concept database inspection failed: {exc}")
+    except (OSError, sqlite3.Error):
+        logger.warning("Concept database inspection failed", exc_info=True)
+        errors.append("Concept database inspection failed.")
 
     marker = None
     if memory_path.exists():
@@ -141,8 +146,9 @@ def inspect_embedding_state(
                         (EMBEDDING_MODEL_SETTING,),
                     ).fetchone()
                     marker = row[0] if row else None
-        except (OSError, sqlite3.Error) as exc:
-            message = f"memory model marker inspection failed: {exc}"
+        except (OSError, sqlite3.Error):
+            logger.warning("Memory model marker inspection failed", exc_info=True)
+            message = "Memory model marker inspection failed."
             if message not in errors:
                 errors.append(message)
     return EmbeddingState(marker=marker, tables=tuple(tables), errors=tuple(errors))

--- a/marm-mcp-server/marm_mcp_server/utils/logging_filters.py
+++ b/marm-mcp-server/marm_mcp_server/utils/logging_filters.py
@@ -1,4 +1,19 @@
 import logging
+import time
+
+_THROTTLE_SECONDS = 300.0
+_last_logged: dict[str, float] = {}
+
+
+def log_warning_throttled(logger: logging.Logger, key: str, message: str) -> None:
+    """The console polls the status endpoints every 5s, so an unreadable database
+    would otherwise write a traceback every cycle for as long as it stays broken."""
+    now = time.monotonic()
+    last = _last_logged.get(key)
+    if last is not None and now - last < _THROTTLE_SECONDS:
+        return
+    _last_logged[key] = now
+    logger.warning(message, exc_info=True)
 
 
 class _SuppressProactorWindowsNoise(logging.Filter):

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.44.1"
+version = "2.44.2"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.44.1",
+  "version": "2.44.2",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.44.1",
+      "version": "2.44.2",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.44.1",
+      "identifier": "lyellr88/marm-mcp-server:2.44.2",
       "transport": { "type": "stdio" }
     }
   ],


### PR DESCRIPTION
## v2.44.2

Closes a CodeQL-flagged information exposure in the runtime status surface, and finishes the ruff pin bump that PR #153 started.

- Database read failures in the runtime status and embedding-state inspectors returned the raw exception message, which reached the console and CLI status payloads and could carry local filesystem paths and SQLite internals (CodeQL `py/stack-trace-exposure` on `/internal/runtime/settings`). The exception is now logged with its traceback, which it previously was not, and the payload carries a fixed human-readable message instead. The console still shows that a database failed to read; the detail moves to the server log.
- Pinned ruff to 0.16.4 in `ruff.yml` and `publish-mcp.yml` to match the `pyproject.toml` dev pin. All three pins have to agree for the pin to do its job, and PR #153 moved only one of them. Verified against the full tree: `ruff check` and `ruff format --check` are clean under 0.16.4 with no new findings and no formatting churn.

### Upgrade Note

None. Local development installs should run `pip install ruff==0.16.4` to stay in lockstep with CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database error handling by showing clear, user-friendly messages instead of exposing internal exception details or filesystem paths.
  * Preserved full diagnostic information in application logs, with repeated status errors limited to reduce noise.

* **Release**
  * Updated the application, server, container images, and installation documentation to version 2.44.2.
  * Updated validation tooling to use the latest pinned Ruff version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->