### PR TITLE
fix: update hybrid smoke-script imports

### DIFF
--- a/scripts/test-scripts/smoke_hybrid_search.py
+++ b/scripts/test-scripts/smoke_hybrid_search.py
@@ -38,9 +38,11 @@ from marm_mcp_server.config.settings import (  # noqa: E402
 from marm_mcp_server.core import memory as memory_module  # noqa: E402
 from marm_mcp_server.core.memory import (  # noqa: E402
     MARMMemory,
+    _safe_fts_query,
+)
+from marm_mcp_server.core.memory_scoring import (  # noqa: E402
     _fetch_and_score_embedding_rows,
     _fetch_and_score_fts_rows,
-    _safe_fts_query,
 )
 
 


### PR DESCRIPTION
## Summary

Part of #165. Does not close it: #165 covers the whole `scripts/test-scripts/` directory and `smoke_embedding_chunking.py` is still broken.

The hybrid-search smoke script imported scoring helpers from `core.memory`, but those helpers moved to `core.memory_scoring` during the v2.14.0 refactor. The script failed during startup with `ImportError`.

## Changes

- Import `_fetch_and_score_embedding_rows` and `_fetch_and_score_fts_rows` from `marm_mcp_server.core.memory_scoring`.
- Keep the facade imports limited to `MARMMemory` and `_safe_fts_query`.

## Tests

- `python scripts/test-scripts/smoke_hybrid_search.py --help` — passed after the fix; the same command reproduced the pre-fix `ImportError` before the change.
- `python -m compileall -q scripts/test-scripts/smoke_hybrid_search.py` — passed.
- `ruff check scripts/test-scripts/smoke_hybrid_search.py` — not run; Ruff is not installed in the active environment.
- `python scripts/test-scripts/smoke_hybrid_search.py` — could not complete because the first run attempted to download the public embedding model and timed out in this environment.

## Compatibility / Known limitations

This is an internal smoke-script import correction with no runtime API or behavior change. The full smoke workload still requires the model download to complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hybrid search smoke-test reliability by ensuring search query handling uses the correct component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
