### PR TITLE
fix: remove API key file when permission hardening fails

### DIFF
--- a/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
+++ b/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
@@ -2,7 +2,8 @@ import os
 import sys
 from pathlib import Path
 
-from ..utils.security import generate_api_key, restrict_windows_file_to_current_user
+from ..services.key_management import _protect_key_file
+from ..utils.security import generate_api_key
 
 _MARM_ENV_PATH = Path.home() / ".marm" / ".env"
 
@@ -51,20 +52,32 @@ def resolve_marm_api_key(server_host: str) -> str:
 
     if server_host == "0.0.0.0" and not marm_api_key and not is_generate_key_cmd:
         marm_api_key = generate_api_key()
+        key_persisted = False
         try:
             _MARM_ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
             _MARM_ENV_PATH.write_text(f"MARM_API_KEY={marm_api_key}\n")
-            try:
-                _MARM_ENV_PATH.chmod(0o600)
-            except OSError:
-                pass
-            if sys.platform == "win32" and not restrict_windows_file_to_current_user(
-                _MARM_ENV_PATH
-            ):
-                print(
-                    f"WARNING: Could not restrict API key file: {_MARM_ENV_PATH}",
-                    file=sys.stderr,
-                )
+            if _protect_key_file(_MARM_ENV_PATH):
+                key_persisted = True
+            else:
+                try:
+                    _MARM_ENV_PATH.unlink(missing_ok=True)
+                except OSError as e:
+                    print(
+                        "WARNING: API key file protection failed and the insecure "
+                        f"file could not be removed: {_MARM_ENV_PATH}: {e}. Remove "
+                        "it immediately. The generated API key remains active in "
+                        "memory for this process only; do not rely on the insecure "
+                        "file surviving a restart. Set MARM_API_KEY explicitly in "
+                        "the environment.",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        "WARNING: API key file protection failed. The API key is being "
+                        "kept in memory only and will not survive a restart. Set "
+                        "MARM_API_KEY explicitly in the environment.",
+                        file=sys.stderr,
+                    )
         except Exception as e:
             print(f"WARNING: Could not save API key to {_MARM_ENV_PATH}: {e}")
 
@@ -72,16 +85,17 @@ def resolve_marm_api_key(server_host: str) -> str:
         print(
             "MARM: SERVER_HOST=0.0.0.0 detected — API key auto-generated (first start)."
         )
-        print(f"Saved to: {_file_link(_MARM_ENV_PATH)}")
-        print()
-        print(
-            "Add this to your MCP client (replace YOUR_KEY with the key from the file above):"
-        )
-        print(
-            '  claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer YOUR_KEY"'
-        )
-        print()
-        print("On subsequent starts the key loads silently from the file above.")
+        if key_persisted:
+            print(f"Saved to: {_file_link(_MARM_ENV_PATH)}")
+            print()
+            print(
+                "Add this to your MCP client (replace YOUR_KEY with the key from the file above):"
+            )
+            print(
+                '  claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer YOUR_KEY"'
+            )
+            print()
+            print("On subsequent starts the key loads silently from the file above.")
         print()
 
     return marm_api_key

--- a/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
+++ b/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
@@ -56,7 +56,11 @@ def resolve_marm_api_key(server_host: str) -> str:
         try:
             _MARM_ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
             _MARM_ENV_PATH.write_text(f"MARM_API_KEY={marm_api_key}\n")
-            if _protect_key_file(_MARM_ENV_PATH):
+            try:
+                key_protected = _protect_key_file(_MARM_ENV_PATH)
+            except Exception:
+                key_protected = False
+            if key_protected:
                 key_persisted = True
             else:
                 try:
@@ -96,6 +100,8 @@ def resolve_marm_api_key(server_host: str) -> str:
             )
             print()
             print("On subsequent starts the key loads silently from the file above.")
+        else:
+            print("Set MARM_API_KEY explicitly and restart to connect.")
         print()
 
     return marm_api_key

--- a/marm-mcp-server/tests/test_config_safety.py
+++ b/marm-mcp-server/tests/test_config_safety.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import stat
 import sys
 from unittest import mock
 
@@ -62,12 +63,13 @@ def test_resolve_marm_api_key_persists_a_generated_key_across_starts(
 
     env_path = tmp_path / ".marm" / ".env"
     monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
-    monkeypatch.setattr(api_key_bootstrap, "_protect_key_file", lambda path: True)
     monkeypatch.delenv("MARM_API_KEY", raising=False)
 
     first_start = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
     assert first_start
     assert env_path.read_text() == f"MARM_API_KEY={first_start}\n"
+    if os.name != "nt":
+        assert stat.S_IMODE(env_path.stat().st_mode) & 0o077 == 0
 
     second_start = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
     assert second_start == first_start
@@ -81,6 +83,40 @@ def test_resolve_marm_api_key_removes_file_when_protection_fails(
     env_path = tmp_path / ".marm" / ".env"
     monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
     monkeypatch.setattr(api_key_bootstrap, "_protect_key_file", lambda path: False)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+    printed = []
+    real_print = print
+
+    def record_print(*args, **kwargs):
+        printed.append(args)
+        real_print(*args, **kwargs)
+
+    monkeypatch.setattr("builtins.print", record_print)
+
+    generated_key = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
+
+    assert generated_key
+    assert not env_path.exists()
+    output = capsys.readouterr()
+    warning = output.err
+    assert "kept in memory only" in warning
+    assert "will not survive a restart" in warning
+    assert "Set MARM_API_KEY explicitly in the environment" in warning
+    assert ("Set MARM_API_KEY explicitly and restart to connect.",) in printed
+
+
+def test_resolve_marm_api_key_removes_file_when_protection_raises(
+    monkeypatch, tmp_path, capsys
+):
+    from marm_mcp_server.config import api_key_bootstrap
+
+    env_path = tmp_path / ".marm" / ".env"
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+
+    def fail_protection(path):
+        raise RuntimeError("ctypes blew up")
+
+    monkeypatch.setattr(api_key_bootstrap, "_protect_key_file", fail_protection)
     monkeypatch.delenv("MARM_API_KEY", raising=False)
 
     generated_key = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")

--- a/marm-mcp-server/tests/test_config_safety.py
+++ b/marm-mcp-server/tests/test_config_safety.py
@@ -62,6 +62,7 @@ def test_resolve_marm_api_key_persists_a_generated_key_across_starts(
 
     env_path = tmp_path / ".marm" / ".env"
     monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.setattr(api_key_bootstrap, "_protect_key_file", lambda path: True)
     monkeypatch.delenv("MARM_API_KEY", raising=False)
 
     first_start = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
@@ -70,3 +71,49 @@ def test_resolve_marm_api_key_persists_a_generated_key_across_starts(
 
     second_start = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
     assert second_start == first_start
+
+
+def test_resolve_marm_api_key_removes_file_when_protection_fails(
+    monkeypatch, tmp_path, capsys
+):
+    from marm_mcp_server.config import api_key_bootstrap
+
+    env_path = tmp_path / ".marm" / ".env"
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.setattr(api_key_bootstrap, "_protect_key_file", lambda path: False)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+
+    generated_key = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
+
+    assert generated_key
+    assert not env_path.exists()
+    warning = capsys.readouterr().err
+    assert "kept in memory only" in warning
+    assert "will not survive a restart" in warning
+    assert "Set MARM_API_KEY explicitly in the environment" in warning
+
+
+def test_resolve_marm_api_key_warns_when_insecure_file_cannot_be_removed(
+    monkeypatch, tmp_path, capsys
+):
+    from marm_mcp_server.config import api_key_bootstrap
+
+    env_path = tmp_path / ".marm" / ".env"
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.setattr(api_key_bootstrap, "_protect_key_file", lambda path: False)
+
+    def fail_unlink(self, missing_ok=False):
+        raise OSError("denied")
+
+    monkeypatch.setattr(type(env_path), "unlink", fail_unlink)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+
+    generated_key = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
+
+    assert generated_key
+    assert env_path.exists()
+    warning = capsys.readouterr().err
+    assert "insecure file could not be removed" in warning
+    assert str(env_path) in warning
+    assert "memory for this process only" in warning
+    assert "Set MARM_API_KEY explicitly in the environment" in warning


### PR DESCRIPTION
## Summary

- reuse the existing `_protect_key_file` helper when startup persists an auto-generated API key
- remove the persisted `.env` file when permission hardening cannot be verified
- continue startup with the generated key in memory only
- add regression coverage for successful protection, protection failure, and file-removal failure

## Problem

The unattended startup path and the interactive key-management path handled permission-hardening failures differently.

The CLI already treats a key file as usable only when `_protect_key_file` successfully secures it. The startup bootstrap path instead performed its own best-effort hardening and could continue while leaving a plaintext bearer token on disk after a chmod or Windows ACL failure.

## Behavior

This implements option 2 from #166.

On startup:

1. the generated key is written
2. `_protect_key_file` verifies that the file was secured
3. if protection succeeds, the file remains persisted as before
4. if protection fails, the file is removed with `unlink(missing_ok=True)` and startup continues with the generated key in memory only

The warning explains that the key will not survive a restart and recommends setting `MARM_API_KEY` explicitly.

If removal itself fails, startup still continues but reports that the insecure file remains and identifies its path rather than incorrectly claiming that the credential is memory-only.

The interactive CLI behavior in `key_management.py` is intentionally unchanged. Interactive setup continues to fail loudly when it cannot secure a credential, while unattended startup avoids leaving an insecure persisted credential without refusing to start.

## Testing

- focused config safety tests: 8 passed
- Python compile check: passed
- repository-wide Ruff check: passed
- repository-wide Ruff format check: 201 files already formatted
- changed-module mypy: passed
- `git diff --check`: passed
- full Python suite: 1219 passed, 25 skipped, 16 deselected; 6 failures and 16 errors were environment-dependent and unrelated to this change

The remaining full-suite failures/errors were caused by local environment limitations including sandbox-blocked `C:\tmp` access, unavailable bundled concept-model data, and blocked graph binary downloads.

`python scripts/run-tests.py` could not run because `pnpm` is unavailable locally.

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection of persisted API key files across supported platforms.
  - If a key file cannot be secured, it is removed when possible and the key remains available only in memory.
  - If removal also fails, the file is retained with a warning so the issue is visible.
  - “Saved to” details and setup instructions appear only after successful secure persistence.
  - Added clear warnings for insecure or memory-only key handling.
  - When persistence fails, users are instructed to set `MARM_API_KEY` explicitly and restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->