### PR TITLE
v2.44.4: Log recall lane repaired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
 <details>
+<summary><strong>August 28th, 2026: Log Recall Lane Repaired (v2.44.4)</strong></summary>
+
+### Fixed: The Log Lane in `marm_smart_recall` Never Matched Anything
+
+`marm_smart_recall` answers from two lanes and returns the union: a semantic lane over stored memories, and a log lane over session log entries. The log lane substring-matched the entire query against each log's topic and summary, so a question like "When did Caroline go to the support group?" could only match if that exact sentence appeared verbatim in stored text. It never did. Measured against the LoCoMo benchmark, the lane scored 0.0% on all 1,977 questions in every category. It had effectively never worked while being offered to every connected agent.
+
+- The lane now tokenizes the query, drops stopwords using the set the semantic lane already uses, matches any term, and ranks results by how many distinct terms each entry matched. The same defect was found and fixed in the semantic lane in v2.31.0; the log lane was missed at the time.
+- Retrieval improves across the board. In a controlled comparison holding the build, database, ingest, and questions fixed with the log lane as the only variable, overall any-evidence-hit went from 63.5% to 69.1 - 69.6% and mean evidence recall from 57.9% to 63.0 - 63.5%. The log lane alone went from 0.0% to 53.3%. Every question category gained between 5.7 and 6.8 points.
+- Response shape is unchanged. `log_results` entries carry the same fields, and the match count used for ranking stays in SQL rather than entering the payload, so HTTP and STDIO remain identical.
+
+### Added: Index Behind the Log Lane
+
+- Tokenizing took the lane from two SQL predicates to as many as 24 against a table whose only index was its primary key, which cost roughly 12ms per recall. A composite index on `log_entries(session_name, entry_date)` brings the session-scoped path to 1.45ms, about 3x faster than the broken lane it replaced. The benchmark's own recall phase over 1,977 queries dropped from 203.3s to 181.1s.
+- The index is created in `init_db()` as an additive `CREATE INDEX IF NOT EXISTS`, verified against an already-populated database. Existing installs pick it up on next start with no migration step and no manual action.
+- Retrieval results are identical with and without it, in all five categories, as expected for an index that changes only how quickly the same rows are found.
+
+</details>
+
+<details>
 <summary><strong>August 27th, 2026: marm-init Setup Correctness (v2.44.3)</strong></summary>
 
 ### Fixed: Setup Paths That Reported Success Without Earning It

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      width="900"
      height="250">
 </picture>
-<h1 align="center">marm-memory v2.44.3 - Give your AI Agents a permanent memory in 60 seconds</h1>
+<h1 align="center">marm-memory v2.44.4 - Give your AI Agents a permanent memory in 60 seconds</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -158,7 +158,7 @@ Docker commands are documented separately below because they require explicit da
 
 MARM is tuned for fast recall first, even as memory grows and long memories are chunked behind the scenes.
 
-These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. Sections 1-4 are timings from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal. Section 5 is a separate accuracy benchmark ([`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py)) and reports two runs, for the reason given there.
+These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. Sections 1-4 are timings from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal. Section 5 is a separate accuracy benchmark ([`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py)) measuring retrieval rather than speed, and its latest row is a controlled before and after, explained there.
 
 ### 1. Retrieval Latency Scaling
 
@@ -204,15 +204,18 @@ The full scan grows roughly linearly with $N$ while hybrid recall grows far more
 
 ### 5. LoCoMo Retrieval Accuracy
 
-All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is used.
+All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is involved, so this measures whether the right memory is retrieved, not whether an agent answers correctly with it.
 
 | Configuration | Any evidence hit | All evidence hit | Mean evidence recall |
 | :--- | :--- | :--- | :--- |
 | MiniLM baseline | 37.5% | 29.5% | not published |
 | Jina v2 Small (v2.29.0) | 53.0% | 43.4% | 47.6% |
-| **Recent (v2.33.1)** | **62.9 - 63.5%** | **53.1 - 53.5%** | **57.4 - 57.9%** |
+| v2.33.1 through v2.44.3 | 62.9 - 63.5% | 53.1 - 53.5% | 57.4 - 57.9% |
+| **v2.44.4 (log lane fix)** | **69.1 - 69.6%** | **58.2 - 58.6%** | **63.0 - 63.5%** |
 
-Performance gains are isolated to the blended retrieval pipeline and localized vector space, ensuring high multi-hop recall accuracy without relying on cloud-hosted LLM judges. Reproduce the full benchmark using [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+The last row is a controlled comparison, same build and data with the log lane as the only variable. That lane previously substring-matched the whole query against log topics and summaries, so a natural-language question never matched and it scored 0.0% on all 1,977 questions. It now tokenizes the query and reaches 53.3% on its own. Ranges rather than single figures because the semantic lane varies about half a point between runs, so a sub-point difference is not a result.
+
+Multi-hop remains the weakest category at 44.9%, and single-hop evidence recall is 36.6% against a 66.2% any-hit rate, so the lane often surfaces some of a question's evidence rather than all of it. Reproduce with [`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
 
 ### 6. vs Competitors: Architecture
 

--- a/docs/INSTALL-LINUX.md
+++ b/docs/INSTALL-LINUX.md
@@ -302,7 +302,7 @@ curl -s http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.44.3",
+  "version": "2.44.4",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/docs/INSTALL-WINDOWS.md
+++ b/docs/INSTALL-WINDOWS.md
@@ -287,7 +287,7 @@ Invoke-WebRequest -Uri http://localhost:8001/health
 {
   "status": "healthy",
   "service": "MARM MCP Server",
-  "version": "2.44.3",
+  "version": "2.44.4",
   "timestamp": "2026-01-01T00:00:00+00:00",
   "database": "connected",
   "semantic_search": "available"

--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -62,7 +62,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"
-LABEL org.opencontainers.image.version="2.44.3"
+LABEL org.opencontainers.image.version="2.44.4"
 LABEL org.opencontainers.image.authors="Ryan Lyell - marm-memory"
 LABEL org.opencontainers.image.url="https://marmsystems.com"
 LABEL org.opencontainers.image.source="https://github.com/Lyellr88/marm-memory"

--- a/marm-mcp-server/README.md
+++ b/marm-mcp-server/README.md
@@ -7,7 +7,7 @@ mcp-name: io.github.Lyellr88/marm-mcp-server
      width="900"
      height="250">
 </picture>
-<h1 align="center">marm-memory v2.44.3 - Give your AI Agents a permanent memory in 60 seconds</h1>
+<h1 align="center">marm-memory v2.44.4 - Give your AI Agents a permanent memory in 60 seconds</h1>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Lyellr88/marm-memory/blob/MARM-main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
@@ -160,7 +160,7 @@ Docker commands are documented separately below because they require explicit da
 
 MARM is tuned for fast recall first, even as memory grows and long memories are chunked behind the scenes.
 
-These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. Sections 1-4 are timings from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal. Section 5 is a separate accuracy benchmark ([`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py)) and reports two runs, for the reason given there.
+These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. Sections 1-4 are timings from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal. Section 5 is a separate accuracy benchmark ([`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py)) measuring retrieval rather than speed, and its latest row is a controlled before and after, explained there.
 
 ### 1. Retrieval Latency Scaling
 
@@ -206,15 +206,18 @@ The full scan grows roughly linearly with $N$ while hybrid recall grows far more
 
 ### 5. LoCoMo Retrieval Accuracy
 
-All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is used.
+All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is involved, so this measures whether the right memory is retrieved, not whether an agent answers correctly with it.
 
 | Configuration | Any evidence hit | All evidence hit | Mean evidence recall |
 | :--- | :--- | :--- | :--- |
 | MiniLM baseline | 37.5% | 29.5% | not published |
 | Jina v2 Small (v2.29.0) | 53.0% | 43.4% | 47.6% |
-| **Recent (v2.33.1)** | **62.9 - 63.5%** | **53.1 - 53.5%** | **57.4 - 57.9%** |
+| v2.33.1 through v2.44.3 | 62.9 - 63.5% | 53.1 - 53.5% | 57.4 - 57.9% |
+| **v2.44.4 (log lane fix)** | **69.1 - 69.6%** | **58.2 - 58.6%** | **63.0 - 63.5%** |
 
-Performance gains are isolated to the blended retrieval pipeline and localized vector space, ensuring high multi-hop recall accuracy without relying on cloud-hosted LLM judges. Reproduce the full benchmark using [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+The last row is a controlled comparison, same build and data with the log lane as the only variable. That lane previously substring-matched the whole query against log topics and summaries, so a natural-language question never matched and it scored 0.0% on all 1,977 questions. It now tokenizes the query and reaches 53.3% on its own. Ranges rather than single figures because the semantic lane varies about half a point between runs, so a sub-point difference is not a result.
+
+Multi-hop remains the weakest category at 44.9%, and single-hop evidence recall is 36.6% against a 66.2% any-hit rate, so the lane often surfaces some of a question's evidence rather than all of it. Reproduce with [`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
 
 ### 6. vs Competitors: Architecture
 

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: lyellr88/marm-mcp-server:2.44.3
+    image: lyellr88/marm-mcp-server:2.44.4
     container_name: marm-mcp-server
     restart: unless-stopped
     
@@ -16,7 +16,7 @@ services:
     environment:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=8001
-      - SERVER_VERSION=2.44.3
+      - SERVER_VERSION=2.44.4
       
       - ENVIRONMENT=production
       - LOG_LEVEL=INFO

--- a/marm-mcp-server/marm_mcp_server/__init__.py
+++ b/marm-mcp-server/marm_mcp_server/__init__.py
@@ -14,12 +14,12 @@ Features:
 - Production-grade performance
 
 Author: Ryan Lyell - marm-memory
-Version: 2.44.3
+Version: 2.44.4
 """
 
 from typing import Any
 
-__version__ = "2.44.3"
+__version__ = "2.44.4"
 __author__ = "Ryan Lyell"
 __email__ = "ryanlyell@marmemory.com"
 

--- a/marm-mcp-server/marm_mcp_server/config/settings.py
+++ b/marm-mcp-server/marm_mcp_server/config/settings.py
@@ -99,7 +99,7 @@ if not (1 <= _raw_port <= 65535):
         f"WARNING: SERVER_PORT={_raw_port} out of [1, 65535], clamped to {SERVER_PORT}",
         file=sys.stderr,
     )
-SERVER_VERSION = "2.44.3"
+SERVER_VERSION = "2.44.4"
 
 GRAPH_ENABLED = os.environ.get("GRAPH_ENABLED", "true").lower() != "false"
 

--- a/marm-mcp-server/marm_mcp_server/core/memory_db.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_db.py
@@ -301,6 +301,11 @@ def init_database(db_path: str) -> None:
             "ON compaction_staging(candidate_hash)"
         )
 
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_log_entries_session "
+            "ON log_entries(session_name, entry_date)"
+        )
+
         conn.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts
                 USING fts5(content, content='memories', content_rowid='rowid',

--- a/marm-mcp-server/marm_mcp_server/core/memory_utils.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_utils.py
@@ -168,7 +168,53 @@ def log_search_terms(query: str, limit: int = 12) -> list[str]:
     if not tokens:
         return []
     kept = [t for t in tokens if t.lower() not in _FTS_STOPWORDS]
-    return (kept or tokens)[:limit]
+    seen: set[str] = set()
+    unique: list[str] = []
+    for token in kept or tokens:
+        folded = token.lower()
+        if folded not in seen:
+            seen.add(folded)
+            unique.append(token)
+    return unique[:limit]
+
+
+def build_log_search(
+    query: str,
+    *,
+    session_name: str | None,
+    search_all: bool,
+    project: str | None,
+    platform: str | None,
+    limit: int,
+) -> tuple[str, list]:
+    """Build the log lane's query once, so HTTP and STDIO cannot drift apart.
+
+    Both transports had their own copy of this SQL, and repairing only the HTTP
+    copy left STDIO returning nothing for natural-language queries.
+    """
+    terms = log_search_terms(query) or [query]
+    likes = [f"%{term}%" for term in terms]
+    match_expr = " + ".join(
+        ["(CASE WHEN topic LIKE ? OR summary LIKE ? THEN 1 ELSE 0 END)"] * len(terms)
+    )
+    where_expr = " OR ".join(["topic LIKE ? OR summary LIKE ?"] * len(terms))
+    sql = (
+        "SELECT id, session_name, topic, summary, entry_date, project, platform, "
+        f"({match_expr}) AS match_count FROM log_entries WHERE ({where_expr})"
+    )
+    params: list = [value for like in likes for value in (like, like)] * 2
+    if not search_all:
+        sql += " AND session_name = ?"
+        params.append(session_name)
+    if project is not None:
+        sql += " AND project = ?"
+        params.append(project)
+    if platform is not None:
+        sql += " AND platform = ?"
+        params.append(platform)
+    sql += " ORDER BY match_count DESC, entry_date DESC LIMIT ?"
+    params.append(limit)
+    return sql, params
 
 
 MEMORY_CHUNK_THRESHOLD_WORDS = 500

--- a/marm-mcp-server/marm_mcp_server/core/memory_utils.py
+++ b/marm-mcp-server/marm_mcp_server/core/memory_utils.py
@@ -155,6 +155,22 @@ def _wide_fts_query(query: str) -> str | None:
     return " OR ".join(f'"{t}"' for t in tokens)
 
 
+def log_search_terms(query: str, limit: int = 12) -> list[str]:
+    """Tokens for the log lane's LIKE search, stopwords dropped.
+
+    The lane has no FTS index, so it substring-matched the whole query and a
+    natural-language question could only hit if it appeared verbatim in a topic
+    or summary. Falls back to the raw tokens when every one is a stopword, and
+    to an empty list when nothing is searchable, so callers keep a fail-open
+    path consistent with the FTS helpers above.
+    """
+    tokens = re.findall(r"\w+", query)
+    if not tokens:
+        return []
+    kept = [t for t in tokens if t.lower() not in _FTS_STOPWORDS]
+    return (kept or tokens)[:limit]
+
+
 MEMORY_CHUNK_THRESHOLD_WORDS = 500
 MEMORY_CHUNK_TARGET_WORDS = 250
 MEMORY_CHUNK_OVERLAP_WORDS = 50

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from ..core.concept_db import ConceptDB, get_concept_db_path
 from ..core.memory import memory
+from ..core.memory_utils import log_search_terms
 from ..core.models import SmartRecallRequest
 from ..core.response_limiter import MCPResponseLimiter
 from ..services.analytics import track_usage
@@ -198,13 +199,21 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request) 
 
         log_results = []
         if request.include_logs:
+            terms = log_search_terms(request.query) or [request.query]
+            likes = [f"%{t}%" for t in terms]
+            match_expr = " + ".join(
+                ["(CASE WHEN topic LIKE ? OR summary LIKE ? THEN 1 ELSE 0 END)"]
+                * len(terms)
+            )
+            where_expr = " OR ".join(["topic LIKE ? OR summary LIKE ?"] * len(terms))
             with memory.get_connection() as conn:
-                log_base = """
-                    SELECT id, session_name, topic, summary, entry_date, project, platform
+                log_base = f"""
+                    SELECT id, session_name, topic, summary, entry_date, project, platform,
+                           ({match_expr}) AS match_count
                     FROM log_entries
-                    WHERE (topic LIKE ? OR summary LIKE ?)
+                    WHERE ({where_expr})
                 """
-                log_params: list = [f"%{request.query}%", f"%{request.query}%"]
+                log_params: list = [x for like in likes for x in (like, like)] * 2
                 if not request.search_all:
                     log_base += " AND session_name = ?"
                     log_params.append(request.session_name)
@@ -214,7 +223,7 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request) 
                 if request.platform is not None:
                     log_base += " AND platform = ?"
                     log_params.append(request.platform)
-                log_base += " ORDER BY entry_date DESC LIMIT ?"
+                log_base += " ORDER BY match_count DESC, entry_date DESC LIMIT ?"
                 log_params.append(request.limit)
                 log_results = [
                     {

--- a/marm-mcp-server/marm_mcp_server/endpoints/memory.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/memory.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from ..core.concept_db import ConceptDB, get_concept_db_path
 from ..core.memory import memory
-from ..core.memory_utils import log_search_terms
+from ..core.memory_utils import build_log_search
 from ..core.models import SmartRecallRequest
 from ..core.response_limiter import MCPResponseLimiter
 from ..services.analytics import track_usage
@@ -199,32 +199,15 @@ async def marm_smart_recall(request: SmartRecallRequest, http_request: Request) 
 
         log_results = []
         if request.include_logs:
-            terms = log_search_terms(request.query) or [request.query]
-            likes = [f"%{t}%" for t in terms]
-            match_expr = " + ".join(
-                ["(CASE WHEN topic LIKE ? OR summary LIKE ? THEN 1 ELSE 0 END)"]
-                * len(terms)
+            log_base, log_params = build_log_search(
+                request.query,
+                session_name=request.session_name,
+                search_all=request.search_all,
+                project=request.project,
+                platform=request.platform,
+                limit=request.limit,
             )
-            where_expr = " OR ".join(["topic LIKE ? OR summary LIKE ?"] * len(terms))
             with memory.get_connection() as conn:
-                log_base = f"""
-                    SELECT id, session_name, topic, summary, entry_date, project, platform,
-                           ({match_expr}) AS match_count
-                    FROM log_entries
-                    WHERE ({where_expr})
-                """
-                log_params: list = [x for like in likes for x in (like, like)] * 2
-                if not request.search_all:
-                    log_base += " AND session_name = ?"
-                    log_params.append(request.session_name)
-                if request.project is not None:
-                    log_base += " AND project = ?"
-                    log_params.append(request.project)
-                if request.platform is not None:
-                    log_base += " AND platform = ?"
-                    log_params.append(request.platform)
-                log_base += " ORDER BY match_count DESC, entry_date DESC LIMIT ?"
-                log_params.append(request.limit)
                 log_results = [
                     {
                         "id": r[0],

--- a/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
+++ b/marm-mcp-server/marm_mcp_server/resources/marm-docs/README.md
@@ -1,4 +1,4 @@
-# MARM Memory v2.44.3 - Give your AI Agents a permanent memory in 60 seconds
+# MARM Memory v2.44.4 - Give your AI Agents a permanent memory in 60 seconds
 
 ## Table of Contents
 
@@ -132,7 +132,7 @@ Docker commands are documented separately below because they require explicit da
 
 MARM is tuned for fast recall first, even as memory grows and long memories are chunked behind the scenes.
 
-These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. Sections 1-4 are timings from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal. Section 5 is a separate accuracy benchmark ([`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py)) and reports two runs, for the reason given there.
+These measurements use the fastembed-backed `jinaai/jina-embeddings-v2-small-en` encoder and a throwaway local SQLite database. Every timed path calls the shipped `MARMMemory` code, not a benchmark-local reimplementation. Sections 1-4 are timings from a single run of [`scripts/benchmarking/performance/bench_hotpath.py`](scripts/benchmarking/performance/bench_hotpath.py) on local hardware; absolute milliseconds vary by machine, so treat the scaling shape as the signal. Section 5 is a separate accuracy benchmark ([`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py)) measuring retrieval rather than speed, and its latest row is a controlled before and after, explained there.
 
 ### 1. Retrieval Latency Scaling
 
@@ -178,15 +178,18 @@ The full scan grows roughly linearly with $N$ while hybrid recall grows far more
 
 ### 5. LoCoMo Retrieval Accuracy
 
-All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is used.
+All 10 LoCoMo conversations are ingested through `marm_log_entry` (5,882 memories), then top-5 `marm_smart_recall` results are scored against 1,977 evidence-annotated questions. No answer-generation model or LLM judge is involved, so this measures whether the right memory is retrieved, not whether an agent answers correctly with it.
 
 | Configuration | Any evidence hit | All evidence hit | Mean evidence recall |
 | :--- | :--- | :--- | :--- |
 | MiniLM baseline | 37.5% | 29.5% | not published |
 | Jina v2 Small (v2.29.0) | 53.0% | 43.4% | 47.6% |
-| **Recent (v2.33.1)** | **62.9 - 63.5%** | **53.1 - 53.5%** | **57.4 - 57.9%** |
+| v2.33.1 through v2.44.3 | 62.9 - 63.5% | 53.1 - 53.5% | 57.4 - 57.9% |
+| **v2.44.4 (log lane fix)** | **69.1 - 69.6%** | **58.2 - 58.6%** | **63.0 - 63.5%** |
 
-Performance gains are isolated to the blended retrieval pipeline and localized vector space, ensuring high multi-hop recall accuracy without relying on cloud-hosted LLM judges. Reproduce the full benchmark using [`scripts/benchmarking/accuracy/locomo/run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
+The last row is a controlled comparison, same build and data with the log lane as the only variable. That lane previously substring-matched the whole query against log topics and summaries, so a natural-language question never matched and it scored 0.0% on all 1,977 questions. It now tokenizes the query and reaches 53.3% on its own. Ranges rather than single figures because the semantic lane varies about half a point between runs, so a sub-point difference is not a result.
+
+Multi-hop remains the weakest category at 44.9%, and single-hop evidence recall is 36.6% against a 66.2% any-hit rate, so the lane often surfaces some of a question's evidence rather than all of it. Reproduce with [`run_eval.py`](scripts/benchmarking/accuracy/locomo/run_eval.py).
 
 ### 6. vs Competitors: Architecture
 

--- a/marm-mcp-server/marm_mcp_server/services/recall.py
+++ b/marm-mcp-server/marm_mcp_server/services/recall.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from ..core.memory import memory
+from ..core.memory_utils import build_log_search
 from ..core.response_limiter import MCPResponseLimiter
 from .graph_context import attach_graph_context, get_graph_context
 
@@ -32,24 +33,15 @@ async def smart_recall(
 
         log_results = []
         if include_logs:
+            log_base, log_params = build_log_search(
+                query,
+                session_name=session_name,
+                search_all=search_all,
+                project=project,
+                platform=platform,
+                limit=limit,
+            )
             with memory.get_connection() as conn:
-                log_base = """
-                    SELECT id, session_name, topic, summary, entry_date, project, platform
-                    FROM log_entries
-                    WHERE (topic LIKE ? OR summary LIKE ?)
-                """
-                log_params: list = [f"%{query}%", f"%{query}%"]
-                if not search_all:
-                    log_base += " AND session_name = ?"
-                    log_params.append(session_name)
-                if project is not None:
-                    log_base += " AND project = ?"
-                    log_params.append(project)
-                if platform is not None:
-                    log_base += " AND platform = ?"
-                    log_params.append(platform)
-                log_base += " ORDER BY entry_date DESC LIMIT ?"
-                log_params.append(limit)
                 log_rows = conn.execute(log_base, log_params).fetchall()
             log_results = [
                 {

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marm-mcp-server"
-version = "2.44.3"
+version = "2.44.4"
 description = "Local-first 3-in-1 AI memory layer & MCP server for Claude Code, Codex, Grok, Gemini, VS Code and Cursor. Fuses session history, codebase indexing & concept graphs in SQLite. Enables zero-cloud, privacy-first context & instant recall also works with multi-agent swarms."
 readme = "README.md"
 license = "Apache-2.0"

--- a/marm-mcp-server/server.json
+++ b/marm-mcp-server/server.json
@@ -3,7 +3,7 @@
   "_schema_date": "2025-12-11",
   "name": "io.github.Lyellr88/marm-mcp-server",
   "description": "Universal MCP Server with advanced AI memory capabilities and semantic search.",
-  "version": "2.44.3",
+  "version": "2.44.4",
   "author": "Ryan Lyell - marm-memory",
   "license": "Apache-2.0",
   "homepage": "https://marmsystems.com",
@@ -17,12 +17,12 @@
     {
       "registryType": "pypi",
       "identifier": "marm-mcp-server",
-      "version": "2.44.3",
+      "version": "2.44.4",
       "transport": { "type": "stdio" }
     },
     {
       "registryType": "oci",
-      "identifier": "lyellr88/marm-mcp-server:2.44.3",
+      "identifier": "lyellr88/marm-mcp-server:2.44.4",
       "transport": { "type": "stdio" }
     }
   ],


### PR DESCRIPTION
## v2.44.4: Log Recall Lane Repaired

`marm_smart_recall` answers from two lanes and returns the union: a semantic lane over stored memories, and a log lane over session log entries. The log lane substring-matched the entire query against each entry's topic and summary, so a question like "When did Caroline go to the support group?" only matched if that exact sentence appeared verbatim in stored text. It never did. Measured against LoCoMo it scored 0.0% on all 1,977 questions in every category, having never worked while being offered to every connected agent.

The same defect was found and fixed in the semantic lane in v2.31.0. The log lane was missed at the time.

- The lane now tokenizes the query, drops stopwords using the set the semantic lane already uses, matches any term, and ranks by how many distinct terms each entry matched.
- A composite index on `log_entries(session_name, entry_date)` backs it. Tokenizing took the lane from 2 SQL predicates to as many as 24 against a table whose only index was its primary key, and the index brings the session-scoped path to 1.45ms, about 3x faster than the broken lane it replaced.
- Response shape is unchanged. The match count used for ranking stays in SQL and never enters the payload, so HTTP and STDIO remain identical.

### Benchmark

Controlled comparison holding build, database, ingest and questions fixed, with the log lane as the only variable. LoCoMo, all 10 conversations, 5,882 turns ingested, 1,977 evidence-annotated questions, top-5 recall. No LLM judge is involved, so this measures retrieval rather than answer quality.

| Metric | Before | After |
|---|---:|---:|
| overall any-evidence-hit | 63.5% | 69.1 - 69.6% |
| mean evidence recall | 57.9% | 63.0 - 63.5% |
| log lane alone | 0.0% | 53.3% |

Every category gained between 5.7 and 6.8 points. Ranges rather than single figures because the semantic lane varied about half a point across three runs with nothing in its path changed, so a sub-point difference is not a result here.

Retrieval results are identical with and without the index in all five categories, as expected for an index that only changes lookup speed. End to end, the benchmark's recall phase over 1,977 queries dropped from 203.3s to 181.1s.

Two things the numbers do not say. Of the log lane's 1,053 hits, 937 are also found by the semantic lane, so the entire improvement rests on 116 questions where the log lane found evidence the semantic lane missed. It wins those by searching different text, `topic` and `summary` rather than memory content. And multi-hop remains the weakest category at 44.9%, which is why the README claim that gains "ensure high multi-hop recall accuracy" was removed.

### Review focus

The index is the riskiest line. `CREATE INDEX IF NOT EXISTS` runs in `init_db()` against every existing user's memory database on next start. It was verified against an already-populated 5,882-row table where it completed instantly, but it has not been exercised against a database with a very large `log_entries` table, where creation would take real time and hold a write lock during startup.

Also worth a look: the lane ORs its terms, so it can return an entry that matched a single common word. Match-count ordering pushes those below real hits, and `log_search_terms` caps at 12 terms after stopword removal, but precision at larger `limit` values is unmeasured.

### Upgrade Note

No user action required. The index is additive and existing installs pick it up on next start with no migration step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved smart recall log searches with stopword-aware, multi-term matching.
  - Ranked results by the number of matching terms while preserving response fields.
  - Improved log-lane retrieval accuracy, including multi-hop and single-hop searches.

- **Performance**
  - Added an index to speed up log lookups by session and date.

- **Documentation**
  - Updated benchmark results, methodology notes, installation examples, and release references.

- **Release**
  - Updated the application, container images, and deployment metadata to version 2.44.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->