### PR TITLE
ci(security): dependency review and build surface flagging on PRs

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,15 +1,10 @@
 name: Supply Chain CI
 
-# CodeQL reads first-party source and GitGuardian reads for secrets. Neither
-# looks at what a pull request adds to the dependency set, so a typosquatted or
-# malicious package reaches users through the tag publish untouched.
 on:
   pull_request:
     branches: [ MARM-main ]
 
-# No `paths:` filter, for the same reason python.yml has none: a path-filtered
-# workflow never starts on an unrelated PR, so a required status check would sit
-# at "waiting to be reported" and block that PR permanently.
+# No `paths:` filter, for the reason given in python.yml.
 permissions:
   contents: read
 
@@ -21,7 +16,6 @@ jobs:
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-latest
-    # Only this job writes, and only to post the failure summary.
     permissions:
       contents: read
       pull-requests: write
@@ -29,16 +23,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Compares the base and head dependency graphs and fails on a newly
-      # introduced advisory. Only new dependencies are judged, so a pre-existing
-      # advisory in the tree does not block unrelated work.
       - name: Review new dependencies
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
-          # Defaults to runtime alone. Dev dependencies execute on the runner
-          # with a repository token during CI and inside the Docker build, so
-          # they are in scope for this gate.
+          # Dev dependencies run on the runner with a repository token, so the runtime-only default is too narrow.
           fail-on-scopes: runtime, development, unknown
           comment-summary-in-pr: on-failure
 
@@ -51,24 +40,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Advisory only. These paths decide what gets built, published, and run in
-      # CI, so a change to one deserves a different read than a docs change. It
-      # never fails the build: a legitimate release PR touches most of them.
-      #
-      # A review aid, not a control. This workflow runs from the pull request's
-      # own revision, so a PR can edit the detector below and silence itself.
-      # Reading it from the base would mean pull_request_target, which hands a
-      # write token to untrusted code and is a worse trade. What actually stops
-      # a hostile change is branch protection, required review, and requiring
-      # approval before a fork's workflows run at all.
       - name: Flag changes to build and release surfaces
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Three dots, so the comparison starts at the merge base. Comparing
-          # the two tips blames the PR for base-branch commits it never made
-          # once MARM-main moves ahead of the branch.
+          # Three dots: comparing the two tips blames the PR for base commits once MARM-main moves ahead.
           changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
           watched=$(printf '%s\n' "$changed" | grep -E \
             '^\.github/|Dockerfile|docker-compose\.yml|pyproject\.toml|server\.json|requirements.*\.txt|package\.json|package-lock\.json|pnpm-lock\.yaml' || true)

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,71 @@
+name: Supply Chain CI
+
+# CodeQL reads first-party source and GitGuardian reads for secrets. Neither
+# looks at what a pull request adds to the dependency set, so a typosquatted or
+# malicious package reaches users through the tag publish untouched.
+on:
+  pull_request:
+    branches: [ MARM-main ]
+
+# No `paths:` filter, for the same reason python.yml has none: a path-filtered
+# workflow never starts on an unrelated PR, so a required status check would sit
+# at "waiting to be reported" and block that PR permanently.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: supply-chain-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Compares the base and head dependency graphs and fails on a newly
+      # introduced advisory. Only new dependencies are judged, so a pre-existing
+      # advisory in the tree does not block unrelated work.
+      - name: Review new dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure
+
+  sensitive-paths:
+    name: Sensitive path review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Advisory only. These paths decide what gets built, published, and run in
+      # CI, so a change to one deserves a different read than a docs change. It
+      # never fails the build: a legitimate release PR touches most of them.
+      - name: Flag changes to build and release surfaces
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          watched=$(printf '%s\n' "$changed" | grep -E \
+            '^\.github/|Dockerfile|docker-compose\.yml|pyproject\.toml|server\.json|requirements.*\.txt|package\.json|package-lock\.json|pnpm-lock\.yaml' || true)
+          if [ -z "$watched" ]; then
+            echo "No build or release surfaces touched."
+            exit 0
+          fi
+          echo "::warning title=Sensitive paths changed::This PR edits files that control the build, the published artifact, or CI itself. Review these by hand."
+          while read -r f; do
+            if [ -n "$f" ]; then
+              echo "::warning file=$f::Build or release surface changed, review by hand"
+            fi
+          done <<< "$watched"
+          if printf '%s\n' "$watched" | grep -q '^\.github/workflows/'; then
+            echo "::warning title=Workflow files changed::A pull request that edits its own CI can weaken the checks reviewing it. Confirm the change is intended."
+          fi
+          exit 0

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -12,7 +12,6 @@ on:
 # at "waiting to be reported" and block that PR permanently.
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: supply-chain-${{ github.event.pull_request.number }}
@@ -22,6 +21,10 @@ jobs:
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-latest
+    # Only this job writes, and only to post the failure summary.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,6 +36,10 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
+          # Defaults to runtime alone. Dev dependencies execute on the runner
+          # with a repository token during CI and inside the Docker build, so
+          # they are in scope for this gate.
+          fail-on-scopes: runtime, development, unknown
           comment-summary-in-pr: on-failure
 
   sensitive-paths:
@@ -47,12 +54,22 @@ jobs:
       # Advisory only. These paths decide what gets built, published, and run in
       # CI, so a change to one deserves a different read than a docs change. It
       # never fails the build: a legitimate release PR touches most of them.
+      #
+      # A review aid, not a control. This workflow runs from the pull request's
+      # own revision, so a PR can edit the detector below and silence itself.
+      # Reading it from the base would mean pull_request_target, which hands a
+      # write token to untrusted code and is a worse trade. What actually stops
+      # a hostile change is branch protection, required review, and requiring
+      # approval before a fork's workflows run at all.
       - name: Flag changes to build and release surfaces
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          # Three dots, so the comparison starts at the merge base. Comparing
+          # the two tips blames the PR for base-branch commits it never made
+          # once MARM-main moves ahead of the branch.
+          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
           watched=$(printf '%s\n' "$changed" | grep -E \
             '^\.github/|Dockerfile|docker-compose\.yml|pyproject\.toml|server\.json|requirements.*\.txt|package\.json|package-lock\.json|pnpm-lock\.yaml' || true)
           if [ -z "$watched" ]; then


### PR DESCRIPTION
## Supply chain checks on pull requests

Outside contributions are arriving now, and a tag push publishes to PyPI, Docker Hub and the MCP Registry, so anything merged reaches users directly. CodeQL reads first-party source and GitGuardian reads for secrets. Neither looks at what a pull request adds to the dependency set, which is the cheapest way to get hostile code into a published artifact: a typosquatted package in `pyproject.toml` passes CodeQL, passes secret scanning, and passes the test suite.

- **Dependency review.** Compares the base and head dependency graphs and fails on a newly introduced advisory at moderate or above. Only new dependencies are judged, so a pre-existing advisory in the tree does not block unrelated work.
- **Sensitive path review.** Warns when a PR touches the files that decide what gets built, published, or run in CI: `.github/`, `Dockerfile`, compose, `pyproject.toml`, `server.json`, requirements, and the npm lockfiles. Advisory only, always exits 0, because a legitimate release PR touches most of them. Workflow edits get a separate warning, since a PR that edits its own CI can weaken the checks reviewing it.

No `paths:` filter, matching the reasoning already documented in `python.yml`, so the job stays eligible to be a required status check.

### Validation

The path script was run under GitHub's shell (`bash --noprofile --norc -eo pipefail`) against three real commit ranges before this was opened:

| Case | Range | Result |
| :--- | :--- | :--- |
| Release PR touching four build surfaces | `03d5cca..ddaa091` | 4 warnings, exit 0 |
| Code-only PR touching none | `ddaa091..4e7fa0b` | "No build or release surfaces touched", exit 0 |
| Workflow edit | simulated | both warnings, exit 0 |

The `-e` and `pipefail` combination matters here: an earlier draft ended the script with `grep -q ... && echo ...`, which fails the step whenever no workflow files changed. That is fixed and covered by case 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated dependency vulnerability checks for pull requests.
  * Added notifications when build, publishing, or CI configuration files change.
  * Added pull request comments when dependency issues are detected.

* **Chores**
  * Added continuous supply-chain validation for pull requests.
  * Ensured checks run consistently and cancel outdated runs for the same pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->