### PR TITLE
ci: categorize generated release notes by label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,37 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - question
+      - wontfix
+
+  categories:
+    - title: "Security"
+      labels:
+        - security
+
+    - title: "Features"
+      labels:
+        - enhancement
+
+    - title: "Fixes"
+      labels:
+        - bug
+
+    - title: "Dependencies"
+      labels:
+        - dependencies
+
+    - title: "Documentation"
+      labels:
+        - documentation
+
+    - title: "CI and tooling"
+      labels:
+        - ci
+        - chore
+
+    - title: "Other"
+      labels:
+        - "*"


### PR DESCRIPTION
## Release notes grouped by label

GitHub's generated release notes now group merged pull requests into Security, Features, Fixes, Dependencies, Documentation, CI and tooling, and Other.

- Categories map to the labels this repository uses. `security`, `ci`, and `chore` were added to cover the gaps.
- Dependency updates are categorized rather than hidden, so a release states plainly what moved.
- Hand-written release bodies and `CHANGELOG.md` are unaffected. This shapes only the generated pull request list and the new-contributor credits beneath it.

Pull requests need a label to land in a category. Unlabeled ones fall through to Other.