### PR TITLE
fix(graph): add project job response models

### DIFF
--- a/marm-mcp-server/marm_mcp_server/endpoints/graph.py
+++ b/marm-mcp-server/marm_mcp_server/endpoints/graph.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from marm_graph.core import code_graph_view
 from marm_graph.core import tool_router as R
@@ -90,6 +90,66 @@ class ConsoleRuntimeTrace(BaseModel):
 class ConsoleRuntimeTracesRequest(BaseModel):
     project: str = Field(..., min_length=1, max_length=512)
     traces: list[ConsoleRuntimeTrace] = Field(..., min_length=1, max_length=500)
+
+
+class _ResponseModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ConsoleProjectIndexResponse(_ResponseModel):
+    job_id: str
+
+
+class _ConsoleProjectJobResponse(_ResponseModel):
+    job_id: str
+    status: str
+    project: str | None
+    phase: str | None
+    error: str | None
+    created_at: str
+    started_at: str | None
+    finished_at: str | None
+
+
+class ConsoleProjectJobQueuedResponse(_ConsoleProjectJobResponse):
+    status: Literal["queued"]
+    project: None
+    phase: Literal["queued"]
+    error: None
+    started_at: None
+    finished_at: None
+
+
+class ConsoleProjectJobRunningResponse(_ConsoleProjectJobResponse):
+    status: Literal["running"]
+    project: None
+    phase: Literal["starting", "indexing"]
+    error: None
+    started_at: str
+    finished_at: None
+
+
+class ConsoleProjectJobSuccessResponse(_ConsoleProjectJobResponse):
+    status: Literal["success"]
+    phase: Literal["complete"]
+    error: None
+    started_at: str
+
+
+class ConsoleProjectJobErrorResponse(_ConsoleProjectJobResponse):
+    status: Literal["error"]
+    project: None
+    phase: Literal["unavailable", "busy", "failed"]
+    error: str
+    started_at: str
+
+
+ConsoleProjectJobResponse = (
+    ConsoleProjectJobQueuedResponse
+    | ConsoleProjectJobRunningResponse
+    | ConsoleProjectJobSuccessResponse
+    | ConsoleProjectJobErrorResponse
+)
 
 
 def _now_iso() -> str:
@@ -360,7 +420,11 @@ async def console_list_projects() -> dict:
     )
 
 
-@router.post("/internal/projects/index", status_code=202)
+@router.post(
+    "/internal/projects/index",
+    status_code=202,
+    response_model=ConsoleProjectIndexResponse,
+)
 async def console_index_project(req: ConsoleIndexRequest) -> dict:
     repo_path = _validated_repo_path(req.repo_path)
     if not _project_job_lock.acquire(blocking=False):
@@ -393,7 +457,9 @@ async def console_index_project(req: ConsoleIndexRequest) -> dict:
     return {"job_id": job_id}
 
 
-@router.get("/internal/projects/jobs/{job_id}")
+@router.get(
+    "/internal/projects/jobs/{job_id}", response_model=ConsoleProjectJobResponse
+)
 async def console_project_job(job_id: str) -> dict:
     _prune_project_jobs()
     with _project_jobs_lock:

--- a/marm-mcp-server/tests/test_endpoint_response_models.py
+++ b/marm-mcp-server/tests/test_endpoint_response_models.py
@@ -125,6 +125,178 @@ def test_marm_delete_response_payloads_are_unchanged(monkeypatch, tmp_path):
         assert response.json() == payload
 
 
+def test_console_project_index_and_queued_job_payloads_are_unchanged(
+    monkeypatch, tmp_path
+):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    graph_endpoint = importlib.import_module("marm_mcp_server.endpoints.graph")
+    client = local_client(server.app)
+    job_id = "job-payload-parity"
+    created_at = "2026-08-28T10:00:00+00:00"
+
+    class DormantThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(graph_endpoint.threading, "Thread", DormantThread)
+    monkeypatch.setattr(graph_endpoint.uuid, "uuid4", lambda: job_id)
+    monkeypatch.setattr(graph_endpoint, "_now_iso", lambda: created_at)
+
+    expected_job = {
+        "job_id": job_id,
+        "status": "queued",
+        "project": None,
+        "phase": "queued",
+        "error": None,
+        "created_at": created_at,
+        "started_at": None,
+        "finished_at": None,
+    }
+    try:
+        created = client.post(
+            "/internal/projects/index",
+            json={"repo_path": str(tmp_path), "mode": "fast"},
+        )
+        queued = client.get(f"/internal/projects/jobs/{job_id}")
+
+        assert created.status_code == 202
+        assert created.json() == {"job_id": job_id}
+        assert queued.status_code == 200
+        assert queued.json() == expected_job
+    finally:
+        graph_endpoint._project_jobs.clear()
+        if graph_endpoint._project_job_lock.locked():
+            graph_endpoint._project_job_lock.release()
+
+
+def test_console_project_job_state_payloads_are_unchanged(monkeypatch, tmp_path):
+    server = load_isolated_server(monkeypatch, tmp_path)
+    graph_endpoint = importlib.import_module("marm_mcp_server.endpoints.graph")
+    client = local_client(server.app)
+    payloads = [
+        {
+            "job_id": "job-running-starting",
+            "status": "running",
+            "project": None,
+            "phase": "starting",
+            "error": None,
+            "created_at": "2026-08-28T10:00:00+00:00",
+            "started_at": "2026-08-28T10:00:01+00:00",
+            "finished_at": None,
+        },
+        {
+            "job_id": "job-running-indexing",
+            "status": "running",
+            "project": None,
+            "phase": "indexing",
+            "error": None,
+            "created_at": "2026-08-28T10:00:00+00:00",
+            "started_at": "2026-08-28T10:00:01+00:00",
+            "finished_at": None,
+        },
+        {
+            "job_id": "job-success",
+            "status": "success",
+            "project": "marm-memory",
+            "phase": "complete",
+            "error": None,
+            "created_at": "2026-08-28T10:00:00+00:00",
+            "started_at": "2026-08-28T10:00:01+00:00",
+            "finished_at": "2026-08-28T10:00:02+00:00",
+        },
+        {
+            "job_id": "job-success-before-finally",
+            "status": "success",
+            "project": None,
+            "phase": "complete",
+            "error": None,
+            "created_at": "2026-08-28T10:00:00+00:00",
+            "started_at": "2026-08-28T10:00:01+00:00",
+            "finished_at": None,
+        },
+        {
+            "job_id": "job-unavailable",
+            "status": "error",
+            "project": None,
+            "phase": "unavailable",
+            "error": "Graph backend unavailable.",
+            "created_at": "2026-08-28T10:00:00+00:00",
+            "started_at": "2026-08-28T10:00:01+00:00",
+            "finished_at": "2026-08-28T10:00:02+00:00",
+        },
+        {
+            "job_id": "job-busy-before-finally",
+            "status": "error",
+            "project": None,
+            "phase": "busy",
+            "error": "Graph index already in progress.",
+            "created_at": "2026-08-28T10:00:00+00:00",
+            "started_at": "2026-08-28T10:00:01+00:00",
+            "finished_at": None,
+        },
+        {
+            "job_id": "job-failed",
+            "status": "error",
+            "project": None,
+            "phase": "failed",
+            "error": "Repository indexing failed.",
+            "created_at": "2026-08-28T10:00:00+00:00",
+            "started_at": "2026-08-28T10:00:01+00:00",
+            "finished_at": "2026-08-28T10:00:02+00:00",
+        },
+    ]
+
+    try:
+        for payload in payloads:
+            stored = dict(payload)
+            if payload["finished_at"] is not None:
+                stored["_finished_timestamp"] = graph_endpoint.datetime.now(
+                    graph_endpoint.timezone.utc
+                ).timestamp()
+            graph_endpoint._project_jobs.clear()
+            graph_endpoint._project_jobs[payload["job_id"]] = stored
+
+            response = client.get(f"/internal/projects/jobs/{payload['job_id']}")
+
+            assert response.status_code == 200
+            assert response.json() == payload
+    finally:
+        graph_endpoint._project_jobs.clear()
+
+
+def test_console_project_job_rejects_undeclared_fields(monkeypatch, tmp_path):
+    """Expose job schema drift as a client-facing 500 instead of filtering it."""
+    server = load_isolated_server(monkeypatch, tmp_path)
+    graph_endpoint = importlib.import_module("marm_mcp_server.endpoints.graph")
+    client = TestClient(
+        server.app,
+        client=("127.0.0.1", 50000),
+        raise_server_exceptions=False,
+    )
+    job_id = "job-with-undeclared-field"
+    graph_endpoint._project_jobs[job_id] = {
+        "job_id": job_id,
+        "status": "queued",
+        "project": None,
+        "phase": "queued",
+        "error": None,
+        "created_at": "2026-08-28T10:00:00+00:00",
+        "started_at": None,
+        "finished_at": None,
+        "worker_detail": "must not disappear",
+    }
+
+    try:
+        response = client.get(f"/internal/projects/jobs/{job_id}")
+    finally:
+        graph_endpoint._project_jobs.clear()
+
+    assert response.status_code == 500
+
+
 def test_response_models_reject_undeclared_fields(monkeypatch, tmp_path):
     """Fail loudly instead of silently filtering a new service response field."""
     server = load_isolated_server(monkeypatch, tmp_path)
@@ -211,4 +383,23 @@ def test_response_models_preserve_mcp_tool_metadata(monkeypatch, tmp_path):
         "#/components/schemas/LogDeleteResponse",
         "#/components/schemas/NotebookDeleteResponse",
         "#/components/schemas/LoggingErrorResponse",
+    }
+
+    index_response_schema = openapi["paths"]["/internal/projects/index"]["post"][
+        "responses"
+    ]["202"]["content"]["application/json"]["schema"]
+    assert index_response_schema == {
+        "$ref": "#/components/schemas/ConsoleProjectIndexResponse"
+    }
+    job_response_refs = {
+        item["$ref"]
+        for item in openapi["paths"]["/internal/projects/jobs/{job_id}"]["get"][
+            "responses"
+        ]["200"]["content"]["application/json"]["schema"]["anyOf"]
+    }
+    assert job_response_refs == {
+        "#/components/schemas/ConsoleProjectJobQueuedResponse",
+        "#/components/schemas/ConsoleProjectJobRunningResponse",
+        "#/components/schemas/ConsoleProjectJobSuccessResponse",
+        "#/components/schemas/ConsoleProjectJobErrorResponse",
     }


### PR DESCRIPTION
## Summary

- add file-local strict response models for `POST /internal/projects/index`
- model queued, running, success, and error states for `GET /internal/projects/jobs/{job_id}` with a `Literal`-based union
- add payload-parity, schema-drift, and OpenAPI coverage for both routes

## Contract checks

- successful response payloads remain unchanged
- undeclared fields fail loudly with an HTTP 500 instead of being silently filtered
- neither converted route is behind `MCPResponseLimiter`
- all 14 MCP tool descriptions and input schemas remain identical to `MARM-main`

## Tests

- `python -m pytest -q tests/test_endpoint_response_models.py` — 7 passed
- `python -m pytest tests/ -q -m "not docker and not smoke_lifecycle"` — 1272 passed, 5 skipped

Part of #167.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added structured response schemas for project indexing and job-status endpoints.
  * Job responses now clearly distinguish queued, running, successful, and failed states.
  * Unexpected response fields are rejected instead of being silently ignored.
  * Updated API metadata to accurately describe the available response formats.

* **Tests**
  * Added coverage for project indexing and all supported job states.
  * Added validation for invalid or undeclared response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->