### PR TITLE
fix(scripts): repair smoke_embedding_chunking against the v2.14.0 chunk profiles

### DIFF
--- a/scripts/test-scripts/smoke_embedding_chunking.py
+++ b/scripts/test-scripts/smoke_embedding_chunking.py
@@ -45,9 +45,9 @@ from marm_mcp_server.config.settings import (  # noqa: E402
 )
 from marm_mcp_server.core import memory as memory_module  # noqa: E402
 from marm_mcp_server.core.memory import (  # noqa: E402
-    CHUNK_OVERLAP_TOKENS,
-    CHUNK_THRESHOLD_WORDS,
-    CHUNK_TOKEN_LIMIT,
+    MEMORY_CHUNK_OVERLAP_WORDS,
+    MEMORY_CHUNK_TARGET_WORDS,
+    MEMORY_CHUNK_THRESHOLD_WORDS,
     MARMMemory,
     _chunk_text,
 )
@@ -59,9 +59,13 @@ from marm_mcp_server.core.memory_scoring import (  # noqa: E402
 SEP = "-" * 70
 SESSION = "smoke-chunking"
 
-# Long memory: first ~210 words are generic filler, distinctive phrase
+# Long memory: the first ~620 words are generic filler, distinctive phrase
 # "crystallization threshold boundary" only appears near the end.
 # Chunking preserves recall of the distinctive late-body phrase.
+# The filler repeats six times so the body clears MEMORY_CHUNK_THRESHOLD_WORDS
+# (500 since v2.14.0, 180 before it). At the old multiplier the body was 343
+# words, under the current threshold, so _chunk_text returned nothing at all
+# and every chunking assertion below was vacuous rather than wrong.
 _FILLER = (
     "This document covers general system architecture notes for the server. "
     "Connection pools are initialized at startup to reduce open/close overhead. "
@@ -74,13 +78,27 @@ _FILLER = (
     f"Embeddings are generated at {DEFAULT_SEMANTIC_DIM} dimensions. "
     "Compaction candidates are surfaced to agents after the configured write threshold. "
 )
-_LONG_BODY = (_FILLER * 3) + (
+_LONG_BODY = (_FILLER * 6) + (
     "The key operational parameter is the crystallization threshold boundary "
     "which governs phase transition detection in the downstream process pipeline. "
     "This value must be configured before calibration or results will be invalid."
 )
 
 SHORT_CONTENT = "MARM stores memories in SQLite with WAL mode."
+
+
+def _memory_chunks(text: str) -> list[str]:
+    """Chunk with the MEMORY profile, the one store_memory() actually uses.
+
+    _store_doc_mirror is the only writer that takes the DOC profile, so a
+    harness for the memory write path must pass the MEMORY_* values here.
+    """
+    return _chunk_text(
+        text,
+        threshold=MEMORY_CHUNK_THRESHOLD_WORDS,
+        target_size=MEMORY_CHUNK_TARGET_WORDS,
+        overlap=MEMORY_CHUNK_OVERLAP_WORDS,
+    )
 
 
 def _unit_vec(dim: int = DEFAULT_SEMANTIC_DIM) -> np.ndarray:
@@ -235,7 +253,7 @@ async def run(require_encoder: bool) -> bool:
         )
         r.check(
             "_chunk_text returns empty for short content",
-            _chunk_text(SHORT_CONTENT) == [],
+            _memory_chunks(SHORT_CONTENT) == [],
         )
         print()
 
@@ -243,34 +261,58 @@ async def run(require_encoder: bool) -> bool:
         print(SEP)
         print("CHECK 3: _chunk_text — threshold, size, overlap, full coverage")
         print(SEP)
-        long_word_count = len(_LONG_BODY.split())
+        all_words = _LONG_BODY.split()
+        long_word_count = len(all_words)
         print(
-            f"  Long body word count: {long_word_count}  threshold: {CHUNK_THRESHOLD_WORDS}"
+            f"  Long body word count: {long_word_count}  "
+            f"threshold: {MEMORY_CHUNK_THRESHOLD_WORDS}  "
+            f"target: {MEMORY_CHUNK_TARGET_WORDS}  "
+            f"overlap: {MEMORY_CHUNK_OVERLAP_WORDS}"
         )
-        chunks = _chunk_text(_LONG_BODY)
         r.check(
-            "_chunk_text produces chunks for long content",
-            len(chunks) > 0,
-            f"got {len(chunks)}",
+            "long body clears the chunking threshold",
+            long_word_count > MEMORY_CHUNK_THRESHOLD_WORDS,
+            f"{long_word_count} words vs threshold {MEMORY_CHUNK_THRESHOLD_WORDS}",
         )
-        oversized = [c for c in chunks if len(c.split()) > CHUNK_TOKEN_LIMIT]
+        chunks = _memory_chunks(_LONG_BODY)
+        expected_count = -(-long_word_count // MEMORY_CHUNK_TARGET_WORDS)
         r.check(
-            "no chunk exceeds CHUNK_TOKEN_LIMIT",
-            len(oversized) == 0,
-            f"oversized: {len(oversized)}",
+            "_chunk_text splits into ceil(words / target) chunks",
+            len(chunks) == expected_count,
+            f"got {len(chunks)}, expected {expected_count}",
         )
-        step = CHUNK_TOKEN_LIMIT - CHUNK_OVERLAP_TOKENS
+        # Each span is padded by overlap // 2 on both sides, so target alone is
+        # not the ceiling: target + overlap is.
+        sizes = [len(c.split()) for c in chunks]
+        size_cap = MEMORY_CHUNK_TARGET_WORDS + MEMORY_CHUNK_OVERLAP_WORDS
+        r.check(
+            "no chunk exceeds target + overlap",
+            max(sizes, default=0) <= size_cap,
+            f"sizes {sizes}, cap {size_cap}",
+        )
+        # The even split exists to stop a full-size chunk plus a tiny trailing
+        # fragment, which is what the old fixed sliding window produced.
+        r.check(
+            "no tiny trailing fragment — chunks are near-equal",
+            len(chunks) < 2 or min(sizes) >= max(sizes) // 2,
+            f"sizes {sizes}",
+        )
         if len(chunks) >= 2:
+            # Span starts come from an even division of the word list, with the
+            # remainder spread over the leading spans, then padded backwards by
+            # overlap // 2.
+            base, remainder = divmod(long_word_count, len(chunks))
+            span_start = base + min(1, remainder)
+            expected_index = max(0, span_start - MEMORY_CHUNK_OVERLAP_WORDS // 2)
             second_first_word = chunks[1].split()[0]
-            all_words = _LONG_BODY.split()
-            expected_first = all_words[step]
+            expected_first = all_words[expected_index]
             r.check(
-                "overlap is correct — second chunk starts at word index step",
+                "second chunk starts overlap // 2 words before its span",
                 second_first_word == expected_first,
                 f"got '{second_first_word}', want '{expected_first}'",
             )
         all_chunk_words = {w for c in chunks for w in c.split()}
-        all_body_words = set(_LONG_BODY.split())
+        all_body_words = set(all_words)
         r.check(
             "chunks collectively cover all words in the long body",
             all_body_words <= all_chunk_words,
@@ -432,7 +474,7 @@ async def run(require_encoder: bool) -> bool:
         else:
             live_id = await memory.store_memory(_LONG_BODY, session=SESSION)
             chunk_count = await _wait_for_chunks(db_path, live_id, timeout=25.0)
-            expected = len(_chunk_text(_LONG_BODY))
+            expected = len(_memory_chunks(_LONG_BODY))
             r.check(
                 "long content: background task writes chunk rows",
                 chunk_count == expected,


### PR DESCRIPTION
I am an AI agent (Claude), writing as Anton's synthetic cofounder under his review. Numbers below are claims to re-run, not things to take on trust.

Closes item 1 of #165 and reports items 2 and 3.

## 1. `smoke_embedding_chunking.py`

Reproduced on current `main`:

```
ImportError: cannot import name 'CHUNK_OVERLAP_TOKENS' from 'marm_mcp_server.core.memory'
```

Beyond the rename you described, two things:

**The fixture no longer clears the threshold.** `_LONG_BODY` was `_FILLER * 3` = **343 words**. The pre-v2.14.0 threshold was 180 (`CHUNK_THRESHOLD_WORDS = 180`, `CHUNK_TOKEN_LIMIT = 150`, removed in a68152a); `MEMORY_CHUNK_THRESHOLD_WORDS` is 500. So `_chunk_text` on that fixture returns `[]`. Fixing only the names and the kwargs would have given a green run where every chunking assertion was vacuous. Filler now repeats six times: **655 words, 3 chunks of [244, 268, 243]**.

**Check 3 described the old sliding window.** Two assertions were wrong in shape, not just in name:

- `no chunk exceeds CHUNK_TOKEN_LIMIT`: the even split pads each span by `overlap // 2` on both sides, so a chunk legitimately exceeds `target`. Measured: the middle chunk is 268 words against a target of 250. The real ceiling is `target + overlap` = 300.
- `overlap is correct — second chunk starts at word index step` with `step = limit - overlap`, which is sliding-window arithmetic. Span starts now come from an even division with the remainder spread over the leading spans, then padded backwards by `overlap // 2`. Asserted in that form, computed from the contract rather than by calling `_split_evenly`.

Added a check that no chunk is a tiny trailing fragment (`min >= max // 2`), since avoiding exactly that is why `_split_evenly` exists.

All `_chunk_text` calls now go through one `_memory_chunks()` helper carrying the MEMORY profile. `_store_doc_mirror` is the only writer that takes the DOC profile, and `store_memory` (what this harness exercises) takes MEMORY, so the helper keeps the two from drifting apart.

### Verification

Full run on Windows / Python 3.12.10, encoder loaded, not `--no-encoder-checks`:

```
CHECK 3: _chunk_text — threshold, size, overlap, full coverage
  Long body word count: 655  threshold: 500  target: 250  overlap: 50
  [PASS] long body clears the chunking threshold — 655 words vs threshold 500
  [PASS] _chunk_text splits into ceil(words / target) chunks — got 3, expected 3
  [PASS] no chunk exceeds target + overlap — sizes [244, 268, 243], cap 300
  [PASS] no tiny trailing fragment — chunks are near-equal — sizes [244, 268, 243]
  [PASS] second chunk starts overlap // 2 words before its span — got 'at', want 'at'
  [PASS] chunks collectively cover all words in the long body
...
SMOKE PASSED — 22 check(s) OK
```

Exit 0. `ruff check` and `ruff format --check` clean.

Because a passing harness proves nothing on its own, I mutated the fix three ways to check the new assertions actually bite:

| Mutation | Result |
|---|---|
| helper switched to the DOC profile (1000/800/100) | 3 checks fail: chunk count 0 vs 3, coverage, live chunk rows |
| fixture back to `_FILLER * 3` (343 words) | 3 checks fail, first one being the threshold check |
| helper passes `overlap=0` | overlap check fails: got `'pools'`, want `'at'` |

## 2. The other six scripts

`write-queue-smoke.py` runs green here (200-write overflow burst verified in SQLite). `smoke-commands.py` targets `tests/test_command_smoke.py` and all four markers it composes (`smoke`, `smoke_lifecycle`, `smoke_docker`, `smoke_destructive`) are still declared in `pyproject.toml`. `compaction-worker-smoke.py` imports `compute_content_hash`, which still exists at `core/consolidation.py:31`. `docker-smoke.py` needs a daemon and was not run.

## 3. Contracts that have moved

**The three HTTP harnesses POST to a tool that was deleted two months ago.** `write-queue-http-smoke.py:157`, `compaction-worker-smoke.py:247` and `swarm-smoke.py` all build `{base_url}/marm_context_log`. That route was removed in e4514f4 ("Removes marm_context_log from the public tool surface"), and `tests/test_stdio_transport.py:187` now asserts `"marm_context_log" not in tool_names`. Current `@router.post` tool surface is `marm_start`, `marm_smart_recall`, `marm_summary`, `marm_log_show`, `marm_notebook`, `marm_refresh`, `marm_compaction`, plus the graph and code tools. Nothing there is a drop-in memory-write; the closest are `marm_notebook` with `action="add"` and the console `POST /api/memories`. That is a call for you, not for me to guess, so I left all three untouched. Happy to repoint them in a follow-up PR if you name the target, or to open it as its own issue.

**`smoke_hybrid_search.py` prints far more than it asserts.** It runs four queries and registers exactly one check (`config key ranks rank-1`); the other three print a ranked table and assert nothing. It ends with `SMOKE PASSED — 1 check(s) OK` out of 227 lines. Not in scope here, and #171 already made it run — flagging it under your line "importing cleanly is not the same as asserting the right thing".

One caveat on my own change: check 8 compares live chunk rows against `_memory_chunks(_LONG_BODY)`, but `store_memory` chunks `sanitize_content(content)`. Word count is unchanged for this fixture (verified), so the comparison holds. It would stop holding for a fixture whose sanitisation drops words.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated embedding chunking smoke tests to use the MEMORY profile.
  * Expanded long-text coverage to validate behavior beyond the 500-word threshold.
  * Added checks for chunk count, size limits, balanced chunk sizes, overlap placement, and encoder consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->