### PR TITLE
ci: build the image on PRs and run the docker-marked tests (#170 item 1)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,149 @@
+name: Docker CI
+
+# The 8 container tests in tests/test_docker_transports.py only ever ran in
+# publish-mcp.yml, which triggers on a `v*` tag. That put every Docker runtime
+# regression on the far side of a release: the tag is already spent by the time
+# the suite says it broke. This workflow builds the image on the PR and runs
+# those tests against it, so the failure lands on the PR that caused it.
+#
+# No `paths:` filter, deliberately. A path-filtered workflow never starts on an
+# unrelated PR, so a required status check would sit at "waiting to be reported"
+# and block that PR permanently. The job runs every time and decides internally
+# whether there is work, which keeps it eligible to be a required check.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Keyed on the PR number, not head_ref: two PRs from different forks can both
+# use a branch called `main`, and sharing a group means one cancels the other's
+# required check, leaving that PR blocked with nothing to report.
+concurrency:
+  group: docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      # Explicit rather than leaning on the fixture default in
+      # tests/test_docker_transports.py, so the tag built below and the tag
+      # under test cannot drift apart silently.
+      MARM_DOCKER_IMAGE: lyellr88/marm-mcp-server:latest
+    steps:
+      # persist-credentials: false because the steps below build and run a
+      # PR-controlled Dockerfile, and the default leaves the job's token in
+      # .git/config where that build can read it. The gh call below passes
+      # GH_TOKEN itself, so it is unaffected.
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # A skip-list, not an allow-list: default to running, and skip only when
+      # every changed file provably cannot reach the image. Dockerfile changes
+      # are deliberately not the trigger -- Dockerfile:11-13 and :48 put
+      # marm_mcp_server/ and marm_graph/ inside the image, so a source-only
+      # change alters the container while touching no Docker file at all.
+      # `grep -qv` asks whether any changed file falls outside the skip set, so
+      # anything unrecognized runs the tests: it fails safe by construction, and
+      # an empty or failed `gh pr diff` lands on run=true for the same reason.
+      #
+      # .claude/, .codex/ and .kiro/ are gitignored today (.gitignore:103-105),
+      # so they cannot appear in a PR diff; they are listed to hold the intent
+      # if that ever changes. The saving that is real today is documentation-only
+      # PRs and every Dependabot npm PR against marm-console/.
+      - name: Detect relevant changes
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh pr diff "${{ github.event.number }}" --name-only)
+          if printf '%s\n' "$files" | grep -qvE '^(docs/|marm-console/|\.claude/|\.codex/|\.kiro/|scripts/benchmarking/|[^/]*\.md$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No image-affecting paths changed. Reporting success without building."
+          fi
+
+      # Python version matches publish-mcp.yml's validate-and-test. If they
+      # drift, this job stops predicting the release gate.
+      - name: Set up Python
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('marm-mcp-server/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # The tests import marm_mcp_server.server for MCP_TOOL_OPERATIONS, so the
+      # package and its runtime dependencies have to be installed even though
+      # the server under test runs inside the container.
+      #
+      # No bundle-concept-model.py step, unlike python.yml and publish-mcp.yml.
+      # It is needed there because concept tests are skipif-guarded on the model
+      # being present; nothing here is. The import is safe without it
+      # (config/settings.py:37-39 probes for the model with is_file() and
+      # spacy.load is lazy, at core/concept_extraction.py:70), and the image
+      # bundles its own copy during the build (Dockerfile:15).
+      - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r marm-mcp-server/requirements.txt
+          pip install -e './marm-mcp-server' --no-deps
+          pip install pytest pytest-asyncio requests
+
+      - name: Set up Docker Buildx
+        if: steps.scope.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # Lifted from publish-mcp.yml's build step: same context, same tag, same
+      # GHA cache scope, so a PR build reads the layers the last release build
+      # wrote instead of starting cold.
+      #
+      # publish-mcp.yml builds the console frontend into
+      # marm_mcp_server/console/static/ before this step and this workflow does
+      # not, because none of the docker-marked tests touch the console. The PR
+      # image is therefore NOT byte-identical to the released one: it is the
+      # same server without the bundled console assets. Anything testing the
+      # console in a container needs that build step added here first.
+      - name: Build Docker image
+        if: steps.scope.outputs.run == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: marm-mcp-server
+          push: false
+          load: true
+          tags: lyellr88/marm-mcp-server:latest
+          cache-from: type=gha,scope=marm-mcp-server
+          cache-to: type=gha,scope=marm-mcp-server,mode=max
+
+      # The whole point of this workflow is that these tests actually execute.
+      # Their fixture skips -- rather than fails -- when the daemon or the image
+      # is missing, which is correct for a laptop and a false green here: a
+      # renamed tag or a build that silently produced nothing would leave the
+      # job reporting success having tested nothing. Assert the image is really
+      # loaded first, so that failure mode is red instead of green.
+      - name: Verify the image is loaded
+        if: steps.scope.outputs.run == 'true'
+        run: docker image inspect "$MARM_DOCKER_IMAGE" > /dev/null
+
+      # -m docker selects exactly the 8 container tests in
+      # test_docker_transports.py. The other 35 Docker tests are static text and
+      # argv assertions, are not docker-marked, and already run in python.yml.
+      # -rs so a skip that does slip through is visible in the log rather than
+      # buried in a dot.
+      - name: Run docker-marked tests
+        if: steps.scope.outputs.run == 'true'
+        working-directory: marm-mcp-server
+        run: python -m pytest tests/ -v -rs -m docker


### PR DESCRIPTION
I am an AI agent (Claude), writing as Anton's synthetic cofounder under his review. Numbers below are claims to re-run, not things to take on trust.

Item 1 of #170: build the image in PR CI and run the docker-marked tests against it. One new file, `.github/workflows/docker.yml`, 149 lines, no other file touched.

I followed your design note rather than re-deriving it. Three places where I deviated or where I think the note's stated benefit does not survive contact with the repo are called out below, because each is a claim you can check in seconds.

## What it does

`pull_request` only, no `paths:` filter, internal skip-list, same shape as `console.yml`. Then: set up Python 3.11, install the package, buildx, build with the same context, tag and GHA cache scope as `publish-mcp.yml`, and `pytest tests/ -v -rs -m docker` in `marm-mcp-server`.

## One step beyond the spec: assert the image is loaded

`docker_image` **skips** when the image is missing rather than failing. That is right on a laptop and a false green here: a renamed tag, or a build that quietly produced nothing, would leave this job reporting success having executed zero container tests. Since the entire point of the issue is that unverified Docker behavior was reporting green, a green that tests nothing seemed like the wrong thing to ship.

So there is a `docker image inspect "$MARM_DOCKER_IMAGE"` step between the build and pytest. `MARM_DOCKER_IMAGE` is set explicitly at job level instead of leaning on the fixture default, so the tag built and the tag tested cannot drift apart silently.

## The gate, and how I checked it

I extracted your `Detect relevant changes` shell verbatim into a standalone script and ran it against fixed file lists. Deterministic, no network. **18 cases, 18 pass, 0 fail:**

| expect `run=false` | expect `run=true` |
|---|---|
| `docs/guide.md`, `docs/api/reference.md` | `marm-mcp-server/marm_mcp_server/core/memory.py` |
| `README.md`, `CHANGELOG.md` | `marm-mcp-server/Dockerfile` |
| `marm-console/package.json` + lockfile | `marm-mcp-server/docker-compose.yml` |
| `.claude/rules/testing.md` | `docs/guide.md` + a source file |
| `scripts/benchmarking/run.py` | `.github/workflows/docker.yml` (self-edit) |
| | `.github/workflows/python.yml` |
| | `marm-mcp-server/README.md` (nested, conservative) |
| | `documentation/notes.py`, `docsite/index.py` (prefix traps) |
| | empty diff (fail-safe) |
| | `Makefile`, a test file, `marm_graph/core/code_graph_view.py` |

The prefix traps and the empty-diff case are the ones I would not have trusted without running: `^docs/` must not swallow `documentation/`, and a failed or empty `gh pr diff` has to land on `run=true`. Both hold.

Convenient consequence: this PR edits `.github/workflows/docker.yml`, which the gate scores `run=true`, so the first real execution of this workflow is this PR's own check. If the build or the tests are wrong, you see it here rather than after merging.

## Three corrections to the design note

**1. `.claude/`, `.codex/` and `.kiro/` cannot appear in a PR diff.** They are gitignored at `.gitignore:103-105` and untracked. The note says the saving covers ".claude/rules edits"; it cannot. What the skip-list actually saves today is documentation-only PRs and every Dependabot npm PR against `marm-console/`, which is still real, just smaller than stated. I kept the three entries and left a comment saying they are inert, so the intent survives if they are ever tracked, without the next reader assuming they do something.

**2. The cache benefit runs one way, not both.** The note says keeping `scope=marm-mcp-server` "means the release build stays warm instead of starting cold." Per GitHub's cache scoping, a workflow run from a PR reads caches from the base branch but writes into a scope isolated to that PR's ref, so PR builds will not feed the tag build. The direction that does work is the useful one: PR builds read the layers the last release build wrote. I kept the same scope for exactly that. Flagging it because this is reasoned from documented behavior, not something I measured.

**3. No `bundle-concept-model.py` step, unlike the other two workflows.** They run it because concept tests are skipif-guarded on the model being present; nothing here is. The import is safe without it: `config/settings.py:37-39` probes with `is_file()` and returns a boolean, and `spacy.load` is lazy at `core/concept_extraction.py:70`. The image bundles its own copy inside the build at `Dockerfile:15`. Adding the step would only slow the job and enlarge the build context. Say the word if you would rather have it for parity.

## Scope, deliberately left out

- **`-m docker` is exactly the 8 container tests.** Verified rather than taken from the issue text: `pytest.mark.docker` appears in one file, `tests/test_docker_transports.py`, which has 8 test functions. The other two Docker files hold 20 and 15 non-marked tests that already run in `python.yml`.
- **`smoke_docker` is not included.** `tests/test_command_smoke.py:293` is opt-in behind `MARM_SMOKE_DOCKER` (`tests/conftest.py:42`) and also needs a daemon and an image, so it is invisible in PR CI for the same reason. It would be a two-line addition here, but it is a different marker with a different opt-in and belongs in its own slice.
- **The console is not built,** so the PR image is not byte-identical to the released one: same server, no bundled console assets. None of the 8 tests touch the console. This is written into the workflow as a comment, and it ties to the point below.
- **Skipping `marm-console/` is only safe as long as that stays true.** A console change does alter the *released* image, because `publish-mcp.yml` builds the frontend into it. It does not alter the image this workflow builds. Those two facts have to move together: adding a container test that touches the console means adding the console build step here and dropping `marm-console/` from the skip-list, in the same change.
- No changelog entry: CI is not user-facing behavior per `CONTRIBUTING.md:305`.

## What I could not verify

There is no Docker daemon and no `actionlint` on the machine I ran this from, so **I have not executed the container tests or this workflow anywhere.** What I did run: the YAML parses, the gate probe above, the marker count, and `git cat-file` to confirm the committed blob is LF-only. A CR in those `$GITHUB_OUTPUT` lines would have written `run=true\r` and made the gate never fire, and that is the kind of thing that fails quietly on a Windows contributor's machine. The build step and the pytest invocation are lifted from `publish-mcp.yml`, where they are known to work; the untested part is whether they still work when the console assets are absent. This PR's own run is the experiment.

Happy to fold in whatever you want changed, including dropping the `docker image inspect` guard if you would rather keep the diff to exactly what the note specified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated pull-request validation for Docker-related changes.
  * Docker images are built and checked for availability before running Docker-specific tests.
  * Documentation-only and other non-image changes can complete validation without an unnecessary image build.
* **Chores**
  * Improved workflow efficiency through caching, controlled concurrency, and restricted permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->