### PR TITLE
test(docker): the healthcheck could never report unhealthy (#170 item 5)

### DIFF
--- a/marm-mcp-server/Dockerfile
+++ b/marm-mcp-server/Dockerfile
@@ -58,7 +58,7 @@ ENV PATH=/home/marm/.local/bin:$PATH
 EXPOSE 8001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health', timeout=5)" || exit 1
+    CMD python -c "import json, sys, urllib.request; sys.exit(0 if json.load(urllib.request.urlopen('http://localhost:8001/health', timeout=5)).get('status') == 'healthy' else 1)" || exit 1
 
 LABEL org.opencontainers.image.title="MARM Universal MCP Server"
 LABEL org.opencontainers.image.description="Production-ready Universal MCP Server with advanced AI memory capabilities, semantic search, and professional-grade architecture"

--- a/marm-mcp-server/docker-compose.yml
+++ b/marm-mcp-server/docker-compose.yml
@@ -31,7 +31,7 @@ services:
           cpus: '0.5'
     
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health', timeout=5)"]
+      test: ["CMD", "python", "-c", "import json, sys, urllib.request; sys.exit(0 if json.load(urllib.request.urlopen('http://localhost:8001/health', timeout=5)).get('status') == 'healthy' else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/marm-mcp-server/tests/test_docker_healthcheck_command.py
+++ b/marm-mcp-server/tests/test_docker_healthcheck_command.py
@@ -1,0 +1,127 @@
+"""What the shipped healthcheck command actually does, not just what it says.
+
+test_docker_static_config.py asserts the command's *text*: that a HEALTHCHECK
+exists, that it probes localhost rather than the bind-all address, and that
+docker-compose.yml mirrors it. Nothing asserted its *behavior*, and the
+behavior had a hole: `/health` answers HTTP 200 even when its own database
+probe failed -- endpoints/system.py:105-115 returns {"status": "unhealthy"}
+from `except` with no status_code override -- so a command that only asks
+urlopen not to raise reports a healthy container for a server that is saying
+the opposite.
+
+These run the command lifted verbatim out of the Dockerfile and out of
+docker-compose.yml, with only host:port rewritten, against a stub serving the
+two payload shapes the endpoint really returns. No Docker daemon needed, so
+this guards the contract on every PR, not only on the Docker-marked runs.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = (REPO_ROOT / "Dockerfile").read_text()
+COMPOSE = (REPO_ROOT / "docker-compose.yml").read_text()
+
+# The payloads endpoints/system.py:88-115 returns, trimmed to the key the
+# healthcheck has to decide on.
+HEALTHY_BODY = {
+    "status": "healthy",
+    "service": "MARM MCP Server",
+    "database": "connected",
+}
+UNHEALTHY_BODY = {
+    "status": "unhealthy",
+    "service": "MARM MCP Server",
+    "error": "Service temporarily unavailable",
+}
+
+
+def _dockerfile_healthcheck_python() -> str:
+    match = re.search(
+        r'HEALTHCHECK.*?\n\s*CMD\s+python\s+-c\s+"(.+?)"', DOCKERFILE, re.DOTALL
+    )
+    assert match, 'Dockerfile has no `CMD python -c "..."` healthcheck'
+    return match.group(1)
+
+
+def _compose_healthcheck_python() -> str:
+    match = re.search(r'test:\s*\["CMD",\s*"python",\s*"-c",\s*"(.+?)"\]', COMPOSE)
+    assert match, "docker-compose.yml has no python healthcheck test command"
+    return match.group(1)
+
+
+class _StubHealth(BaseHTTPRequestHandler):
+    body: dict = HEALTHY_BODY
+
+    def do_GET(self):
+        if self.path != "/health":
+            self.send_response(404)
+            self.end_headers()
+            return
+        raw = json.dumps(type(self).body).encode()
+        self.send_response(200)  # the endpoint answers 200 on both branches
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def stub_health():
+    server = HTTPServer(("127.0.0.1", 0), _StubHealth)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _run(command: str, port: int) -> int:
+    """Run the healthcheck exactly as the container would, against `port`."""
+    assert "localhost:8001" in command, command
+    return subprocess.run(
+        [sys.executable, "-c", command.replace("localhost:8001", f"localhost:{port}")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).returncode
+
+
+def test_healthcheck_passes_when_service_reports_healthy(stub_health):
+    _StubHealth.body = HEALTHY_BODY
+    assert _run(_dockerfile_healthcheck_python(), stub_health.server_address[1]) == 0
+
+
+def test_healthcheck_fails_when_service_reports_unhealthy(stub_health):
+    """The regression this file exists for: HTTP 200 carrying a self-declared
+    unhealthy body must not be read as a healthy container."""
+    _StubHealth.body = UNHEALTHY_BODY
+    assert _run(_dockerfile_healthcheck_python(), stub_health.server_address[1]) != 0
+
+
+def test_healthcheck_fails_when_nothing_is_listening(stub_health):
+    """The case the old command did catch -- keep catching it."""
+    port = stub_health.server_address[1]
+    stub_health.shutdown()
+    stub_health.server_close()
+    assert _run(_dockerfile_healthcheck_python(), port) != 0
+
+
+def test_dockerfile_and_compose_healthchecks_are_the_same_program():
+    """The behavior tests above run the Dockerfile's copy. This is what makes
+    them cover the compose copy too, and it is stricter than the substring
+    check in test_docker_static_config.py."""
+    assert _compose_healthcheck_python() == _dockerfile_healthcheck_python()

--- a/marm-mcp-server/tests/test_docker_transports.py
+++ b/marm-mcp-server/tests/test_docker_transports.py
@@ -26,7 +26,13 @@ def _run_docker(args, timeout=60):
 
 
 def _docker_available():
-    result = _run_docker(["ps"], timeout=20)
+    try:
+        result = _run_docker(["ps"], timeout=20)
+    except OSError:
+        # No docker CLI on PATH at all (a Windows or macOS dev box without
+        # Docker Desktop): the fixture below promises a skip, and without this
+        # the FileNotFoundError surfaces as a collection error instead.
+        return False
     return result.returncode == 0
 
 
@@ -261,6 +267,111 @@ def test_docker_healthcheck_status_becomes_healthy(docker_image, marm_data_dir):
 
         assert status == "healthy", (
             f"container health status never became healthy (last: {status})"
+        )
+    finally:
+        _run_docker(["rm", "-f", container], timeout=30)
+
+
+# A stand-in for the server that answers /health with a fixed payload, so the
+# container's real HEALTHCHECK can be pointed at a service that reports itself
+# unhealthy. The live server cannot be driven into that state from outside:
+# its /health failure branch needs a broken SQLite handle, and connections are
+# pooled at startup (core/memory_db.py:30-56), so nothing done to the mounted
+# data dir afterwards reaches an already-open connection.
+_STUB_HEALTH_SERVER = """
+import json, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+status = sys.argv[1]
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != "/health":
+            self.send_response(404)
+            self.end_headers()
+            return
+        raw = json.dumps({"status": status, "service": "MARM MCP Server"}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *args):
+        pass
+
+
+HTTPServer(("0.0.0.0", 8001), Handler).serve_forever()
+"""
+
+
+def _wait_for_container_health(container, timeout=90):
+    """Docker's own health verdict, once it stops being 'starting'."""
+    deadline = time.time() + timeout
+    status = None
+    while time.time() < deadline:
+        inspect = _run_docker(
+            ["inspect", "--format={{.State.Health.Status}}", container], timeout=20
+        )
+        status = inspect.stdout.strip()
+        if status in ("healthy", "unhealthy"):
+            return status
+        time.sleep(1)
+    return status
+
+
+@pytest.mark.parametrize(
+    ("reported_status", "expected_health"),
+    [("healthy", "healthy"), ("unhealthy", "unhealthy")],
+)
+def test_docker_healthcheck_follows_the_reported_status(
+    docker_image, reported_status, expected_health
+):
+    """The unhealthy half of the healthcheck, which nothing covered before.
+
+    /health answers HTTP 200 on both of its branches (endpoints/system.py:88-115
+    returns {"status": "unhealthy"} from `except`), so a healthcheck that only
+    asks urlopen not to raise can never turn a container unhealthy no matter
+    what the service says. This drives the image's baked-in HEALTHCHECK -- and
+    Docker's runner for it, not our own HTTP polling -- against both answers.
+
+    test_docker_healthcheck_command.py checks the same contract without a
+    daemon; this one proves it survives being baked into the image.
+    """
+    container = f"marm-test-healthstatus-{uuid.uuid4().hex[:10]}"
+
+    run = _run_docker(
+        [
+            "run",
+            "-d",
+            "--name",
+            container,
+            "--entrypoint",
+            "python",
+            "--health-interval=2s",
+            "--health-timeout=5s",
+            "--health-retries=2",
+            "--health-start-period=1s",
+            docker_image,
+            "-c",
+            _STUB_HEALTH_SERVER,
+            reported_status,
+        ],
+        timeout=90,
+    )
+    assert run.returncode == 0, run.stderr
+
+    try:
+        status = _wait_for_container_health(container)
+        logs = _run_docker(["logs", container], timeout=20)
+        inspect = _run_docker(
+            ["inspect", "--format={{json .State.Health}}", container], timeout=20
+        )
+        assert status == expected_health, (
+            f"service reported {reported_status!r}, docker said {status!r}\n"
+            f"health: {inspect.stdout.strip()}\n"
+            f"logs: {logs.stdout}{logs.stderr}"
         )
     finally:
         _run_docker(["rm", "-f", container], timeout=30)


### PR DESCRIPTION
I am an AI agent (Claude), writing as Anton's synthetic cofounder under his review.

Item 5, first bullet: "The healthcheck reaching unhealthy. Only the healthy transition is asserted, so a healthcheck that can never fail would pass."

While writing that test I found the bullet is not hypothetical. For the database-failure case the shipped healthcheck could not fail at all.

## The hole

`/health` answers HTTP 200 on both of its branches. `endpoints/system.py:88-115` returns `{"status": "unhealthy", ...}` from `except` with no `status_code` override, and the healthcheck was `urllib.request.urlopen(...)` with nothing looking at the body. `urlopen` raises only on an HTTP error status, so a server that is actively telling you its database is gone reads as a healthy container for as long as the process keeps listening.

Measured rather than reasoned:

1. Route shape reproduced in a scratch FastAPI app (same `async def`, no `status_code=`, dict returned from `except`): `db_broken=False -> HTTP 200 status='healthy'`, `db_broken=True -> HTTP 200 status='unhealthy'`.
2. The old command run verbatim against a stub: exit 0 on the healthy payload, **exit 0 on the unhealthy payload**, exit 1 only with nothing listening.
3. On a real container, from the mutation run described below: `assert 'healthy' == 'unhealthy'`. Docker itself reported the container healthy while the service inside reported unhealthy.

Worth noting because it hid this: `_wait_for_health` in `test_docker_transports.py` is *stricter* than the container healthcheck, since it parses `status`. The healthy-path test was passing through a stricter probe than the one the image ships.

## What this PR does

- `Dockerfile` and `docker-compose.yml`: decide on the reported status instead of on the absence of an HTTP error. One line each, same program in both.
- `tests/test_docker_healthcheck_command.py` (new, 4 tests, no daemon): lifts the command out of the Dockerfile and out of compose, rewrites only host:port, and runs it against a stub serving the endpoint's real payloads. Healthy passes, unhealthy fails, nothing-listening still fails, and the two files must be the same program (stricter than the substring check in `test_docker_static_config.py`).
- `tests/test_docker_transports.py`: the same contract through Docker's own healthcheck runner and the image's baked-in HEALTHCHECK, parametrized over both answers.
- `_docker_available()`: return False instead of raising when there is no `docker` CLI at all. Drive-by; the fixture already promises a skip, but on a box without Docker the `FileNotFoundError` surfaced as 10 collection errors instead. Say the word and I will drop it.

## Verification

All runs are in my fork, none of this needed anything from you:

- Docker CI on the change: `collected 1431 items / 1421 deselected / 10 selected`, **10 passed in 40.09s** against a real container ([run](https://github.com/tonydzi/marm-memory/actions/runs/33616238353)). Before this PR the same job was 8 selected / 29.08s.
- Mutation: same tests, healthcheck reverted to the old command. **1 failed, 9 passed**, and the failure is exactly `test_docker_healthcheck_follows_the_reported_status[unhealthy-unhealthy]` with `assert 'healthy' == 'unhealthy'` ([run](https://github.com/tonydzi/marm-memory/actions/runs/33616595341)). The test bites, and the fix is what makes it pass.
- Python CI on the change: 1393 passed, 26 skipped, 226.39s. Your `MARM-main` run 20 minutes earlier was 1389 passed, 26 skipped, 291.85s, so the four new tests land inside runner variance rather than showing up as a cost.
- Local, no daemon on this host: `ruff check` and `ruff format --check` clean over `tests/`, `test_docker_static_config.py` still 20 passed with the edited files, and three more mutants of the new command (always exit 0, wrong key, truthiness instead of equality) each redden 2 to 4 of the new tests.
- Supply Chain CI is red in my fork only because Dependency graph is not enabled there. It has nothing to do with this diff.

## Three calls I would rather you overrule than not see

1. **Stub server instead of breaking the real app.** The live server cannot be driven into its unhealthy branch from outside: connections are pooled at startup (`core/memory_db.py:30-56`), so touching the mounted data dir afterwards does not reach an already-open handle. The container test therefore runs the real image with `--entrypoint python` and a stub answering `/health`, leaving the image's own HEALTHCHECK and Docker's runner in the loop; only the health timings are overridden (2s interval, 2 retries). If you know a lever that breaks the real server's database at runtime, I will swap the stub for it.
2. **Fixed on the container side, not the endpoint.** Returning 503 from `/health` when the body says unhealthy is arguably the more standard fix, and it would make every external monitor correct, not just Docker. I did not do it because it changes a public contract your console and any deployed probe already depend on. That is your call; if you want it that way, I will move the fix and keep these tests.
3. **`docs/INSTALL-DOCKER.md:381` stays true** ("STDIO mode has no HTTP healthcheck"). STDIO containers had a failing healthcheck before this change too, since nothing listens on 8001 there; that behavior is unchanged.

Items 2, 3 and 4 remain untouched and unclaimed by me. Of item 5, the remaining bullets (exposed-network auth, upgrade path, bind-mount uid mismatch) are also still free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now verify that the service reports a healthy status, rather than treating any successful HTTP response as healthy.
  * Environments without Docker installed no longer encounter test collection errors.

* **Tests**
  * Added coverage for healthy, unhealthy, unavailable, and container-level health-check scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->